### PR TITLE
Add recurring cron-based scheduled tasks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,8 @@ CLAUDE_CODE_DISABLE_AUTO_MEMORY=0
 API_PORT=9100
 API_SECRET=       # If set, listens on 0.0.0.0 with Bearer auth; if empty, localhost only
 
+# Default timezone for recurring cron tasks (IANA format)
+# SCHEDULE_TIMEZONE=Asia/Shanghai
+
 # Logging
 LOG_LEVEL=info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,3 +213,14 @@ If the service starts but Feishu events don't arrive:
 
 The bot only responds when **@mentioned** in group chats. In DMs it replies to all messages. This is by design in `event-handler.ts`.
 
+## Feature Completion Workflow
+
+When implementing a feature or fixing a bug, follow this end-to-end workflow unless the user says otherwise:
+
+1. **Build & Test** — Run `npm run build`, `npm test`, `npm run lint` and fix any failures before proceeding.
+2. **Update docs** — Update README.md, README_zh.md, and CLAUDE.md if the change affects user-facing behavior, API surface, CLI commands, or architecture.
+3. **Commit** — Create a descriptive commit on the current branch.
+4. **Push & PR** — Push the branch and create a PR to `main` via `gh pr create`.
+5. **CI** — Wait for CI checks to pass (check with `gh pr checks`). Fix any failures.
+6. **Merge** — Once CI is green, merge via `gh pr merge --squash --delete-branch`.
+

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,7 +58,7 @@ MetaBot 解放了它。给每个 Agent 一个 Claude Code 大脑、持久化的�
 | **MetaMemory** | 内嵌 SQLite 知识库，全文搜索，Web UI。Agent 跨会话读写 Markdown 文档。所有 Agent 共享。 |
 | **IM Bridge** | 飞书或 Telegram（含手机端）与任意 Agent 对话。带颜色状态的流式卡片 + 工具调用追踪。 |
 | **Agent 总线** | 9100 端口 REST API。Agent 通过 `curl` 互相委派任务。运行时创建/删除 Bot。以 `/metabot-api` skill 形式按需加载，不注入每次对话。 |
-| **定时任务调度器** | Agent 安排未来的工作 —— "2小时后检查一下"。跨重启持久化，忙时自动重试。 |
+| **定时任务调度器** | 一次性延迟和周期性 cron 任务。`0 8 * * 1-5` = 工作日早8点新闻简报。支持时区配置（默认 Asia/Shanghai）。跨重启持久化，忙时自动重试。 |
 | **CLI 工具** | `metabot`、`mm`、`mb` 命令安装到 `~/.local/bin/`。`metabot update` 一键更新重启。`mm` 管理 MetaMemory，`mb` 管理 Agent 总线。 |
 
 ## 安装
@@ -116,6 +116,10 @@ curl -X POST localhost:9100/api/tasks \
 # 安排 1 小时后的跟进
 curl -X POST localhost:9100/api/schedule \
   -d '{"botName":"backend-bot","chatId":"oc_xxx","prompt":"检查迁移结果","delaySeconds":3600}'
+
+# 创建周期性定时任务（工作日早8点）
+curl -X POST localhost:9100/api/schedule \
+  -d '{"botName":"news-bot","chatId":"oc_xxx","prompt":"阅读并总结科技新闻","cronExpr":"0 8 * * 1-5"}'
 
 # 运行时创建新 Bot
 curl -X POST localhost:9100/api/bots \
@@ -221,10 +225,12 @@ MetaBot 以 `bypassPermissions` 模式运行 Claude Code — 无交互式确认�
 | `GET` | `/api/bots/:name` | 获取 Bot 详情 |
 | `DELETE` | `/api/bots/:name` | 删除 Bot |
 | `POST` | `/api/tasks` | 委派任务给 Bot |
