### PR TITLE
feat: add description field to bot config

### DIFF
--- a/bots.example.json
+++ b/bots.example.json
@@ -2,6 +2,7 @@
   "feishuBots": [
     {
       "name": "project-alpha",
+      "description": "Frontend development agent for Project Alpha",
       "feishuAppId": "cli_xxx",
       "feishuAppSecret": "secret1",
       "defaultWorkingDirectory": "/home/user/project-alpha"

--- a/src/api/bot-registry.ts
+++ b/src/api/bot-registry.ts
@@ -16,6 +16,7 @@ export interface RegisteredBot {
 /** Public DTO returned by list() — no secrets or internal refs. */
 export interface BotInfo {
   name: string;
+  description?: string;
   platform: string;
   workingDirectory: string;
   allowedTools: string[];
@@ -71,6 +72,7 @@ export class BotRegistry {
   list(): BotInfo[] {
     return Array.from(this.bots.values()).map((b) => ({
       name: b.name,
+      ...(b.config.description ? { description: b.config.description } : {}),
       platform: b.platform,
       workingDirectory: b.config.claude.defaultWorkingDirectory,
       allowedTools: b.config.claude.allowedTools,

--- a/src/api/http-server.ts
+++ b/src/api/http-server.ts
@@ -379,6 +379,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
           }
           entry = {
             name,
+            ...(body.description ? { description: body.description } : {}),
             feishuAppId: appId,
             feishuAppSecret: appSecret,
             defaultWorkingDirectory: workDir,
@@ -396,6 +397,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
           }
           entry = {
             name,
+            ...(body.description ? { description: body.description } : {}),
             telegramBotToken: token,
             defaultWorkingDirectory: workDir,
             ...(body.allowedTools ? { allowedTools: body.allowedTools } : {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 /** Shared config fields used by MessageBridge and ClaudeExecutor (platform-agnostic). */
 export interface BotConfigBase {
   name: string;
+  description?: string;
   claude: {
     defaultWorkingDirectory: string;
     allowedTools: string[];
@@ -75,6 +76,7 @@ function commaSplit(value: string | undefined): string[] {
 
 export interface FeishuBotJsonEntry {
   name: string;
+  description?: string;
   feishuAppId: string;
   feishuAppSecret: string;
   defaultWorkingDirectory: string;
@@ -89,6 +91,7 @@ export interface FeishuBotJsonEntry {
 function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
   return {
     name: entry.name,
+    ...(entry.description ? { description: entry.description } : {}),
     feishu: {
       appId: entry.feishuAppId,
       appSecret: entry.feishuAppSecret,
@@ -101,6 +104,7 @@ function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
 
 export interface TelegramBotJsonEntry {
   name: string;
+  description?: string;
   telegramBotToken: string;
   defaultWorkingDirectory: string;
   allowedTools?: string[];
@@ -114,6 +118,7 @@ export interface TelegramBotJsonEntry {
 function telegramBotFromJson(entry: TelegramBotJsonEntry): TelegramBotConfig {
   return {
     name: entry.name,
+    ...(entry.description ? { description: entry.description } : {}),
     telegram: {
       botToken: entry.telegramBotToken,
     },


### PR DESCRIPTION
## Summary
- Add optional `description` field to bot config (`bots.json`)
- `mb bots` now shows bot descriptions alongside name/platform/workingDirectory
- `POST /api/bots` accepts and persists `description` for runtime-created bots
- Enables agent-to-agent capability discovery

## Changes
- `BotConfigBase`, `FeishuBotJsonEntry`, `TelegramBotJsonEntry` — added `description?: string`
- `BotInfo` DTO and `BotRegistry.list()` — include description in API output
- `POST /api/bots` — accept description in request body
- `bots.example.json` — added example description

## Test plan
- [x] All 155 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)