### PR TITLE
Rename metabot-api skill to metabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We built MetaBot to run [XVI Robotics](https://github.com/xvirobotics) as an **a
 | **MetaSkill** | Agent factory. `/metaskill ios app` generates a complete `.claude/` agent team (tech-lead + specialists + code-reviewer) after researching best practices. |
 | **MetaMemory** | Embedded SQLite knowledge store with full-text search and Web UI. Agents read/write Markdown documents across sessions. Shared by all agents. |
 | **IM Bridge** | Chat with any agent from Feishu/Lark or Telegram (including mobile). Streaming cards with color-coded status and tool call tracking. |
-| **Agent Bus** | REST API on port 9100. Agents delegate tasks to each other via `curl`. Create/remove bots at runtime. Exposed as the `/metabot-api` skill — loaded on demand, not injected into every prompt. |
+| **Agent Bus** | REST API on port 9100. Agents delegate tasks to each other via `curl`. Create/remove bots at runtime. Exposed as the `/metabot` skill — loaded on demand, not injected into every prompt. |
 | **Task Scheduler** | One-time delays and recurring cron jobs. `0 8 * * 1-5` = weekday 8am news briefing. Timezone-aware (default: Asia/Shanghai). Persists across restarts, auto-retries when busy. |
 | **CLI Tools** | `metabot`, `mm`, and `mb` commands installed to `~/.local/bin/`. `metabot update` to pull/rebuild/restart. `mm` for MetaMemory, `mb` for Agent Bus. |
 
@@ -215,7 +215,7 @@ MetaBot runs Claude Code in `bypassPermissions` mode — no interactive approval
 | `/memory search <query>` | Search knowledge base |
 | `/help` | Show help |
 | `/metaskill ...` | Generate agent teams, agents, or skills |
-| `/metabot-api` | Agent bus, scheduling, and bot management API docs (loaded on demand) |
+| `/metabot` | Agent bus, scheduling, and bot management API docs (loaded on demand) |
 | `/anything` | Any unrecognized command is forwarded to Claude Code as a skill |
 
 ## API Reference

--- a/README_zh.md
+++ b/README_zh.md
@@ -57,7 +57,7 @@ MetaBot 解放了它。给每个 Agent 一个 Claude Code 大脑、持久化的�
 | **MetaSkill** | Agent 工厂。`/metaskill ios app` 调研最佳实践后生成完整的 `.claude/` Agent 团队（tech-lead + 专家 + reviewer）。 |
 | **MetaMemory** | 内嵌 SQLite 知识库，全文搜索，Web UI。Agent 跨会话读写 Markdown 文档。所有 Agent 共享。 |
 | **IM Bridge** | 飞书或 Telegram（含手机端）与任意 Agent 对话。带颜色状态的流式卡片 + 工具调用追踪。 |
-| **Agent 总线** | 9100 端口 REST API。Agent 通过 `curl` 互相委派任务。运行时创建/删除 Bot。以 `/metabot-api` skill 形式按需加载，不注入每次对话。 |
+| **Agent 总线** | 9100 端口 REST API。Agent 通过 `curl` 互相委派任务。运行时创建/删除 Bot。以 `/metabot` skill 形式按需加载，不注入每次对话。 |
 | **定时任务调度器** | 一次性延迟和周期性 cron 任务。`0 8 * * 1-5` = 工作日早8点新闻简报。支持时区配置（默认 Asia/Shanghai）。跨重启持久化，忙时自动重试。 |
 | **CLI 工具** | `metabot`、`mm`、`mb` 命令安装到 `~/.local/bin/`。`metabot update` 一键更新重启。`mm` 管理 MetaMemory，`mb` 管理 Agent 总线。 |
 
@@ -212,7 +212,7 @@ MetaBot 以 `bypassPermissions` 模式运行 Claude Code — 无交互式确认�
 | `/memory search 关键词` | 搜索知识库 |
 | `/help` | 帮助 |
 | `/metaskill ...` | 生成 Agent 团队、Agent 或 Skill |
-| `/metabot-api` | Agent 总线、定时任务、Bot 管理 API 文档（按需加载） |
+| `/metabot` | Agent 总线、定时任务、Bot 管理 API 文档（按需加载） |
 | `/任意命令` | 非内置命令自动转发给 Claude Code |
 
 ## API 参考

--- a/docs/index.html
+++ b/docs/index.html
@@ -508,7 +508,7 @@
                 <div class="icon">API</div>
                 <div>
                     <h4>Agent Bus</h4>
-                    <p>REST API on port 9100. Agents delegate tasks to each other via curl. Create and remove bots at runtime. Exposed as the /metabot-api skill.</p>
+                    <p>REST API on port 9100. Agents delegate tasks to each other via curl. Create and remove bots at runtime. Exposed as the /metabot skill.</p>
                 </div>
             </div>
             <div class="comp-card">

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -8,10 +8,8 @@ module.exports = {
       interpreter: path.join(__dirname, 'node_modules/.bin/tsx'),
       cwd: __dirname,
 
-      // Watch for code changes and auto-restart
-      watch: ['src', 'bots.json'],
-      watch_delay: 1000,
-      ignore_watch: ['node_modules', 'dist', '*.log', 'nohup.out'],
+      // Watch disabled — use `metabot restart` to apply code changes manually
+      watch: false,
 
       // Auto-restart on crash
       autorestart: true,

--- a/install.sh
+++ b/install.sh
@@ -533,11 +533,11 @@ if [[ -d "$HOME/.claude/skills/memory" ]]; then
 fi
 success "metamemory skill installed → $SKILLS_DIR/metamemory"
 
-# Install metabot-api skill (bundled in src/skills/metabot-api/)
-info "Installing metabot-api skill..."
-mkdir -p "$SKILLS_DIR/metabot-api"
-cp "$METABOT_HOME/src/skills/metabot-api/SKILL.md" "$SKILLS_DIR/metabot-api/SKILL.md"
-success "metabot-api skill installed → $SKILLS_DIR/metabot-api"
+# Install metabot skill (bundled in src/skills/metabot/)
+info "Installing metabot skill..."
+mkdir -p "$SKILLS_DIR/metabot"
+cp "$METABOT_HOME/src/skills/metabot/SKILL.md" "$SKILLS_DIR/metabot/SKILL.md"
+success "metabot skill installed → $SKILLS_DIR/metabot"
 
 # Determine working directory
 if [[ "$SKIP_CONFIG" == "false" ]]; then
@@ -560,7 +560,7 @@ if [[ -n "${DEPLOY_WORK_DIR:-}" ]]; then
   SKILLS_DEST="$DEPLOY_WORK_DIR/.claude/skills"
 
   # Copy skills
-  for SKILL in metaskill metamemory metabot-api; do
+  for SKILL in metaskill metamemory metabot; do
     if [[ -d "$SKILLS_DIR/$SKILL" ]]; then
       mkdir -p "$SKILLS_DEST/$SKILL"
       cp -r "$SKILLS_DIR/$SKILL/." "$SKILLS_DEST/$SKILL/"

--- a/src/api/skills-installer.ts
+++ b/src/api/skills-installer.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import * as url from 'node:url';
 import type { Logger } from '../utils/logger.js';
 
-const SKILL_NAMES = ['metaskill', 'metamemory', 'metabot-api'];
+const SKILL_NAMES = ['metaskill', 'metamemory', 'metabot'];
 
 export function installSkillsToWorkDir(workDir: string, logger: Logger): void {
   const userSkillsDir = path.join(os.homedir(), '.claude', 'skills');

--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -97,7 +97,7 @@ export class ClaudeExecutor {
       // race conditions when multiple chats run concurrently.
       // Port and secret are already set as METABOT_* env vars in config.ts.
       appendSections.push(
-        `## MetaBot API\nYou are running as bot "${apiContext.botName}" in chat "${apiContext.chatId}".\nUse the /metabot-api skill for full API documentation (agent bus, scheduling, bot management).`
+        `## MetaBot API\nYou are running as bot "${apiContext.botName}" in chat "${apiContext.chatId}".\nUse the /metabot skill for full API documentation (agent bus, scheduling, bot management).`
       );
     }
 

--- a/src/skills/metabot/SKILL.md
+++ b/src/skills/metabot/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: metabot-api
+name: metabot
 description: "MetaBot HTTP API for agent collaboration: delegate tasks to other bots, schedule future tasks, manage bots. Use when the user wants to schedule tasks, delegate work to another bot, create/remove bots, or check scheduled tasks."
 ---
 

--- a/src/workspace/CLAUDE.md
+++ b/src/workspace/CLAUDE.md
@@ -25,7 +25,7 @@ mm folders              # Browse folder tree
 
 For full API (create with tags, update, delete), use the `/metamemory` skill.
 
-### /metabot-api — Agent Bus, Scheduling & Bot Management
+### /metabot — Agent Bus, Scheduling & Bot Management
 Use the `mb` shell shortcut for quick operations:
 
 ```bash
@@ -36,7 +36,7 @@ mb schedule add <bot> <chatId> <sec> <prompt>  # Schedule a task
 mb health                                  # Health check
 ```
 
-For full API (create bots, update tasks, sendCards), use the `/metabot-api` skill.
+For full API (create bots, update tasks, sendCards), use the `/metabot` skill.
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary
- Rename `metabot-api` skill to `metabot` for brevity
- Update all references across codebase (README, install.sh, executor.ts, skills-installer.ts, workspace CLAUDE.md, docs)
- Disable PM2 watch mode to prevent auto-restarts when editing code

## Test plan
- [x] `npm run build` passes
- [x] All 93 tests pass
- [x] `npm run lint` clean (no errors)
- [x] Verified no remaining `metabot-api` references via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)