-| `POST` | `/api/schedule` | 创建定时任务 |
-| `GET` | `/api/schedule` | 列出定时任务 |
+| `POST` | `/api/schedule` | 创建一次性或周期性 (cron) 定时任务 |
+| `GET` | `/api/schedule` | 列出定时任务（一次性 + 周期性） |
 | `PATCH` | `/api/schedule/:id` | 更新定时任务 |
 | `DELETE` | `/api/schedule/:id` | 取消定时任务 |
+| `POST` | `/api/schedule/:id/pause` | 暂停周期性任务 |
+| `POST` | `/api/schedule/:id/resume` | 恢复已暂停的周期性任务 |
 | `GET` | `/api/stats` | 费用与使用统计（按 Bot/用户） |
 | `GET` | `/api/metrics` | Prometheus 监控指标 |
 
@@ -257,6 +263,9 @@ mm delete DOC_ID                    # 删除文档
 mb bots                             # 列出所有 Bot
 mb task <bot> <chatId> <prompt>     # 委派任务
 mb schedule list                    # 列出定时任务
+mb schedule cron <bot> <chatId> '<cron>' <prompt>  # 创建周期性任务
+mb schedule pause <id>              # 暂停周期性任务
+mb schedule resume <id>             # 恢复周期性任务
 mb stats                            # 费用和使用统计
 mb health                           # 状态检查
 ```
@@ -265,7 +274,7 @@ mb health                           # 状态检查
 
 ```bash
 npm run dev          # 热重载开发服务器（tsx）
-npm test             # 运行测试（vitest，71 个测试）
+npm test             # 运行测试（vitest，93 个测试）
 npm run lint         # ESLint 检查
 npm run format       # Prettier 格式化
 npm run build        # TypeScript 编译到 dist/

--- a/bin/mb
+++ b/bin/mb
@@ -69,14 +69,41 @@ print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'delaySeconds':
           -H "$METABOT_AUTH" -H "Content-Type: application/json" \
           -d @- | _json
         ;;
+      cron|c)
+        bot="$1" chat="$2" cron_expr="$3"; shift 3 2>/dev/null || true
+        prompt="$*"
+        if [[ -z "${bot:-}" || -z "${chat:-}" || -z "${cron_expr:-}" || -z "${prompt:-}" ]]; then
+          echo "Usage: mb schedule cron <botName> <chatId> '<cronExpr>' <prompt>"
+          echo "  Example: mb schedule cron mybot oc_xxx '0 8 * * 1-5' Generate daily report"
+          exit 1
+        fi
+        python3 -c "
+import json, sys
+print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'cronExpr': sys.argv[3], 'prompt': sys.argv[4]}))
+" "$bot" "$chat" "$cron_expr" "$prompt" | \
+        curl -s -X POST "$METABOT_URL/api/schedule" \
+          -H "$METABOT_AUTH" -H "Content-Type: application/json" \
+          -d @- | _json
+        ;;
+      pause|p)
+        if [[ -z "${1:-}" ]]; then echo "Usage: mb schedule pause <id>"; exit 1; fi
+        curl -s -X POST "$METABOT_URL/api/schedule/$1/pause" -H "$METABOT_AUTH" | _json
+        ;;
+      resume|r)
+        if [[ -z "${1:-}" ]]; then echo "Usage: mb schedule resume <id>"; exit 1; fi
+        curl -s -X POST "$METABOT_URL/api/schedule/$1/resume" -H "$METABOT_AUTH" | _json
+        ;;
       cancel|rm)
         if [[ -z "${1:-}" ]]; then echo "Usage: mb schedule cancel <id>"; exit 1; fi
-        curl -s -X DELETE "$METABOT_URL/api/schedule/$1" -H "$METABOT_AUTH"
+        curl -s -X DELETE "$METABOT_URL/api/schedule/$1" -H "$METABOT_AUTH" | _json
         ;;
       *)
         echo "mb schedule - Task scheduling"
