### PR TITLE
feat: decouple wiki sync & doc reader from chat bot credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,14 @@ MEMORY_SERVER_URL=http://localhost:8100
 # MEMORY_TOKEN=                 # Reader token (shared folders only)
 
 # =============================================================================
+# Feishu Service App (wiki sync & doc reader)
+# =============================================================================
+# Dedicated Feishu app for wiki sync and document reading, independent of chat bots.
+# If not set, falls back to the first Feishu bot's credentials.
+# FEISHU_SERVICE_APP_ID=cli_xxx
+# FEISHU_SERVICE_APP_SECRET=xxx
+
+# =============================================================================
 # Wiki Sync (MetaMemory → Feishu Wiki, one-way)
 # =============================================================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ One-way sync from MetaMemory documents to a Feishu Wiki space. The folder tree i
 **API endpoints:** `POST /api/sync` (trigger), `GET /api/sync` (status), `POST /api/sync/document` (single doc sync), `GET /api/feishu/document` (read Feishu doc).
 
 **Environment variables:**
-- `WIKI_SYNC_ENABLED` — Set to `false` to disable (default: enabled when Feishu bots exist)
+- `FEISHU_SERVICE_APP_ID` / `FEISHU_SERVICE_APP_SECRET` — Dedicated Feishu app for wiki sync & doc reader (falls back to first Feishu bot if not set)
+- `WIKI_SYNC_ENABLED` — Set to `false` to disable (default: enabled when service app or Feishu bots exist)
 - `WIKI_SPACE_NAME` — Wiki space name (default: `MetaMemory`)
 - `WIKI_SYNC_THROTTLE_MS` — Delay between API calls (default: 300ms)
 - `WIKI_AUTO_SYNC` — Set to `false` to disable auto-sync (default: enabled when wiki sync is configured)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/clau
 | `MEMORY_SECRET` | `API_SECRET` | MetaMemory auth (legacy) |
 | `MEMORY_ADMIN_TOKEN` | — | Admin token (full access, sees all folders) |
 | `MEMORY_TOKEN` | — | Reader token (shared folders only) |
-| `WIKI_SYNC_ENABLED` | true | Enable MetaMemory→Wiki sync (requires Feishu bot) |
+| `FEISHU_SERVICE_APP_ID` | — | Feishu service app for wiki sync & doc reader (falls back to first bot) |
+| `FEISHU_SERVICE_APP_SECRET` | — | Feishu service app secret |
+| `WIKI_SYNC_ENABLED` | true | Enable MetaMemory→Wiki sync |
 | `WIKI_SPACE_ID` | — | Feishu Wiki space ID |
 | `WIKI_SPACE_NAME` | MetaMemory | Feishu Wiki space name |
 | `WIKI_AUTO_SYNC` | true | Auto-sync on MetaMemory changes (debounced) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -162,7 +162,9 @@ npm run dev
 | `MEMORY_SECRET` | `API_SECRET` | MetaMemory 认证（旧版） |
 | `MEMORY_ADMIN_TOKEN` | — | 管理员 Token（完整访问，可见所有文件夹） |
 | `MEMORY_TOKEN` | — | 读者 Token（仅可见 shared 文件夹） |
-| `WIKI_SYNC_ENABLED` | true | 启用 MetaMemory→飞书知识库同步（需配置飞书 Bot） |
+| `FEISHU_SERVICE_APP_ID` | — | 飞书服务应用（用于知识库同步和文档读取，未设置时回退到第一个 Bot） |
+| `FEISHU_SERVICE_APP_SECRET` | — | 飞书服务应用密钥 |
+| `WIKI_SYNC_ENABLED` | true | 启用 MetaMemory→飞书知识库同步 |
 | `WIKI_SPACE_ID` | — | 飞书知识库空间 ID |
 | `WIKI_SPACE_NAME` | MetaMemory | 飞书知识库空间名称 |
 | `WIKI_AUTO_SYNC` | true | MetaMemory 变更时自动同步（带防抖） |

--- a/src/api/http-server.ts
+++ b/src/api/http-server.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as http from 'node:http';
+import type * as lark from '@larksuiteoapi/node-sdk';
 import type { Logger } from '../utils/logger.js';
 import type { BotRegistry } from './bot-registry.js';
 import type { TaskScheduler } from '../scheduler/task-scheduler.js';
