### PR TITLE
feat: remote URL config for CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/clau
 | `WIKI_AUTO_SYNC` | true | Auto-sync on MetaMemory changes (debounced) |
 | `WIKI_AUTO_SYNC_DEBOUNCE_MS` | 5000 | Debounce delay for auto-sync |
 | `CLAUDE_EXECUTABLE_PATH` | auto-detect | Path to `claude` binary (resolved via `which` if not set) |
+| `METABOT_URL` | `http://localhost:9100` | MetaBot API URL (for CLI remote access) |
+| `MEMORY_SERVER_URL` | `http://localhost:8100` | MetaMemory server URL (for CLI remote access) |
 | `WEBHOOK_URLS` | — | Comma-separated webhook URLs for task completion notifications |
 | `LOG_LEVEL` | info | Log level |
 
@@ -280,6 +282,19 @@ mb stats                            # cost & usage stats
 mb health                           # status check
 mb update                           # pull + rebuild + restart (one command)
 ```
+
+### Remote Access
+
+CLI tools (`mb`, `mm`) can connect to a remote MetaBot/MetaMemory server. Add the URLs to your local `.env` file:
+
+```bash
+# In ~/.metabot/.env or ~/metabot/.env
+METABOT_URL=http://your-server:9100      # mb commands target this server
+MEMORY_SERVER_URL=http://your-server:8100 # mm commands target this server
+API_SECRET=your-secret                    # shared auth token
+```
+
+This allows multiple machines to share the same MetaBot and MetaMemory instance — local bots can delegate tasks to a remote agent bus, and any machine can read/write shared memory.
 
 ## Development
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -170,6 +170,8 @@ npm run dev
 | `WIKI_AUTO_SYNC` | true | MetaMemory 变更时自动同步（带防抖） |
 | `WIKI_AUTO_SYNC_DEBOUNCE_MS` | 5000 | 自动同步防抖延迟 |
 | `CLAUDE_EXECUTABLE_PATH` | 自动检测 | `claude` 二进制路径（未设置时通过 `which` 解析） |
+| `METABOT_URL` | `http://localhost:9100` | MetaBot API 地址（CLI 远程访问） |
+| `MEMORY_SERVER_URL` | `http://localhost:8100` | MetaMemory 服务地址（CLI 远程访问） |
 | `WEBHOOK_URLS` | — | 逗号分隔的 Webhook URL，任务完成后发通知 |
 | `LOG_LEVEL` | info | 日志级别 |
 
@@ -280,6 +282,19 @@ mb stats                            # 费用和使用统计
 mb health                           # 状态检查
 mb update                           # 一键更新：拉取 + 构建 + 重启
 ```
+
+### 远程访问
+
+CLI 工具（`mb`、`mm`）支持连接远程 MetaBot/MetaMemory 服务器。在本地 `.env` 文件中配置 URL：
+
+```bash
+# 在 ~/.metabot/.env 或 ~/metabot/.env 中
+METABOT_URL=http://your-server:9100      # mb 命令连接的服务器
+MEMORY_SERVER_URL=http://your-server:8100 # mm 命令连接的服务器
+API_SECRET=your-secret                    # 共享认证 Token
+```
+
+这样多台机器可以共享同一个 MetaBot 和 MetaMemory 实例 —— 本地 Bot 可以向远程 Agent Bus 委派任务，任何机器都能读写共享记忆。
 
 ## 开发
 

--- a/bin/mb
+++ b/bin/mb
@@ -9,8 +9,9 @@ METABOT_ENV="${METABOT_HOME:-$HOME/metabot}/.env"
 if [[ -f "$METABOT_ENV" ]]; then
   _port=$(grep -oP '^API_PORT=\K.*' "$METABOT_ENV" 2>/dev/null || true)
   _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  _url=$(grep -oP '^METABOT_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
 fi
-METABOT_URL="${METABOT_URL:-http://localhost:${_port:-9100}}"
+METABOT_URL="${METABOT_URL:-${_url:-http://localhost:${_port:-9100}}}"
 _secret="${_secret:-${API_SECRET:-changeme}}"
 METABOT_AUTH="Authorization: Bearer $_secret"
 

--- a/bin/mm
+++ b/bin/mm
@@ -21,8 +21,10 @@ if [[ -n "$METABOT_ENV" && -f "$METABOT_ENV" ]]; then
   _reader_token=$(grep -oP '^MEMORY_TOKEN=\K.*' "$METABOT_ENV" 2>/dev/null || true)
   _memory_secret=$(grep -oP '^MEMORY_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
   _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  _memory_url=$(grep -oP '^MEMORY_SERVER_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  [[ -z "$_memory_url" ]] && _memory_url=$(grep -oP '^MEMORY_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
 fi
-MEMORY_URL="${MEMORY_URL:-http://localhost:8100}"
+MEMORY_URL="${MEMORY_URL:-${_memory_url:-http://localhost:8100}}"
 
 # Token priority: MEMORY_ADMIN_TOKEN > MEMORY_TOKEN > MEMORY_SECRET > API_SECRET
 # Always resolve from .env; ignore pre-set MEMORY_AUTH (may be stale/wrong token)


### PR DESCRIPTION
## Summary
- `mb` now reads `METABOT_URL` from `.env` for remote MetaBot API access
- `mm` now reads `MEMORY_SERVER_URL` / `MEMORY_URL` from `.env` for remote MetaMemory access
- Added "Remote Access" section to both READMEs documenting cross-machine setup
- Added `METABOT_URL` and `MEMORY_SERVER_URL` to env vars reference table

This enables multiple machines to share one MetaBot + MetaMemory instance via CLI.

## Test plan
- [x] `mb health` works with default (localhost) config
- [x] `mm health` works with default (localhost) config
- [x] Build, tests, lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)