### PR TITLE
docs: add Star History chart to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ pm2 startup && pm2 save             # auto-start on boot
 
 MetaBot is built by [XVI Robotics](https://github.com/xvirobotics), where we develop humanoid robot brains. We use MetaBot internally to run our company as an agent-native organization — a small team of humans supervising self-improving AI agents. We open-sourced it because we believe this is how companies will work in the future.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=xvirobotics/metabot&type=Date)](https://star-history.com/#xvirobotics/metabot&Date)
+
 ## License
 
 [MIT](LICENSE)

--- a/README_zh.md
+++ b/README_zh.md
@@ -326,6 +326,10 @@ pm2 startup && pm2 save             # 开机自启
 
 MetaBot 由 [XVI Robotics](https://github.com/xvirobotics) 打造，我们做人形机器人大脑。我们在内部用 MetaBot 把公司打造成 Agent Native 组织 —— 一个小团队的人类，监督自我进化的 AI Agent。我们开源它，因为我们相信这是未来公司的运行方式。
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=xvirobotics/metabot&type=Date)](https://star-history.com/#xvirobotics/metabot&Date)
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Add Star History chart (via star-history.com) to both README.md and README_zh.md, placed before the License section

🤖 Generated with [Claude Code](https://claude.com/claude-code)