@@ -17,6 +18,7 @@ interface ApiServerOptions {
   logger: Logger;
   botsConfigPath?: string;
   docSync?: DocSync;
+  feishuServiceClient?: lark.Client;
 }
 
 interface JsonBody {
@@ -66,7 +68,7 @@ async function parseJsonBody(req: http.IncomingMessage): Promise<JsonBody> {
 }
 
 export function startApiServer(options: ApiServerOptions): http.Server {
-  const { port, secret, registry, scheduler, logger, botsConfigPath, docSync } = options;
+  const { port, secret, registry, scheduler, logger, botsConfigPath, docSync, feishuServiceClient } = options;
   const host = secret ? '0.0.0.0' : '127.0.0.1';
 
   const server = http.createServer(async (req, res) => {
@@ -593,22 +595,28 @@ export function startApiServer(options: ApiServerOptions): http.Server {
           return;
         }
 
-        // Find a feishu bot to use
-        const feishuBots = registry.listByPlatform('feishu');
-        if (feishuBots.length === 0) {
-          jsonResponse(res, 400, { error: 'No Feishu bots configured' });
+        // Find a Feishu client to use: specific bot > service client > first bot fallback
+        let clientForDoc: lark.Client | undefined;
+        if (botName) {
+          const bot = registry.getByPlatform(botName, 'feishu');
+          clientForDoc = bot?.feishuClient;
+          if (!clientForDoc) {
+            jsonResponse(res, 404, { error: `Feishu bot not found: ${botName}` });
+            return;
+          }
+        } else {
+          clientForDoc = feishuServiceClient;
+          if (!clientForDoc) {
+            const feishuBots = registry.listByPlatform('feishu');
+            clientForDoc = feishuBots[0]?.feishuClient;
+          }
+        }
+        if (!clientForDoc) {
+          jsonResponse(res, 400, { error: 'No Feishu service app or bots configured' });
           return;
         }
 
-        const bot = botName
-          ? registry.getByPlatform(botName, 'feishu')
-          : feishuBots[0];
-        if (!bot || !bot.feishuClient) {
-          jsonResponse(res, 404, { error: `Feishu bot not found: ${botName}` });
-          return;
-        }
-
-        const reader = new FeishuDocReader(bot.feishuClient, logger);
+        const reader = new FeishuDocReader(clientForDoc, logger);
         let result;
 
         if (docUrl) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,11 @@ export interface TelegramBotConfig extends BotConfigBase {
 export interface AppConfig {
   feishuBots: BotConfig[];
   telegramBots: TelegramBotConfig[];
+  /** Dedicated Feishu service app for wiki sync & doc reader (independent of chat bots). */
+  feishuService?: {
+    appId: string;
+    appSecret: string;
+  };
   log: {
     level: string;
   };
@@ -245,6 +250,20 @@ export function loadAppConfig(): AppConfig {
     process.env.METABOT_API_SECRET = apiSecret;
   }
 
+  // Feishu service app for wiki sync & doc reader (falls back to first Feishu bot)
+  let feishuService: AppConfig['feishuService'];
+  if (process.env.FEISHU_SERVICE_APP_ID && process.env.FEISHU_SERVICE_APP_SECRET) {
+    feishuService = {
+      appId: process.env.FEISHU_SERVICE_APP_ID,
+      appSecret: process.env.FEISHU_SERVICE_APP_SECRET,
+    };
+  } else if (feishuBots.length > 0) {
+    feishuService = {
+      appId: feishuBots[0].feishu.appId,
+      appSecret: feishuBots[0].feishu.appSecret,
+    };
+  }
+
   const memoryEnabled = process.env.MEMORY_ENABLED !== 'false';
   const memoryPort = process.env.MEMORY_PORT ? parseInt(process.env.MEMORY_PORT, 10) : 8100;
   const memoryDatabaseDir = process.env.MEMORY_DATABASE_DIR || './data';
@@ -255,6 +274,7 @@ export function loadAppConfig(): AppConfig {
   return {
     feishuBots,
     telegramBots,
+    feishuService,
     log: {
       level: process.env.LOG_LEVEL || 'info',
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,15 +150,25 @@ async function main() {
     });
   }
 
-  // Initialize wiki sync service (uses first Feishu bot's credentials)
+  // Create a dedicated Feishu service client for wiki sync & doc reader
+  let feishuServiceClient: lark.Client | undefined;
+  if (appConfig.feishuService) {
+    feishuServiceClient = new lark.Client({
+      appId: appConfig.feishuService.appId,
+      appSecret: appConfig.feishuService.appSecret,
+      disableTokenCache: false,
+    });
+    logger.info('Feishu service client initialized (for wiki sync & doc reader)');
+  }
+
+  // Initialize wiki sync service (uses dedicated service app credentials)
   let docSync: DocSync | undefined;
-  if (feishuHandles.length > 0 && process.env.WIKI_SYNC_ENABLED !== 'false') {
-    const firstBot = appConfig.feishuBots[0];
+  if (appConfig.feishuService && process.env.WIKI_SYNC_ENABLED !== 'false') {
     const syncMemoryClient = new MemoryClient(appConfig.memoryServerUrl, logger, appConfig.memory.secret || undefined);
     docSync = new DocSync(
       {
-        feishuAppId: firstBot.feishu.appId,
-        feishuAppSecret: firstBot.feishu.appSecret,
+        feishuAppId: appConfig.feishuService.appId,
+        feishuAppSecret: appConfig.feishuService.appSecret,
         databaseDir: appConfig.memory.databaseDir,
         wikiSpaceName: process.env.WIKI_SPACE_NAME || 'MetaMemory',
         wikiSpaceId: process.env.WIKI_SPACE_ID || undefined,
@@ -195,6 +205,7 @@ async function main() {
     logger,
     botsConfigPath,
     docSync,
+    feishuServiceClient,
   });
 
   // Graceful shutdown


### PR DESCRIPTION
## Summary
- Add `FEISHU_SERVICE_APP_ID` / `FEISHU_SERVICE_APP_SECRET` env vars for a dedicated Feishu service app used by wiki sync and document reader
- Wiki sync and doc reader no longer hardcode the first Feishu bot's credentials
- Falls back to first bot's credentials if service app env vars are not set (backward compatible)
- Updated `.env.example`, CLAUDE.md, README.md, README_zh.md

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 155 tests pass
- [x] `npm run lint` — no errors
- [ ] Verify wiki sync works with `FEISHU_SERVICE_APP_ID` set
- [ ] Verify `fd read` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)