### PR TITLE
Upgrade Claude Agent SDK to 0.2.x and add setup documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "feishu-claudecode",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.0",
         "@larksuiteoapi/node-sdk": "^1.58.0",
         "dotenv": "^16.4.0",
         "pino": "^9.0.0",
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.1.77",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.77.tgz",
-      "integrity": "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==",
+      "version": "0.2.42",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.42.tgz",
+      "integrity": "sha512-/CugP7AjP57Dqtl2sbsDtxdbpQoPKIhjyF5WrTViGu4NHQdM+UikrRs4MhZ2jeotiC5R7iK9ZUN9SiBgcZ8oLw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -39,7 +39,7 @@
         "@img/sharp-win32-x64": "^0.33.5"
       },
       "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@larksuiteoapi/node-sdk": "^1.58.0",
     "dotenv": "^16.4.0",
     "pino": "^9.0.0",

--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -35,6 +35,11 @@ export class StreamProcessor {
       case 'stream_event':
         this.processStreamEvent(message);
         break;
+
+      case 'task_notification':
+      case 'tool_use_summary':
+        // SDK 0.2 message types — no action needed for card display
+        break;
     }
 
     // Determine running status


### PR DESCRIPTION
## Summary

- Upgrade `@anthropic-ai/claude-agent-sdk` from `^0.1.0` to `^0.2.0` (resolves compatibility with SDK 0.2.x)
- Handle new SDK message types (`task_notification`, `tool_use_summary`) in `stream-processor.ts` to prevent runtime warnings
- Add comprehensive `CLAUDE.md` with prerequisites, step-by-step Feishu app setup guide, and troubleshooting section

## Changes

| File | Change |
|------|--------|
| `package.json` / `package-lock.json` | SDK version bump |
| `src/claude/stream-processor.ts` | Handle new message types from SDK 0.2.x |
| `CLAUDE.md` | Full project documentation |

## Test plan

- [x] `npm run build` passes cleanly
- [x] Bot tested end-to-end: send message in Feishu → streaming card response from Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)