### PR TITLE
Add metabot CLI for update/start/stop/restart

### DIFF
--- a/bin/metabot
+++ b/bin/metabot
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# metabot - MetaBot management CLI
+# Usage: metabot update | start | stop | restart | logs | status
+
+set -euo pipefail
+
+METABOT_HOME="${METABOT_HOME:-$HOME/metabot}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+success() { echo -e "${GREEN}[OK]${NC} $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*"; }
+
+cmd_update() {
+  if [[ ! -d "$METABOT_HOME/.git" ]]; then
+    error "MetaBot not found at $METABOT_HOME"
+    echo "  Run the installer first: curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash"
+    exit 1
+  fi
+
+  info "Pulling latest code..."
+  cd "$METABOT_HOME"
+  git pull --ff-only || { error "git pull failed"; exit 1; }
+
+  info "Installing dependencies..."
+  npm install --production=false
+
+  info "Building..."
+  npm run build
+
+  info "Restarting MetaBot..."
+  pm2 restart metabot 2>/dev/null || pm2 start ecosystem.config.cjs
+  pm2 save --force 2>/dev/null || true
+
+  success "MetaBot updated and restarted!"
+}
+
+cmd_start()   { pm2 start "$METABOT_HOME/ecosystem.config.cjs"; pm2 save --force 2>/dev/null || true; }
+cmd_stop()    { pm2 stop metabot; }
+cmd_restart() { pm2 restart metabot; }
+cmd_logs()    { pm2 logs metabot "${@}"; }
+cmd_status()  { pm2 describe metabot; }
+
+case "${1:-help}" in
+  update|up)    cmd_update ;;
+  start)        cmd_start ;;
+  stop)         cmd_stop ;;
+  restart|rs)   cmd_restart ;;
+  logs|log)     shift; cmd_logs "$@" ;;
+  status|st)    cmd_status ;;
+  *)
+    echo -e "${BOLD}metabot${NC} - MetaBot management CLI"
+    echo ""
+    echo "  metabot update     Pull latest, rebuild, and restart"
+    echo "  metabot start      Start MetaBot with PM2"
+    echo "  metabot stop       Stop MetaBot"
+    echo "  metabot restart    Restart MetaBot"
+    echo "  metabot logs       View live logs (pass -n 100 etc.)"
+    echo "  metabot status     Show PM2 process status"
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -778,10 +778,10 @@ fi
 # Source it in the current shell so mm/mb work immediately after install
 source "$BASH_ALIASES" 2>/dev/null || true
 
-# Install mm/mb as standalone executables in ~/.local/bin (no source needed)
+# Install mm/mb/metabot as standalone executables in ~/.local/bin (no source needed)
 LOCAL_BIN="$HOME/.local/bin"
 mkdir -p "$LOCAL_BIN"
-for cli in mm mb; do
+for cli in mm mb metabot; do
   if [[ -f "$METABOT_HOME/bin/$cli" ]]; then
     cp "$METABOT_HOME/bin/$cli" "$LOCAL_BIN/$cli"
     chmod +x "$LOCAL_BIN/$cli"
@@ -799,7 +799,7 @@ if ! echo "$PATH" | grep -q "$LOCAL_BIN"; then
   echo "export PATH=\"$LOCAL_BIN:\$PATH\"" >> "$HOME/.bashrc"
   info "Added ~/.local/bin to PATH in ~/.bashrc"
 fi
-success "mm/mb CLI tools installed to $LOCAL_BIN (available without sourcing)"
+success "mm/mb/metabot CLI tools installed to $LOCAL_BIN"
 
 # ============================================================================
 # Phase 8: Build + Start MetaBot with PM2


### PR DESCRIPTION
## Summary
- New `bin/metabot` CLI with commands: `update`, `start`, `stop`, `restart`, `logs`, `status`
- `metabot update` — git pull + npm install + build + pm2 restart (one command to update)
- Installed to `~/.local/bin/metabot` alongside `mm` and `mb` during install

## Test plan
- [ ] `metabot update` pulls, builds, restarts
- [ ] `metabot logs` shows PM2 logs
- [ ] `metabot help` shows usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)