### PR TITLE
refactor: rename MEMORY_SERVER_URL to META_MEMORY_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,7 @@ API_SECRET=       # If set, listens on 0.0.0.0 with Bearer auth; if empty, local
 # MEMORY_ENABLED=true           # Set to 'false' to disable embedded MetaMemory
 # MEMORY_PORT=8100              # MetaMemory server port
 # MEMORY_DATABASE_DIR=./data    # SQLite database directory
-MEMORY_SERVER_URL=http://localhost:8100
+META_MEMORY_URL=http://localhost:8100
 
 # Auth tokens (admin=full access, reader=shared folders only)
 # MEMORY_SECRET is the legacy token (gets admin access for backward compat)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Sessions are isolated per `chatId` with no collision between bots since each bot
 
 Knowledge persistence is handled by an external **MetaMemory server** (FastAPI + SQLite). The server stores documents as Markdown in a folder tree with full-text search (FTS5).
 
-- **Server URL**: Configured via `MEMORY_SERVER_URL` env var (default: `http://localhost:8100`)
+- **Server URL**: Configured via `META_MEMORY_URL` env var (default: `http://localhost:8100`)
 - **Claude Code Skill**: Claude autonomously reads/writes memory documents via the `metamemory` skill (installed at `~/.claude/skills/metamemory/SKILL.md`). When users say "remember this" or Claude wants to persist knowledge, it calls the memory API via curl.
 - **Feishu commands**: `/memory list`, `/memory search <query>`, `/memory status` — quick queries via `MemoryClient` without spawning Claude.
 - **Web UI**: Browse documents at `http://localhost:8100` — folder tree, markdown rendering, search.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/clau
 | `WIKI_AUTO_SYNC_DEBOUNCE_MS` | 5000 | Debounce delay for auto-sync |
 | `CLAUDE_EXECUTABLE_PATH` | auto-detect | Path to `claude` binary (resolved via `which` if not set) |
 | `METABOT_URL` | `http://localhost:9100` | MetaBot API URL (for CLI remote access) |
-| `MEMORY_SERVER_URL` | `http://localhost:8100` | MetaMemory server URL (for CLI remote access) |
+| `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory server URL (for CLI remote access) |
 | `WEBHOOK_URLS` | — | Comma-separated webhook URLs for task completion notifications |
 | `LOG_LEVEL` | info | Log level |
 
@@ -290,7 +290,7 @@ CLI tools (`mb`, `mm`) can connect to a remote MetaBot/MetaMemory server. Add th
 ```bash
 # In ~/.metabot/.env or ~/metabot/.env
 METABOT_URL=http://your-server:9100      # mb commands target this server
-MEMORY_SERVER_URL=http://your-server:8100 # mm commands target this server
+META_MEMORY_URL=http://your-server:8100 # mm commands target this server
 API_SECRET=your-secret                    # shared auth token
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -171,7 +171,7 @@ npm run dev
 | `WIKI_AUTO_SYNC_DEBOUNCE_MS` | 5000 | 自动同步防抖延迟 |
 | `CLAUDE_EXECUTABLE_PATH` | 自动检测 | `claude` 二进制路径（未设置时通过 `which` 解析） |
 | `METABOT_URL` | `http://localhost:9100` | MetaBot API 地址（CLI 远程访问） |
-| `MEMORY_SERVER_URL` | `http://localhost:8100` | MetaMemory 服务地址（CLI 远程访问） |
+| `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory 服务地址（CLI 远程访问） |
 | `WEBHOOK_URLS` | — | 逗号分隔的 Webhook URL，任务完成后发通知 |
 | `LOG_LEVEL` | info | 日志级别 |
 
@@ -290,7 +290,7 @@ CLI 工具（`mb`、`mm`）支持连接远程 MetaBot/MetaMemory 服务器。在
 ```bash
 # 在 ~/.metabot/.env 或 ~/metabot/.env 中
 METABOT_URL=http://your-server:9100      # mb 命令连接的服务器
