### PR TITLE
fix: address multiple community-reported issues

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -455,7 +455,7 @@ LOG_LEVEL=$LogLevel
 MEMORY_SERVER_URL=$MemoryServerUrl
 "@
 
-    $envContent | Out-File -FilePath $EnvFile -Encoding utf8 -NoNewline
+    [System.IO.File]::WriteAllText($EnvFile, $envContent, [System.Text.UTF8Encoding]::new($false))
     Write-Success ".env generated"
 
     # Generate bots.json (use node for safe JSON escaping)
@@ -476,7 +476,7 @@ MEMORY_SERVER_URL=$MemoryServerUrl
     }
 
     $botsResult = node -e "const c={};const f=JSON.parse(process.argv[1]);const t=JSON.parse(process.argv[2]);if(f.length>0)c.feishuBots=f;if(t.length>0)c.telegramBots=t;console.log(JSON.stringify(c,null,2))" $FeishuBotsJson $TelegramBotsJson
-    ($botsResult -join "`n") | Out-File -FilePath $BotsJson -Encoding utf8 -NoNewline
+    [System.IO.File]::WriteAllText($BotsJson, ($botsResult -join "`n"), [System.Text.UTF8Encoding]::new($false))
     Write-Success "bots.json generated"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -512,6 +512,12 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     console.log(JSON.stringify(config, null, 2));
   " "$FEISHU_BOTS_JSON" "$TELEGRAM_BOTS_JSON" > "$BOTS_JSON"
   chmod 600 "$BOTS_JSON"
+
+  # Validate generated JSON
+  if ! node -e "JSON.parse(require('fs').readFileSync('$BOTS_JSON','utf-8'))" 2>/dev/null; then
+    error "Generated bots.json is invalid. Please check your bot name and credentials for special characters."
+    exit 1
+  fi
   success "bots.json generated"
 fi
 

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -422,6 +422,13 @@ export class MessageBridge {
         }
       }
 
+      // Auto-clear stale session when Claude can't find the conversation
+      if (lastState.status === 'error' && lastState.errorMessage &&
+          (lastState.errorMessage.includes('No conversation found') || lastState.errorMessage.includes('session'))) {
+        this.logger.info({ chatId }, 'Clearing stale session ID due to conversation not found');
+        this.sessionManager.resetSession(chatId);
+      }
+
       await this.sendFinalCard(messageId, lastState, chatId);
 
       // Audit + cost tracking
@@ -445,6 +452,13 @@ export class MessageBridge {
       await this.outputHandler.sendOutputFiles(chatId, outputsDir, processor, lastState);
     } catch (err: any) {
       this.logger.error({ err, chatId, userId }, 'Claude execution error');
+
+      // Auto-clear stale session when Claude can't find the conversation
+      const errMsg: string = err.message || '';
+      if (errMsg.includes('No conversation found') || errMsg.includes('session')) {
+        this.logger.info({ chatId }, 'Clearing stale session ID due to conversation not found');
+        this.sessionManager.resetSession(chatId);
+      }
 
       const durationMs = Date.now() - startTime;
       this.audit.log({

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,7 +143,7 @@ function buildClaudeConfig(entry: {
     allowedTools: entry.allowedTools || commaSplit(process.env.CLAUDE_ALLOWED_TOOLS) || defaultTools,
     maxTurns: entry.maxTurns ?? (process.env.CLAUDE_MAX_TURNS ? parseInt(process.env.CLAUDE_MAX_TURNS, 10) : undefined),
     maxBudgetUsd: entry.maxBudgetUsd ?? (process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined),
-    model: entry.model || process.env.CLAUDE_MODEL || 'claude-opus-4-6',
+    model: entry.model || process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || 'claude-opus-4-6',
     outputsBaseDir: entry.outputsBaseDir || process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), 'metabot-outputs'),
     downloadsDir: entry.downloadsDir || process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,10 @@ async function startFeishuBot(botConfig: BotConfig, logger: Logger, memoryServer
     if (botOpenId) {
       botLogger.info({ botOpenId }, 'Bot info fetched');
     } else {
-      botLogger.warn('Could not get bot open_id, group @mention filtering may be less accurate');
+      botLogger.warn('Could not get bot open_id. Ensure the Feishu app has Bot capability enabled and the app version is published.');
     }
-  } catch (err) {
-    botLogger.warn({ err }, 'Failed to fetch bot info, group @mention filtering may be less accurate');
+  } catch (err: any) {
+    botLogger.warn({ err: err?.message || err }, 'Failed to fetch bot info. Check: 1) Bot capability is enabled in Feishu app 2) App is published 3) App credentials are correct');
   }
 
   // Create sender and bridge (FeishuSenderAdapter wraps the Feishu-specific MessageSender)

--- a/src/telegram/telegram-sender.ts
+++ b/src/telegram/telegram-sender.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as https from 'node:https';
 import * as http from 'node:http';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { Bot, InputFile } from 'grammy';
 import type { IMessageSender } from '../bridge/message-sender.interface.js';
 import type { CardState, CardStatus } from '../types.js';
@@ -462,9 +463,14 @@ export class TelegramSender implements IMessageSender {
 
 function downloadUrl(url: string, savePath: string): Promise<void> {
   return new Promise((resolve, reject) => {
+    const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+    const options: https.RequestOptions = {};
+    if (proxyUrl) {
+      options.agent = new HttpsProxyAgent(proxyUrl);
+    }
     const proto = url.startsWith('https') ? https : http;
     const fileStream = fs.createWriteStream(savePath);
-    proto.get(url, (res) => {
+    proto.get(url, options, (res) => {
       if (res.statusCode !== 200) {
         fileStream.close();
         reject(new Error(`HTTP ${res.statusCode}`));


### PR DESCRIPTION
## Summary
- **#29**: Add JSON validation after `bots.json` generation in `install.sh` to catch malformed output
- **#30**: Fix Windows `install.ps1` BOM encoding — use `[System.IO.File]::WriteAllText()` with `UTF8Encoding($false)` instead of `Out-File -Encoding utf8`
- **#31/#32**: Auto-clear stale session ID when Claude returns "No conversation found" error, so next message starts a fresh session instead of repeatedly failing
- **#33**: Improve error messages for Feishu bot `open_id` fetch failure with actionable troubleshooting steps
- **#34**: Add `HTTPS_PROXY`/`HTTP_PROXY` support for Telegram file downloads via `https-proxy-agent`
- **#36**: Support `ANTHROPIC_MODEL` env var for third-party API providers (DashScope, etc.) as fallback after `CLAUDE_MODEL`

## Test plan
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] Verify stale session auto-recovery by resuming with an invalid session ID
- [ ] Verify `install.sh` produces valid JSON for bots.json
- [ ] Verify Telegram proxy support with `HTTPS_PROXY` env var set

Closes #29, #30, #31, #32, #33, #34, #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)