### PR TITLE
Default allowAll to true for bots.json mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ curl -X POST localhost:9100/api/bots \
 | `defaultWorkingDirectory` | Yes | — | Working directory for Claude |
 | `feishuAppId` / `feishuAppSecret` | Feishu | — | Feishu app credentials |
 | `telegramBotToken` | Telegram | — | Telegram bot token |
-| `allowAll` | No | `false` | Allow all users (skip auth check) |
+| `allowAll` | No | `true` | Allow all users (skip auth check) |
 | `authorizedUserIds` | No | — | User ID allowlist |
 | `allowedTools` | No | Read,Edit,Write,Glob,Grep,Bash | Claude tools whitelist |
 | `maxTurns` / `maxBudgetUsd` | No | unlimited | Execution limits |

--- a/README_zh.md
+++ b/README_zh.md
@@ -151,7 +151,7 @@ curl -X POST localhost:9100/api/bots \
 | `defaultWorkingDirectory` | 是 | — | Claude 的工作目录 |
 | `feishuAppId` / `feishuAppSecret` | 飞书 | — | 飞书应用凭证 |
 | `telegramBotToken` | Telegram | — | Telegram Bot Token |
-| `allowAll` | 否 | `false` | 允许所有用户（跳过鉴权） |
+| `allowAll` | 否 | `true` | 允许所有用户（跳过鉴权） |
 | `authorizedUserIds` | 否 | — | 用户 ID 白名单 |
 | `allowedTools` | 否 | Read,Edit,Write,Glob,Grep,Bash | Claude 可用工具 |
 | `maxTurns` / `maxBudgetUsd` | 否 | 不限 | 执行限制 |

--- a/bots.example.json
+++ b/bots.example.json
@@ -12,7 +12,6 @@
       "feishuAppId": "cli_yyy",
       "feishuAppSecret": "secret2",
       "defaultWorkingDirectory": "/home/user/project-beta",
-      "allowAll": true,
       "allowedTools": ["Read", "Edit", "Write", "Glob", "Grep", "Bash"],
       "maxTurns": 30,
       "maxBudgetUsd": 0.5

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,7 +99,7 @@ function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
     auth: {
       authorizedUserIds: entry.authorizedUserIds || [],
       authorizedChatIds: entry.authorizedChatIds || [],
-      allowAll: entry.allowAll ?? false,
+      allowAll: entry.allowAll ?? true,
     },
     claude: buildClaudeConfig(entry),
   };
@@ -131,7 +131,7 @@ function telegramBotFromJson(entry: TelegramBotJsonEntry): TelegramBotConfig {
     auth: {
       authorizedUserIds: entry.authorizedUserIds || [],
       authorizedChatIds: entry.authorizedChatIds || [],
-      allowAll: entry.allowAll ?? false,
+      allowAll: entry.allowAll ?? true,
     },
     claude: buildClaudeConfig(entry),
   };


### PR DESCRIPTION
## Summary
- Change `allowAll` default from `false` to `true` in bots.json mode
- Bot-level auth is redundant — Feishu/Telegram handle access control at the platform level
- Previous deny-by-default caused new installs to silently reject all messages
- Updated bots.example.json and README docs

## Test plan
- [ ] New install without `allowAll` in bots.json can receive and respond to messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)