### PR TITLE
feat: add mb update command to sync CLI tools

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -119,6 +119,34 @@ print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'cronExpr': sys
   health|h)
     curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/health" | _json
     ;;
+  # --- Update CLI tools ---
+  update|up)
+    METABOT_SRC="${METABOT_HOME:-$HOME/metabot}"
+    LOCAL_BIN="$HOME/.local/bin"
+    if [[ ! -d "$METABOT_SRC/bin" ]]; then
+      echo "Error: MetaBot source not found at $METABOT_SRC/bin"
+      exit 1
+    fi
+    mkdir -p "$LOCAL_BIN"
+    updated=0
+    for cli in mb mm metabot fd; do
+      src="$METABOT_SRC/bin/$cli"
+      dst="$LOCAL_BIN/$cli"
+      if [[ -f "$src" ]]; then
+        if ! cmp -s "$src" "$dst" 2>/dev/null; then
+          cp "$src" "$dst"
+          chmod +x "$dst"
+          echo "  Updated: $cli"
+          updated=$((updated + 1))
+        fi
+      fi
+    done
+    if [[ $updated -eq 0 ]]; then
+      echo "All CLI tools are up to date."
+    else
+      echo "Updated $updated CLI tool(s) in $LOCAL_BIN"
+    fi
+    ;;
   # --- Help ---
   *)
     echo "mb - MetaBot API CLI"
@@ -144,5 +172,6 @@ print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'cronExpr': sys
     echo ""
     echo "  System:"
     echo "    mb health                        - Health check"
+    echo "    mb update                        - Update CLI tools from source"
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -815,13 +815,6 @@ for cli in $CLI_TOOLS; do
   if [[ -f "$METABOT_HOME/bin/$cli" ]]; then
     cp "$METABOT_HOME/bin/$cli" "$LOCAL_BIN/$cli"
     chmod +x "$LOCAL_BIN/$cli"
-    # Patch secrets into the standalone script
-    if [[ -n "${API_SECRET:-}" ]]; then
-      sed_i "s|changeme|${API_SECRET}|g" "$LOCAL_BIN/$cli"
-    fi
-    if [[ -n "${API_PORT:-}" && "$cli" == "mb" ]]; then
-      sed_i "s|9100|${API_PORT}|g" "$LOCAL_BIN/$cli"
-    fi
   fi
 done
 # Ensure ~/.local/bin is in PATH (most distros include it, but not all)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint src/ tests/ --fix",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
-    "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'"
+    "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
+    "update-cli": "for cli in mb mm metabot fd; do [ -f bin/$cli ] && cp bin/$cli ~/.local/bin/$cli && chmod +x ~/.local/bin/$cli && echo \"Updated: $cli\"; done"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
@@ -33,7 +34,7 @@
     "eslint": "^10.0.2",
     "prettier": "^3.8.1",
     "tsx": "^4.19.0",
-    "typescript": "^5.6.0",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1",
     "vitest": "^3.1.1"
   }


### PR DESCRIPTION
## Summary
- Add `mb update` subcommand to copy latest `bin/*` from repo to `~/.local/bin/`
- Add `npm run update-cli` script for the same purpose
- Remove `sed`-based secret injection from `install.sh` — `bin/mb` already reads `.env` at runtime, so baking secrets into the copy was unnecessary and prevented clean updates

## Problem
When `bin/mb` was updated in the repo (e.g. changing `sendCards` default), the installed copy at `~/.local/bin/mb` stayed stale. Restarting the service didn't help because the CLI tools are separate copies.

## Test plan
- [x] All 155 tests pass
- [x] Build succeeds
- [x] Verified `~/.local/bin/mb` now has `sendCards: True` after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)