### PR TITLE
fix: 2-member group chat detection (wrong Feishu API field)

### DIFF
--- a/src/feishu/message-sender.ts
+++ b/src/feishu/message-sender.ts
@@ -169,7 +169,9 @@ export class MessageSender {
       const resp: any = await this.client.im.v1.chat.get({
         path: { chat_id: chatId },
       });
-      return resp?.data?.member_count;
+      const userCount = parseInt(resp?.data?.user_count, 10) || 0;
+      const botCount = parseInt(resp?.data?.bot_count, 10) || 0;
+      return userCount + botCount;
     } catch (err) {
       this.logger.error({ err, chatId }, 'Failed to get chat member count');
       return undefined;


### PR DESCRIPTION
## Summary
- Feishu `im.v1.chat.get` returns `user_count` (string) + `bot_count` (string), not `member_count`
- The old code read `resp.data.member_count` which was always `undefined`
- This caused the 2-member group detection to silently fail — bot always required @mention in groups

## Fix
Read `user_count` + `bot_count` and parseInt both (they're strings in the Feishu API)

## Test plan
- [x] Build succeeds
- [x] All 155 tests pass
- [ ] Manual: send message in 2-member group without @mention → bot should respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)