### PR TITLE
Remove Agent Communication curl examples from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,29 +103,6 @@ Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/clau
 - **Self-growing organization** — a manager bot that creates new agents on demand, assigns tasks, schedules follow-ups
 - **Autonomous research pipeline** — agents that search, analyze, save findings to MetaMemory, and schedule next steps
 
-## Agent Communication
-
-Agents talk to each other through the HTTP API. Claude uses `curl` autonomously:
-
-```bash
-# Delegate a task to another bot
-curl -X POST localhost:9100/api/tasks \
-  -H "Authorization: Bearer $SECRET" \
-  -d '{"botName":"backend-bot","chatId":"oc_xxx","prompt":"run the migration"}'
-
-# Schedule a follow-up in 1 hour
-curl -X POST localhost:9100/api/schedule \
-  -d '{"botName":"backend-bot","chatId":"oc_xxx","prompt":"verify migration","delaySeconds":3600}'
-
-# Schedule a recurring daily task (weekdays 8am)
-curl -X POST localhost:9100/api/schedule \
-  -d '{"botName":"news-bot","chatId":"oc_xxx","prompt":"read and summarize tech news","cronExpr":"0 8 * * 1-5"}'
-
-# Create a new bot at runtime
-curl -X POST localhost:9100/api/bots \
-  -d '{"platform":"telegram","name":"data-bot","telegramBotToken":"...","defaultWorkingDirectory":"/data"}'
-```
-
 ## Configuration
 
 **`bots.json`** — define your bots:

--- a/README_zh.md
+++ b/README_zh.md
@@ -103,29 +103,6 @@ npm run dev
 - **自生长的组织** — 管理者 Bot 按需创建新 Agent，分配任务，安排后续跟进
 - **自主研究流水线** — Agent 搜索、分析、将发现存入 MetaMemory、安排下一步
 
-## Agent 间通信
-
-Agent 通过 HTTP API 互相通信。Claude 自主使用 `curl`：
-
-```bash
-# 委派任务给另一个 Bot
-curl -X POST localhost:9100/api/tasks \
-  -H "Authorization: Bearer $SECRET" \
-  -d '{"botName":"backend-bot","chatId":"oc_xxx","prompt":"跑一下迁移脚本"}'
-
-# 安排 1 小时后的跟进
-curl -X POST localhost:9100/api/schedule \
-  -d '{"botName":"backend-bot","chatId":"oc_xxx","prompt":"检查迁移结果","delaySeconds":3600}'
-
-# 创建周期性定时任务（工作日早8点）
-curl -X POST localhost:9100/api/schedule \
-  -d '{"botName":"news-bot","chatId":"oc_xxx","prompt":"阅读并总结科技新闻","cronExpr":"0 8 * * 1-5"}'
-
-# 运行时创建新 Bot
-curl -X POST localhost:9100/api/bots \
-  -d '{"platform":"telegram","name":"data-bot","telegramBotToken":"...","defaultWorkingDirectory":"/data"}'
-```
-
 ## 配置
 
 **`bots.json`** — 定义你的 Bot：


### PR DESCRIPTION
## Summary
- Remove the "Agent Communication" section with raw curl examples from both README.md and README_zh.md
- Agent communication is now handled via the `/metabot` skill shortcut, making curl examples obsolete

🤖 Generated with [Claude Code](https://claude.com/claude-code)