-MEMORY_SERVER_URL=http://your-server:8100 # mm 命令连接的服务器
+META_MEMORY_URL=http://your-server:8100 # mm 命令连接的服务器
 API_SECRET=your-secret                    # 共享认证 Token
 ```
 

--- a/bin/mm
+++ b/bin/mm
@@ -21,10 +21,10 @@ if [[ -n "$METABOT_ENV" && -f "$METABOT_ENV" ]]; then
   _reader_token=$(grep -oP '^MEMORY_TOKEN=\K.*' "$METABOT_ENV" 2>/dev/null || true)
   _memory_secret=$(grep -oP '^MEMORY_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
   _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _memory_url=$(grep -oP '^MEMORY_SERVER_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  [[ -z "$_memory_url" ]] && _memory_url=$(grep -oP '^MEMORY_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  _memory_url=$(grep -oP '^META_MEMORY_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  [[ -z "$_memory_url" ]] && _memory_url=$(grep -oP '^MEMORY_SERVER_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
 fi
-MEMORY_URL="${MEMORY_URL:-${_memory_url:-http://localhost:8100}}"
+META_MEMORY_URL="${META_MEMORY_URL:-${_memory_url:-http://localhost:8100}}"
 
 # Token priority: MEMORY_ADMIN_TOKEN > MEMORY_TOKEN > MEMORY_SECRET > API_SECRET
 # Always resolve from .env; ignore pre-set MEMORY_AUTH (may be stale/wrong token)
@@ -68,21 +68,21 @@ shift 2>/dev/null || true
 case "$cmd" in
   search|s)
     query=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(' '.join(sys.argv[1:])))" "$@" 2>/dev/null || echo "$*")
-    _curl "$MEMORY_URL/api/search?q=$query" | _json
+    _curl "$META_MEMORY_URL/api/search?q=$query" | _json
     ;;
   get|g)
-    _curl "$MEMORY_URL/api/documents/$1" | _json
+    _curl "$META_MEMORY_URL/api/documents/$1" | _json
     ;;
   path|p)
     # Get document by path, e.g.: mm path /metabot/weekly-updates
     path=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(' '.join(sys.argv[1:])))" "$@" 2>/dev/null || echo "$*")
-    _curl "$MEMORY_URL/api/documents/by-path?path=$path" | _json
+    _curl "$META_MEMORY_URL/api/documents/by-path?path=$path" | _json
     ;;
   list|ls)
-    _curl "$MEMORY_URL/api/documents?folder_id=${1:-root}&limit=50" | _json
+    _curl "$META_MEMORY_URL/api/documents?folder_id=${1:-root}&limit=50" | _json
     ;;
   folders|f)
-    _curl "$MEMORY_URL/api/folders" | _json
+    _curl "$META_MEMORY_URL/api/folders" | _json
     ;;
 
   # --- Create document ---
@@ -130,7 +130,7 @@ if by:
     payload['created_by'] = by
 print(json.dumps(payload))
 " "$_title" "$_folder" "$_content" "$_tags" "$_by" | \
-    _curl -X POST "$MEMORY_URL/api/documents" \
+    _curl -X POST "$META_MEMORY_URL/api/documents" \
       -H "Content-Type: application/json" \
       -d @- | _json
     ;;
@@ -173,7 +173,7 @@ if not payload:
     sys.exit(1)
 print(json.dumps(payload))
 " "$_content" "$_title" "$_tags" | \
-    _curl -X PUT "$MEMORY_URL/api/documents/$_doc_id" \
+    _curl -X PUT "$META_MEMORY_URL/api/documents/$_doc_id" \
       -H "Content-Type: application/json" \
       -d @- | _json
     ;;
@@ -191,7 +191,7 @@ print(json.dumps(payload))
 import json, sys
 print(json.dumps({'name': sys.argv[1], 'parent_id': sys.argv[2]}))
 " "$_name" "$_parent" | \
-    _curl -X POST "$MEMORY_URL/api/folders" \
+    _curl -X POST "$META_MEMORY_URL/api/folders" \
       -H "Content-Type: application/json" \
       -d @- | _json
     ;;
@@ -202,11 +202,11 @@ print(json.dumps({'name': sys.argv[1], 'parent_id': sys.argv[2]}))
       echo "Usage: mm delete <doc_id>"
       exit 1
     fi
-    _curl -X DELETE "$MEMORY_URL/api/documents/$1" | _json
+    _curl -X DELETE "$META_MEMORY_URL/api/documents/$1" | _json
     ;;
 
   health|h)
-    _curl "$MEMORY_URL/api/health" | _json
+    _curl "$META_MEMORY_URL/api/health" | _json
     ;;
 
   *)

--- a/install.ps1
+++ b/install.ps1
@@ -452,7 +452,7 @@ LOG_LEVEL=$LogLevel
     $envContent += @"
 
 # MetaMemory
-MEMORY_SERVER_URL=$MemoryServerUrl
+META_MEMORY_URL=$MemoryServerUrl
 "@
 
     [System.IO.File]::WriteAllText($EnvFile, $envContent, [System.Text.UTF8Encoding]::new($false))

--- a/install.sh
+++ b/install.sh
@@ -426,7 +426,7 @@ API_TIMEOUT_MS=600000"
   API_SECRET="$(openssl rand -hex 32 2>/dev/null || head -c 64 /dev/urandom | xxd -p | tr -d '\n' | head -c 64)"
   API_PORT="9100"
   LOG_LEVEL="info"
-  MEMORY_SERVER_URL="http://localhost:8100"
+  META_MEMORY_URL="http://localhost:8100"
 
   # Claude executable path
   CLAUDE_PATH=""
@@ -470,7 +470,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     fi
     echo ""
     echo "# MetaMemory"
-    echo "MEMORY_SERVER_URL=${MEMORY_SERVER_URL}"
+    echo "META_MEMORY_URL=${META_MEMORY_URL}"
   } > "$METABOT_HOME/.env"
   chmod 600 "$METABOT_HOME/.env"
   success ".env generated"

--- a/src/config.ts
+++ b/src/config.ts
@@ -244,7 +244,7 @@ export function loadAppConfig(): AppConfig {
     }
   }
 
-  const memoryServerUrl = (process.env.MEMORY_SERVER_URL || 'http://localhost:8100').replace(/\/+$/, '');
+  const memoryServerUrl = (process.env.META_MEMORY_URL || process.env.MEMORY_SERVER_URL || 'http://localhost:8100').replace(/\/+$/, '');
 
   const apiPort = process.env.API_PORT ? parseInt(process.env.API_PORT, 10) : 9100;
   const apiSecret = process.env.API_SECRET || undefined;

--- a/src/memory/skill/SKILL.md
+++ b/src/memory/skill/SKILL.md
@@ -6,7 +6,7 @@ description: Read and write shared memory documents. Use this when you need to s
 ## MetaMemory Document Server
 
 A shared memory server stores documents as organized Markdown files in a folder tree.
-Server URL: !`echo ${MEMORY_SERVER_URL:-http://localhost:8100}`
+Server URL: !`echo ${META_MEMORY_URL:-${MEMORY_SERVER_URL:-http://localhost:8100}}`
 
 ### When to Use
 - User asks to "remember", "save", "note down" something


### PR DESCRIPTION
## Summary
- Rename `MEMORY_SERVER_URL` → `META_MEMORY_URL` across all config files, CLI tools, installers, and docs
- Old `MEMORY_SERVER_URL` still works as backward-compatible fallback in `src/config.ts`, `bin/mm`, and `SKILL.md`
- Updated `.env.example`, `install.sh`, `install.ps1`, `CLAUDE.md`, both READMEs

## Test plan
- [x] `mm health` works
- [x] `mb health` works
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)