### PR TITLE
feat: default sendCards to true for mb task

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -41,7 +41,7 @@ case "$cmd" in
     fi
     python3 -c "
 import json, sys
-print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'prompt': sys.argv[3], 'sendCards': False}))
+print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'prompt': sys.argv[3], 'sendCards': True}))
 " "$bot" "$chat" "$prompt" | \
     curl -s -X POST "$METABOT_URL/api/tasks" \
       -H "$METABOT_AUTH" -H "Content-Type: application/json" \

--- a/install.sh
+++ b/install.sh
@@ -729,7 +729,7 @@ mb() {
       fi
       curl -s -X POST "$METABOT_URL/api/tasks" \
         -H "$METABOT_AUTH" -H "Content-Type: application/json" \
-        -d "{\"botName\":\"$bot\",\"chatId\":\"$chat\",\"prompt\":\"$prompt\",\"sendCards\":false}"
+        -d "{\"botName\":\"$bot\",\"chatId\":\"$chat\",\"prompt\":\"$prompt\",\"sendCards\":true}"
       ;;
     # --- Scheduling ---
     schedule|sched|sc)

--- a/src/api/http-server.ts
+++ b/src/api/http-server.ts
@@ -128,7 +128,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
           prompt,
           chatId,
           userId: 'api',
-          sendCards: sendCards ?? false,
+          sendCards: sendCards ?? true,
         });
 
         jsonResponse(res, result.success ? 200 : 500, result);


### PR DESCRIPTION
## Summary
- Change `sendCards` default from `false` to `true` in `mb task` CLI, `POST /api/tasks` API, and `install.sh`
- Task results now post to Feishu chat by default, matching user expectations
- Explicit `sendCards: false` still supported to suppress chat output

## Test plan
- [x] `npm run build` passes
- [x] All 155 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)