### PR TITLE
CI: drop Node 18 from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Remove Node 18 from CI test matrix — ESLint 10.x requires Node 20+ (`util.styleText` API)
- Branch protection on main updated to require `check (20)`, `check (22)`, `build` only

## Test plan
- [ ] CI passes on Node 20 and 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)