### PR TITLE
feat: auto-reply in 2-member group chats without @mention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Feishu WSClient → EventHandler (parse, @mention filter) → MessageBridge → 
 
 - **`src/index.ts`** — Entrypoint. Creates Feishu WS client, fetches bot info for @mention detection, wires up the event dispatcher and bridge, handles graceful shutdown.
 - **`src/config.ts`** — Loads config. `BotConfig` is the per-bot type; `AppConfig` wraps `{ bots, log }`. `loadAppConfig()` reads `BOTS_CONFIG` JSON file or falls back to single-bot mode from env vars.
-- **`src/feishu/event-handler.ts`** — Registers `im.message.receive_v1` on the Lark `EventDispatcher`. Handles text/image parsing, @mention stripping, group chat filtering (only responds when @mentioned). Exports `IncomingMessage` type.
+- **`src/feishu/event-handler.ts`** — Registers `im.message.receive_v1` on the Lark `EventDispatcher`. Handles text/image parsing, @mention stripping, group chat filtering (only responds when @mentioned, except in 2-member groups which are treated like DMs). Exports `IncomingMessage` type.
 - **`src/bridge/message-bridge.ts`** — Core orchestrator. Routes commands (`/reset`, `/stop`, `/status`, `/help`, `/memory`), manages running tasks per chat (one task at a time per `chatId`), executes Claude queries with streaming card updates, handles image input/output, enforces 1-hour timeout.
 - **`src/memory/memory-client.ts`** — Lightweight HTTP client for the MetaMemory server. Used by `/memory` commands (list, search, status) for quick Feishu responses without spawning Claude.
 - **`src/claude/executor.ts`** — Wraps `query()` from the Agent SDK as an async generator yielding `SDKMessage`. Configures permissionMode, allowedTools, MCP settings, session resume.
@@ -102,7 +102,7 @@ When Claude enters plan mode and writes a plan to `.claude/plans/*.md`, the plan
 
 ### Session Isolation
 
-Sessions are keyed by `chatId` (not `userId`), so each group chat and DM gets its own independent session, working directory, and conversation history.
+Sessions are keyed by `chatId` (not `userId`), so each group chat and DM gets its own independent session, working directory, and conversation history. Group chats with exactly 2 members (1 user + 1 bot) are treated like DMs — no @mention required. This lets users "fork" a bot by creating multiple small group chats, each with its own session. The member count is cached for 5 minutes to avoid excessive API calls.
 
 ## Configuration
 
@@ -185,6 +185,7 @@ This is the step-by-step procedure to configure a Feishu bot for this bridge ser
    - **`im:message`** — Read and send messages in private and group chats
    - **`im:message:readonly`** — Read messages in private and group chats
    - **`im:resource`** — Upload images and files (needed to send output files back to chat)
+   - **`im:chat:readonly`** — Read chat info (needed for 2-member group detection)
 5. Click **"Add Scopes"**
 
 ### Step 5: Configure Events (requires running service)

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -1,6 +1,7 @@
 import * as lark from '@larksuiteoapi/node-sdk';
 import type { BotConfig } from '../config.js';
 import type { Logger } from '../utils/logger.js';
+import { MessageSender } from './message-sender.js';
 
 // Re-export from shared types so existing imports continue to work
 export type { IncomingMessage } from '../types.js';
@@ -8,11 +9,29 @@ import type { IncomingMessage } from '../types.js';
 
 export type MessageHandler = (msg: IncomingMessage) => void;
 
+// Cache for group member counts (to avoid calling Feishu API on every message)
+const MEMBER_COUNT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const memberCountCache = new Map<string, { count: number; ts: number }>();
+
+async function isPrivateLikeGroup(chatId: string, sender: MessageSender): Promise<boolean> {
+  const cached = memberCountCache.get(chatId);
+  if (cached && Date.now() - cached.ts < MEMBER_COUNT_CACHE_TTL_MS) {
+    return cached.count === 2;
+  }
+  const count = await sender.getChatMemberCount(chatId);
+  if (count !== undefined) {
+    memberCountCache.set(chatId, { count, ts: Date.now() });
+    return count === 2;
+  }
+  return false;
+}
+
 export function createEventDispatcher(
   config: BotConfig,
   logger: Logger,
   onMessage: MessageHandler,
   botOpenId?: string,
+  messageSender?: MessageSender,
 ): lark.EventDispatcher {
   const dispatcher = new lark.EventDispatcher({});
 
@@ -42,19 +61,18 @@ export function createEventDispatcher(
         const messageId = message.message_id;
 
         // In group chats, only respond when the bot is @mentioned
+        // Exception: 2-member groups (1 user + 1 bot) are treated like DMs
         const mentions = message.mentions;
         if (chatType === 'group') {
-          if (!mentions || mentions.length === 0) {
-            logger.debug('Ignoring group message without @mention');
-            return;
-          }
-          // If we know the bot's open_id, check that the bot is specifically mentioned
-          if (botOpenId) {
-            const botMentioned = mentions.some(
-              (m: any) => m.id?.open_id === botOpenId,
-            );
-            if (!botMentioned) {
-              logger.debug('Ignoring group message that does not @mention the bot');
+          const botMentioned = mentions?.some(
+            (m: any) => !botOpenId || m.id?.open_id === botOpenId,
+          );
+          if (!botMentioned) {
+            // Check if this is a private-like group (only 2 members)
+            if (messageSender && await isPrivateLikeGroup(chatId, messageSender)) {
+              logger.debug({ chatId }, 'Private-like group (2 members), processing without @mention');
+            } else {
+              logger.debug('Ignoring group message without @mention');
               return;
             }
           }

--- a/src/feishu/message-sender.ts
+++ b/src/feishu/message-sender.ts
@@ -164,6 +164,18 @@ export class MessageSender {
     return true;
   }
 
+  async getChatMemberCount(chatId: string): Promise<number | undefined> {
+    try {
+      const resp: any = await this.client.im.v1.chat.get({
+        path: { chat_id: chatId },
+      });
+      return resp?.data?.member_count;
+    } catch (err) {
+      this.logger.error({ err, chatId }, 'Failed to get chat member count');
+      return undefined;
+    }
+  }
+
   async sendText(chatId: string, text: string): Promise<void> {
     try {
       await this.client.im.v1.message.create({

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ async function startFeishuBot(botConfig: BotConfig, logger: Logger, memoryServer
     bridge.handleMessage(msg).catch((err) => {
       botLogger.error({ err, msg }, 'Unhandled error in message bridge');
     });
-  }, botOpenId);
+  }, botOpenId, rawSender);
 
   // Create WebSocket client
   const wsClient = new lark.WSClient({


### PR DESCRIPTION
## Summary
- Group chats with exactly 2 members (1 user + 1 bot) are treated like DMs — no @mention required
- This lets users "fork" a bot by creating multiple small group chats, each with its own session
- Member count is fetched via `im.v1.chat.get` and cached for 5 minutes

## Changes
- `src/feishu/message-sender.ts` — Add `getChatMemberCount()` method
- `src/feishu/event-handler.ts` — Add member count cache + bypass @mention for 2-member groups
- `src/index.ts` — Pass `MessageSender` to event dispatcher
- `CLAUDE.md` — Update docs

## Note
Requires `im:chat:readonly` permission added to the Feishu app.

## Test plan
- [ ] Create a 2-member Feishu group (1 user + 1 bot), send message without @mention → bot should respond
- [ ] In a 3+ member group, send message without @mention → bot should NOT respond
- [ ] In a 3+ member group, send message with @mention → bot should respond
- [ ] Verify cache: second message in 2-member group should not trigger API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)