### PR TITLE
Fix metabot CLI failing to start from outside project directory

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,9 +1,11 @@
+const path = require('path');
+
 module.exports = {
   apps: [
     {
       name: 'metabot',
       script: 'src/index.ts',
-      interpreter: 'node_modules/.bin/tsx',
+      interpreter: path.join(__dirname, 'node_modules/.bin/tsx'),
       cwd: __dirname,
 
       // Watch for code changes and auto-restart


### PR DESCRIPTION
## Summary
- PM2 ecosystem config used a relative interpreter path (`node_modules/.bin/tsx`) which only resolved when cwd was the metabot directory
- Changed to absolute path via `path.join(__dirname, 'node_modules/.bin/tsx')` so `metabot start` works from any directory

## Test plan
- [x] `metabot start` from `/tmp` — launches successfully (status: online)
- [x] `pm2 describe metabot` shows correct absolute interpreter path
- [x] `npm run build` / `npm test` / `npm run lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)