-        echo "  mb schedule list                                    - List pending tasks"
-        echo "  mb schedule add <bot> <chatId> <delaySec> <prompt>  - Schedule a task"
+        echo "  mb schedule list                                    - List all scheduled tasks"
+        echo "  mb schedule add <bot> <chatId> <delaySec> <prompt>  - Schedule a one-time task"
+        echo "  mb schedule cron <bot> <chatId> '<cron>' <prompt>   - Schedule a recurring task"
+        echo "  mb schedule pause <id>                              - Pause a recurring task"
+        echo "  mb schedule resume <id>                             - Resume a paused task"
         echo "  mb schedule cancel <id>                             - Cancel a task"
         ;;
     esac
@@ -104,8 +131,11 @@ print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'delaySeconds':
     echo "    mb task <bot> <chatId> <prompt>  - Delegate task to a bot"
     echo ""
     echo "  Scheduling:"
-    echo "    mb schedule list                 - List pending scheduled tasks"
+    echo "    mb schedule list                 - List all scheduled tasks"
     echo "    mb schedule add <bot> <chatId> <delaySec> <prompt>"
+    echo "    mb schedule cron <bot> <chatId> '<cron>' <prompt>"
+    echo "    mb schedule pause <id>           - Pause a recurring task"
+    echo "    mb schedule resume <id>          - Resume a paused task"
     echo "    mb schedule cancel <id>          - Cancel a scheduled task"
     echo ""
     echo "  Monitoring:"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",
         "@larksuiteoapi/node-sdk": "^1.58.0",
         "better-sqlite3": "^12.6.2",
+        "cron-parser": "^5.5.0",
         "dotenv": "^16.4.0",
         "grammy": "^1.40.0",
         "pino": "^9.0.0",
@@ -2151,6 +2152,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
+      "integrity": "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3089,6 +3102,15 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@larksuiteoapi/node-sdk": "^1.58.0",
     "better-sqlite3": "^12.6.2",
+    "cron-parser": "^5.5.0",
     "dotenv": "^16.4.0",
     "grammy": "^1.40.0",
     "pino": "^9.0.0",

