### PR TITLE
fix: mb CLI auth reads .env instead of stale env vars

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -4,19 +4,15 @@
 
 set -euo pipefail
 
-# --- Config: env vars > .env file > defaults ---
-if [[ -z "${METABOT_URL:-}" ]]; then
-  METABOT_ENV="${METABOT_HOME:-$HOME/metabot}/.env"
-  if [[ -f "$METABOT_ENV" ]]; then
-    _port=$(grep -oP '^API_PORT=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-    _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  fi
-  METABOT_URL="http://localhost:${_port:-9100}"
+# --- Config: always read .env, then fall back to env vars / defaults ---
+METABOT_ENV="${METABOT_HOME:-$HOME/metabot}/.env"
+if [[ -f "$METABOT_ENV" ]]; then
+  _port=$(grep -oP '^API_PORT=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
 fi
-if [[ -z "${METABOT_AUTH:-}" ]]; then
-  _secret="${_secret:-${API_SECRET:-changeme}}"
-  METABOT_AUTH="Authorization: Bearer $_secret"
-fi
+METABOT_URL="${METABOT_URL:-http://localhost:${_port:-9100}}"
+_secret="${_secret:-${API_SECRET:-changeme}}"
+METABOT_AUTH="Authorization: Bearer $_secret"
 
 _json() { python3 -m json.tool 2>/dev/null || cat; }
 


### PR DESCRIPTION
## Summary
- `mb` CLI now always reads `API_SECRET` from `.env` file
- Previously it checked `METABOT_AUTH` env var first, which could contain a stale secret from PM2's environment
- This caused all `mb` commands to fail with "Unauthorized"

## Root cause
PM2 injects env vars at process start. If `API_SECRET` was later changed in `.env`, the PM2-inherited `METABOT_AUTH` still held the old value, and `mb` used it without checking `.env`.

## Test plan
- [x] All 155 tests pass
- [x] `mb health`, `mb bots`, `mb stats`, `mb schedule list` all work
- [x] `mm health` also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)