### PR TITLE
fix: replace grep -oP with sed for macOS compatibility

### DIFF
--- a/bin/fd
+++ b/bin/fd
@@ -15,8 +15,8 @@ _find_env() {
 }
 METABOT_ENV="$(_find_env)"
 if [[ -n "$METABOT_ENV" && -f "$METABOT_ENV" ]]; then
-  _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _api_port=$(grep -oP '^API_PORT=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  _secret=$(sed -n 's/^API_SECRET=//p' "$METABOT_ENV" 2>/dev/null || true)
+  _api_port=$(sed -n 's/^API_PORT=//p' "$METABOT_ENV" 2>/dev/null || true)
 fi
 API_URL="${API_URL:-http://localhost:${_api_port:-9100}}"
 API_SECRET="${API_SECRET:-${_secret:-}}"

--- a/bin/mb
+++ b/bin/mb
@@ -7,9 +7,9 @@ set -euo pipefail
 # --- Config: always read .env, then fall back to env vars / defaults ---
 METABOT_ENV="${METABOT_HOME:-$HOME/metabot}/.env"
 if [[ -f "$METABOT_ENV" ]]; then
-  _port=$(grep -oP '^API_PORT=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _url=$(grep -oP '^METABOT_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  _port=$(sed -n 's/^API_PORT=//p' "$METABOT_ENV" 2>/dev/null || true)
+  _secret=$(sed -n 's/^API_SECRET=//p' "$METABOT_ENV" 2>/dev/null || true)
+  _url=$(sed -n 's/^METABOT_URL=//p' "$METABOT_ENV" 2>/dev/null || true)
 fi
 METABOT_URL="${METABOT_URL:-${_url:-http://localhost:${_port:-9100}}}"
 _secret="${_secret:-${API_SECRET:-changeme}}"

--- a/bin/mm
+++ b/bin/mm
@@ -17,12 +17,12 @@ _find_env() {
 }
 METABOT_ENV="$(_find_env)"
 if [[ -n "$METABOT_ENV" && -f "$METABOT_ENV" ]]; then
-  _admin_token=$(grep -oP '^MEMORY_ADMIN_TOKEN=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _reader_token=$(grep -oP '^MEMORY_TOKEN=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _memory_secret=$(grep -oP '^MEMORY_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _secret=$(grep -oP '^API_SECRET=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  _memory_url=$(grep -oP '^META_MEMORY_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
-  [[ -z "$_memory_url" ]] && _memory_url=$(grep -oP '^MEMORY_SERVER_URL=\K.*' "$METABOT_ENV" 2>/dev/null || true)
+  _admin_token=$(sed -n 's/^MEMORY_ADMIN_TOKEN=//p' "$METABOT_ENV" 2>/dev/null || true)
+  _reader_token=$(sed -n 's/^MEMORY_TOKEN=//p' "$METABOT_ENV" 2>/dev/null || true)
+  _memory_secret=$(sed -n 's/^MEMORY_SECRET=//p' "$METABOT_ENV" 2>/dev/null || true)
+  _secret=$(sed -n 's/^API_SECRET=//p' "$METABOT_ENV" 2>/dev/null || true)
+  _memory_url=$(sed -n 's/^META_MEMORY_URL=//p' "$METABOT_ENV" 2>/dev/null || true)
+  [[ -z "$_memory_url" ]] && _memory_url=$(sed -n 's/^MEMORY_SERVER_URL=//p' "$METABOT_ENV" 2>/dev/null || true)
 fi
 META_MEMORY_URL="${META_MEMORY_URL:-${_memory_url:-http://localhost:8100}}"
 


### PR DESCRIPTION
## Summary
- Replace `grep -oP '^KEY=\K.*'` with `sed -n 's/^KEY=//p'` in `mb`, `mm`, and `fd` CLI tools
- `grep -oP` uses Perl regex which is GNU grep only — fails on macOS (BSD grep)
- `sed -n 's/^KEY=//p'` is POSIX-compatible and works on macOS, Linux, and Git Bash (Windows)

## Test plan
- [x] `mb health` works on Linux
- [x] `mm health` works on Linux
- [x] `fd --help` works on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)