### PR TITLE
fix: macos sed -i compatibility in install.sh and setup.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,15 @@ if [[ "$OS" != "Linux" && "$OS" != "Darwin" ]]; then
   exit 1
 fi
 
+# Portable sed -i helper
+sed_i() {
+  if [[ "$OS" == "Darwin" ]]; then
+    sed -i "" "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 # ============================================================================
 # Phase 1: Check prerequisites
 # ============================================================================
@@ -683,7 +692,7 @@ mm() {
 MMEOF
   # Patch the actual API_SECRET into the file
   if [[ -n "${API_SECRET:-}" ]]; then
-    sed -i "s|\${API_SECRET:-changeme}|${API_SECRET}|g" "$BASH_ALIASES"
+    sed_i "s|\${API_SECRET:-changeme}|${API_SECRET}|g" "$BASH_ALIASES"
   fi
   success "mm() shortcut installed"
 else
@@ -780,10 +789,10 @@ mb() {
 MBEOF
   # Patch the actual secrets into the file
   if [[ -n "${API_PORT:-}" ]]; then
-    sed -i "s|\${METABOT_API_PORT:-9100}|${API_PORT}|g" "$BASH_ALIASES"
+    sed_i "s|\${METABOT_API_PORT:-9100}|${API_PORT}|g" "$BASH_ALIASES"
   fi
   if [[ -n "${API_SECRET:-}" ]]; then
-    sed -i "s|\${METABOT_API_SECRET:-changeme}|${API_SECRET}|g" "$BASH_ALIASES"
+    sed_i "s|\${METABOT_API_SECRET:-changeme}|${API_SECRET}|g" "$BASH_ALIASES"
   fi
   success "mb() shortcut installed"
 else
@@ -808,10 +817,10 @@ for cli in $CLI_TOOLS; do
     chmod +x "$LOCAL_BIN/$cli"
     # Patch secrets into the standalone script
     if [[ -n "${API_SECRET:-}" ]]; then
-      sed -i "s|changeme|${API_SECRET}|g" "$LOCAL_BIN/$cli"
+      sed_i "s|changeme|${API_SECRET}|g" "$LOCAL_BIN/$cli"
     fi
     if [[ -n "${API_PORT:-}" && "$cli" == "mb" ]]; then
-      sed -i "s|9100|${API_PORT}|g" "$LOCAL_BIN/$cli"
+      sed_i "s|9100|${API_PORT}|g" "$LOCAL_BIN/$cli"
     fi
   fi
 done

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,15 @@ ok()    { echo -e "${GREEN}[OK]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 fail()  { echo -e "${RED}[FAIL]${NC} $1"; exit 1; }
 
+# Portable sed -i helper
+sed_i() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    sed -i "" "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 echo ""
 echo "========================================="
 echo "  MetaBot Setup"
@@ -87,7 +96,7 @@ BOTEOF
 
   # Set BOTS_CONFIG in .env
   if grep -q "^BOTS_CONFIG=" .env; then
-    sed -i "s|^BOTS_CONFIG=.*|BOTS_CONFIG=./bots.json|" .env
+    sed_i "s|^BOTS_CONFIG=.*|BOTS_CONFIG=./bots.json|" .env
   else
     echo "BOTS_CONFIG=./bots.json" >> .env
   fi


### PR DESCRIPTION
Introduces a portable `sed_i` helper function in both scripts to handle the syntax differences between GNU and BSD `sed` on macOS.