--- a/src/scheduler/cron-utils.ts
+++ b/src/scheduler/cron-utils.ts
@@ -1,0 +1,54 @@
+import { CronExpressionParser } from 'cron-parser';
+
+const DEFAULT_TIMEZONE = process.env.SCHEDULE_TIMEZONE || 'Asia/Shanghai';
+
+/**
+ * Validate a 5-field cron expression (minute hour dom month dow).
+ * Also accepts predefined aliases like @daily, @hourly, etc.
+ */
+export function isValidCron(expr: string): boolean {
+  try {
+    if (expr.startsWith('@')) {
+      CronExpressionParser.parse(expr);
+      return true;
+    }
+    // Ensure exactly 5 fields (minute hour dom month dow)
+    const fields = expr.trim().split(/\s+/);
+    if (fields.length !== 5) return false;
+    // Prepend seconds field for cron-parser v5 (expects 6 fields)
+    CronExpressionParser.parse(`0 ${expr}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compute the next occurrence after `afterDate` (default: now).
+ * Returns Unix ms timestamp.
+ * @param expr - 5-field cron expression or predefined alias
+ * @param timezone - IANA timezone string
+ * @param afterDate - Date to compute next occurrence from
+ */
+export function nextCronOccurrence(
+  expr: string,
+  timezone?: string,
+  afterDate?: Date,
+): number {
+  const tz = timezone || DEFAULT_TIMEZONE;
+  const fullExpr = expr.startsWith('@') ? expr : `0 ${expr}`;
+  const options: Record<string, unknown> = { tz };
+  if (afterDate) {
+    options.currentDate = afterDate;
+  }
+  const parsed = CronExpressionParser.parse(fullExpr, options);
+  const next = parsed.next();
+  return next.getTime();
+}
+
+/**
+ * Return default timezone from env or fallback.
+ */
+export function getDefaultTimezone(): string {
+  return DEFAULT_TIMEZONE;
+}

--- a/src/skills/metabot-api/SKILL.md
+++ b/src/skills/metabot-api/SKILL.md
@@ -21,10 +21,15 @@ mb bot <name>                              # Get bot details
 # Task delegation
 mb task <botName> <chatId> <prompt>        # Delegate task to another bot
 
-# Scheduling
-mb schedule list                           # List pending scheduled tasks
-mb schedule add <bot> <chatId> <sec> <prompt>  # Schedule a future task
+# Scheduling (one-time)
+mb schedule list                           # List all scheduled tasks
+mb schedule add <bot> <chatId> <sec> <prompt>  # Schedule a one-time future task
 mb schedule cancel <id>                    # Cancel a scheduled task
+
+# Scheduling (recurring / cron)
+mb schedule cron <bot> <chatId> '<cronExpr>' <prompt>  # Create recurring task
+mb schedule pause <id>                     # Pause a recurring task
+mb schedule resume <id>                    # Resume a paused recurring task
 
 # Monitoring
 mb stats                                   # Cost & usage stats (per-bot, per-user)
@@ -76,6 +81,31 @@ curl -s -X PATCH http://localhost:${METABOT_API_PORT:-9100}/api/schedule/<id> \
   -H "Authorization: Bearer $METABOT_API_SECRET" \
   -H "Content-Type: application/json" \
   -d '{"prompt":"updated prompt","delaySeconds":7200}'
+```
+
+**Create recurring scheduled task (cron):**
+```bash
+curl -s -X POST http://localhost:${METABOT_API_PORT:-9100}/api/schedule \
+  -H "Authorization: Bearer $METABOT_API_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"botName":"<bot>","chatId":"<chatId>","prompt":"<task>","cronExpr":"0 8 * * 1-5","timezone":"Asia/Shanghai","label":"Daily report"}'
+```
+Cron format: `minute hour day month weekday` (5 fields). Examples: `0 8 * * *` = daily 8am, `0 8 * * 1-5` = weekdays 8am, `*/30 * * * *` = every 30 min. Default timezone: Asia/Shanghai.
+
+**Pause/resume recurring task:**
+```bash
+curl -s -X POST http://localhost:${METABOT_API_PORT:-9100}/api/schedule/<id>/pause \
+  -H "Authorization: Bearer $METABOT_API_SECRET"
+curl -s -X POST http://localhost:${METABOT_API_PORT:-9100}/api/schedule/<id>/resume \
+  -H "Authorization: Bearer $METABOT_API_SECRET"
+```
+
+**Update recurring task:**
+```bash
+curl -s -X PATCH http://localhost:${METABOT_API_PORT:-9100}/api/schedule/<id> \
+  -H "Authorization: Bearer $METABOT_API_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"cronExpr":"0 9 * * *","prompt":"Updated prompt","timezone":"Asia/Shanghai"}'
 ```
 
 When asked to create a bot:

--- a/tests/cron-utils.test.ts
+++ b/tests/cron-utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { isValidCron, nextCronOccurrence, getDefaultTimezone } from '../src/scheduler/cron-utils.js';
+
+describe('cron-utils', () => {
+  describe('isValidCron', () => {
+    it('accepts standard 5-field expressions', () => {
+      expect(isValidCron('0 8 * * *')).toBe(true);       // daily 8am
+      expect(isValidCron('*/5 * * * *')).toBe(true);      // every 5 min
+      expect(isValidCron('0 8 * * 1-5')).toBe(true);      // weekdays 8am
+      expect(isValidCron('30 9 1 * *')).toBe(true);       // 1st of month 9:30
+      expect(isValidCron('0 0 * * 0')).toBe(true);        // sunday midnight
+    });
+
+    it('accepts predefined aliases', () => {
+      expect(isValidCron('@daily')).toBe(true);
+      expect(isValidCron('@hourly')).toBe(true);
+      expect(isValidCron('@weekly')).toBe(true);
+      expect(isValidCron('@monthly')).toBe(true);
+      expect(isValidCron('@yearly')).toBe(true);
+    });
+
+    it('rejects invalid expressions', () => {
+      expect(isValidCron('invalid')).toBe(false);
+      expect(isValidCron('0 8 * *')).toBe(false);         // only 4 fields
+      expect(isValidCron('60 8 * * *')).toBe(false);       // minute out of range
+      expect(isValidCron('0 25 * * *')).toBe(false);       // hour out of range
+      expect(isValidCron('')).toBe(false);
+    });
+  });
+
+  describe('nextCronOccurrence', () => {
+    it('returns a future timestamp', () => {
+      const now = Date.now();
+      const next = nextCronOccurrence('* * * * *', 'UTC');
+      expect(next).toBeGreaterThan(now - 1000); // within 1 second tolerance
+    });
+
+    it('respects afterDate parameter', () => {
+      // "0 8 * * *" = daily 8am UTC
+      // If afterDate is 2025-01-15 07:00 UTC, next should be 2025-01-15 08:00 UTC
+      const afterDate = new Date('2025-01-15T07:00:00Z');
+      const next = nextCronOccurrence('0 8 * * *', 'UTC', afterDate);
+      const expected = new Date('2025-01-15T08:00:00Z').getTime();
+      expect(next).toBe(expected);
+    });
+
+    it('advances past afterDate when already past the time', () => {
+      // If afterDate is 2025-01-15 09:00 UTC (past 8am), next should be 2025-01-16 08:00 UTC
+      const afterDate = new Date('2025-01-15T09:00:00Z');
+      const next = nextCronOccurrence('0 8 * * *', 'UTC', afterDate);
+      const expected = new Date('2025-01-16T08:00:00Z').getTime();
+      expect(next).toBe(expected);
+    });
+
+    it('handles timezone correctly', () => {
+      // "0 8 * * *" with Asia/Shanghai (+8) → 8:00 CST = 00:00 UTC
+      const afterDate = new Date('2025-01-15T00:00:01Z'); // just past midnight UTC = 8:00:01 CST
+      const next = nextCronOccurrence('0 8 * * *', 'Asia/Shanghai', afterDate);
+      // Next 8am Shanghai = 2025-01-16 00:00 UTC
+      const expected = new Date('2025-01-16T00:00:00Z').getTime();
+      expect(next).toBe(expected);
+    });
+  });
+
+  describe('getDefaultTimezone', () => {
+    it('returns Asia/Shanghai by default', () => {
+      // SCHEDULE_TIMEZONE is not set in test env
+      expect(getDefaultTimezone()).toBe('Asia/Shanghai');
+    });
+  });
+});

--- a/tests/task-scheduler-recurring.test.ts
+++ b/tests/task-scheduler-recurring.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { TaskScheduler } from '../src/scheduler/task-scheduler.js';
+import type { BotRegistry } from '../src/api/bot-registry.js';
+import type { Logger } from '../src/utils/logger.js';
+
+// Mock cron-utils to return deterministic values
+vi.mock('../src/scheduler/cron-utils.js', () => ({
+  isValidCron: (expr: string) => {
+    const invalid = ['invalid', '', '0 8 * *', '60 8 * * *'];
+    return !invalid.includes(expr);
+  },
+  nextCronOccurrence: vi.fn(() => Date.now() + 60_000), // default: 1 min from now
+  getDefaultTimezone: () => 'Asia/Shanghai',
+}));
+
+// Get reference to the mock so we can change return values
+import { nextCronOccurrence } from '../src/scheduler/cron-utils.js';
+const mockNextCron = vi.mocked(nextCronOccurrence);
+
+const PERSIST_DIR = path.join(os.homedir(), '.metabot');
+const PERSIST_FILE = path.join(PERSIST_DIR, 'scheduled-tasks.json');
+
+function createMockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as Logger;
+}
+
+function createMockRegistry(botExists = true, isBusy = false): BotRegistry {
+  const mockBridge = {
+    isBusy: vi.fn().mockReturnValue(isBusy),
+    executeApiTask: vi.fn().mockResolvedValue({ success: true }),
+  };
+  const mockSender = {
+    sendTextNotice: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockBot = {
+    bridge: mockBridge,
+    sender: mockSender,
+    config: { claude: { defaultWorkingDirectory: '/tmp' } },
+  };
+  return {
+    get: vi.fn().mockReturnValue(botExists ? mockBot : undefined),
+    list: vi.fn().mockReturnValue([]),
+    register: vi.fn(),
+    deregister: vi.fn(),
+  } as unknown as BotRegistry;
+}
+
+describe('TaskScheduler - Recurring Tasks', () => {
+  let originalPersist: string | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Save and clear any existing persist file
+    try {
+      originalPersist = fs.readFileSync(PERSIST_FILE, 'utf-8');
+    } catch {
+      originalPersist = undefined;
+    }
+    try { fs.unlinkSync(PERSIST_FILE); } catch { /* ignore */ }
+    mockNextCron.mockImplementation(() => Date.now() + 60_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // Restore persist file
+    try { fs.unlinkSync(PERSIST_FILE); } catch { /* ignore */ }
+    if (originalPersist) {
+      fs.mkdirSync(PERSIST_DIR, { recursive: true });
+      fs.writeFileSync(PERSIST_FILE, originalPersist);
+    }
+  });
+
+  it('creates a recurring task with correct fields', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'testbot',
+      chatId: 'chat1',
+      prompt: 'Read news',
+      cronExpr: '0 8 * * *',
+      timezone: 'Asia/Shanghai',
+      label: 'Daily news',
+    });
+
+    expect(recurring.id).toBeTruthy();
+    expect(recurring.botName).toBe('testbot');
+    expect(recurring.chatId).toBe('chat1');
+    expect(recurring.prompt).toBe('Read news');
+    expect(recurring.cronExpr).toBe('0 8 * * *');
+    expect(recurring.timezone).toBe('Asia/Shanghai');
+    expect(recurring.status).toBe('active');
+    expect(recurring.label).toBe('Daily news');
+    expect(recurring.sendCards).toBe(true);
+    expect(recurring.nextExecuteAt).toBeGreaterThan(0);
+
+    scheduler.destroy();
+  });
+
+  it('throws for invalid cron expression', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    expect(() => scheduler.scheduleRecurring({
+      botName: 'testbot',
+      chatId: 'chat1',
+      prompt: 'test',
+      cronExpr: 'invalid',
+    })).toThrow('Invalid cron expression');
+    scheduler.destroy();
+  });
+
+  it('uses default timezone when not specified', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'testbot',
+      chatId: 'chat1',
+      prompt: 'test',
+      cronExpr: '0 8 * * *',
+    });
+
+    expect(recurring.timezone).toBe('Asia/Shanghai');
+    scheduler.destroy();
+  });
+
+  it('lists recurring tasks (excluding cancelled)', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    scheduler.scheduleRecurring({ botName: 'b', chatId: 'c', prompt: 'p1', cronExpr: '0 8 * * *' });
+    scheduler.scheduleRecurring({ botName: 'b', chatId: 'c', prompt: 'p2', cronExpr: '0 9 * * *' });
+
+    expect(scheduler.listRecurringTasks()).toHaveLength(2);
+    expect(scheduler.recurringTaskCount()).toBe(2);
+
+    scheduler.destroy();
+  });
+
+  it('pauses and resumes a recurring task', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'p', cronExpr: '0 8 * * *',
+    });
+
+    expect(scheduler.pauseRecurring(recurring.id)).toBe(true);
+    const paused = scheduler.getRecurringTask(recurring.id);
+    expect(paused?.status).toBe('paused');
+
+    // Cannot pause again
+    expect(scheduler.pauseRecurring(recurring.id)).toBe(false);
+
+    expect(scheduler.resumeRecurring(recurring.id)).toBe(true);
+    const resumed = scheduler.getRecurringTask(recurring.id);
+    expect(resumed?.status).toBe('active');
+
+    // Cannot resume again
+    expect(scheduler.resumeRecurring(recurring.id)).toBe(false);
+
+    scheduler.destroy();
+  });
+
+  it('cancels a recurring task', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'p', cronExpr: '0 8 * * *',
+    });
+
+    expect(scheduler.cancelRecurring(recurring.id)).toBe(true);
+    expect(scheduler.getRecurringTask(recurring.id)?.status).toBe('cancelled');
+    expect(scheduler.listRecurringTasks()).toHaveLength(0);
+
+    // Cannot cancel again
+    expect(scheduler.cancelRecurring(recurring.id)).toBe(false);
+
+    scheduler.destroy();
+  });
+
+  it('updates a recurring task', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'old', cronExpr: '0 8 * * *', label: 'old',
+    });
+
+    const updated = scheduler.updateRecurring(recurring.id, {
+      prompt: 'new prompt',
+      label: 'new label',
+    });
+
+    expect(updated?.prompt).toBe('new prompt');
+    expect(updated?.label).toBe('new label');
+    expect(updated?.cronExpr).toBe('0 8 * * *'); // unchanged
+
+    scheduler.destroy();
+  });
+
+  it('rejects updating with invalid cron', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'p', cronExpr: '0 8 * * *',
+    });
+
+    expect(() => scheduler.updateRecurring(recurring.id, { cronExpr: 'invalid' }))
+      .toThrow('Invalid cron expression');
+
+    scheduler.destroy();
+  });
+
+  it('fires recurring instance and schedules next', async () => {
+    const registry = createMockRegistry();
+    const scheduler = new TaskScheduler(registry, createMockLogger());
+
+    // Mock: first call returns "now + 100ms", subsequent calls return "now + 60s"
+    let callCount = 0;
+    mockNextCron.mockImplementation(() => {
+      callCount++;
+      return callCount === 1
+        ? Date.now() + 100
+        : Date.now() + 60_000;
+    });
+
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'testbot', chatId: 'chat1', prompt: 'Do work', cronExpr: '* * * * *',
+    });
+
+    // Advance past the first fire time
+    await vi.advanceTimersByTimeAsync(200);
+
+    // The recurring task should have fired: check the bridge was called
+    const bot = (registry.get as ReturnType<typeof vi.fn>).mock.results[0]?.value;
+    if (bot) {
+      expect(bot.bridge.executeApiTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: 'Do work',
+          chatId: 'chat1',
+          userId: 'scheduler',
+        }),
+      );
+    }
+
+    // After firing, recurring should have updated lastExecutedAt and nextExecuteAt
+    const updated = scheduler.getRecurringTask(recurring.id);
+    expect(updated?.lastExecutedAt).toBeGreaterThan(0);
+    expect(updated?.status).toBe('active');
+
+    scheduler.destroy();
+  });
+
+  it('persists and restores recurring tasks across instances', () => {
+    const logger = createMockLogger();
+    const registry = createMockRegistry();
+
+    // Create scheduler with recurring task
+    const scheduler1 = new TaskScheduler(registry, logger);
+    const recurring = scheduler1.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'p', cronExpr: '0 8 * * *', label: 'test',
+    });
+    scheduler1.destroy();
+
+    // New scheduler instance should restore it
+    const scheduler2 = new TaskScheduler(registry, logger);
+    const restored = scheduler2.listRecurringTasks();
+    expect(restored).toHaveLength(1);
+    expect(restored[0].id).toBe(recurring.id);
+    expect(restored[0].prompt).toBe('p');
+    expect(restored[0].cronExpr).toBe('0 8 * * *');
+    expect(restored[0].status).toBe('active');
+
+    scheduler2.destroy();
+  });
+
+  it('backward-compatible: loads old array format persist file', () => {
+    // Write old-format persist file (plain array)
+    fs.mkdirSync(PERSIST_DIR, { recursive: true });
+    const oldData = [
+      {
+        id: 'old-task-1',
+        botName: 'b',
+        chatId: 'c',
+        prompt: 'old task',
+        executeAt: Date.now() + 60_000,
+        sendCards: true,
+        status: 'pending',
+        createdAt: Date.now(),
+        retryCount: 0,
+      },
+    ];
+    fs.writeFileSync(PERSIST_FILE, JSON.stringify(oldData));
+
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+
+    // One-time task should be restored
+    expect(scheduler.listTasks()).toHaveLength(1);
+    expect(scheduler.listTasks()[0].id).toBe('old-task-1');
+
+    // No recurring tasks
+    expect(scheduler.listRecurringTasks()).toHaveLength(0);
+
+    scheduler.destroy();
+  });
+
+  it('does not restore cancelled recurring tasks', () => {
+    const logger = createMockLogger();
+    const registry = createMockRegistry();
+
+    const scheduler1 = new TaskScheduler(registry, logger);
+    const recurring = scheduler1.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'p', cronExpr: '0 8 * * *',
+    });
+    scheduler1.cancelRecurring(recurring.id);
+    scheduler1.destroy();
+
+    const scheduler2 = new TaskScheduler(registry, logger);
+    expect(scheduler2.listRecurringTasks()).toHaveLength(0);
+    scheduler2.destroy();
+  });
+
+  it('restores paused recurring tasks without setting timers', () => {
+    const logger = createMockLogger();
+    const registry = createMockRegistry();
+
+    const scheduler1 = new TaskScheduler(registry, logger);
+    const recurring = scheduler1.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'p', cronExpr: '0 8 * * *',
+    });
+    scheduler1.pauseRecurring(recurring.id);
+    scheduler1.destroy();
+
+    const scheduler2 = new TaskScheduler(registry, logger);
+    const restored = scheduler2.listRecurringTasks();
+    expect(restored).toHaveLength(1);
+    expect(restored[0].status).toBe('paused');
+
+    scheduler2.destroy();
+  });
+
+  it('one-time tasks still work alongside recurring tasks', () => {
+    const scheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+
+    const oneTime = scheduler.scheduleTask({
+      botName: 'b', chatId: 'c', prompt: 'one-time', delaySeconds: 60,
+    });
+    const recurring = scheduler.scheduleRecurring({
+      botName: 'b', chatId: 'c', prompt: 'recurring', cronExpr: '0 8 * * *',
+    });
+
+    expect(scheduler.listTasks()).toHaveLength(1);
+    expect(scheduler.listTasks()[0].id).toBe(oneTime.id);
+    expect(scheduler.listRecurringTasks()).toHaveLength(1);
+    expect(scheduler.listRecurringTasks()[0].id).toBe(recurring.id);
+
+    scheduler.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add recurring task support using standard 5-field cron expressions (e.g. `0 8 * * 1-5` for weekdays at 8am)
- Timezone-aware scheduling (default: `Asia/Shanghai`, configurable via `SCHEDULE_TIMEZONE` env var or per-task)
- Full lifecycle: create, pause, resume, cancel, update recurring tasks
- Backward-compatible API — existing one-time scheduling unchanged
- CLI: `mb schedule cron/pause/resume` commands
- 22 new tests (93 total)
- Add "Feature Completion Workflow" rule to CLAUDE.md for end-to-end dev workflow

## Key changes
- **`src/scheduler/cron-utils.ts`** — new cron parser wrapper (validation, next-occurrence)
- **`src/scheduler/task-scheduler.ts`** — `RecurringTask` model, scheduling logic, backward-compatible persistence
- **`src/api/http-server.ts`** — extended schedule routes, new pause/resume endpoints
- **`bin/mb`** — new `cron`, `pause`, `resume` subcommands
- **`SKILL.md`** — documented recurring schedule API for agents
- **READMEs** — updated both EN and ZH with recurring schedule docs

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 93 tests pass (22 new)
- [x] `npm run lint` — 0 errors
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)