### PR TITLE
docs: add comprehensive developer manual and contributor guidelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig — consistent coding styles across editors
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## What
+
+<!-- Brief description of what this PR does -->
+
+## Why
+
+<!-- Why is this change needed? Link to related issue if applicable: Fixes #123 -->
+
+## How
+
+<!-- How was this implemented? Describe the approach and any key decisions -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
+- [ ] Documentation (changes to docs only)
+- [ ] CI/Config (changes to CI pipeline, build config, or dependencies)
+
+## Checklist
+
+- [ ] `npm run build` passes with no errors
+- [ ] `npm test` passes with no failures
+- [ ] `npm run lint` reports no errors
+- [ ] I have updated documentation (README, CLAUDE.md) if this changes user-facing behavior
+- [ ] I have updated `.env.example` if new environment variables were added
+- [ ] PR targets the correct branch (`dev` for features/fixes, `main` for hotfixes)
+
+## Screenshots / Logs
+
+<!-- If applicable, add screenshots or relevant log output -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,67 +1,427 @@
 # Contributing to MetaBot
 
-Thanks for your interest in contributing! This guide will help you get started.
+Thank you for your interest in contributing to MetaBot! This guide covers everything you need to get started — whether you're a human developer or an AI agent.
 
-## Development Setup
+**[Chinese version / 中文版](./CONTRIBUTING_zh.md)**
+
+## Code of Conduct
+
+We are committed to providing a welcoming and respectful environment for everyone. Be kind, be constructive, and assume good intent. Harassment, discrimination, and personal attacks will not be tolerated.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Node.js | 20+ | Runtime |
+| npm | 10+ | Package manager |
+| Git | 2.x+ | Version control |
+| Claude Code CLI | latest | `npm i -g @anthropic-ai/claude-code` — must be authenticated |
+| Feishu dev account | — | Optional, only needed for testing bot integration |
+
+## Getting Started
 
 ```bash
-# 1. Clone the repo
-git clone https://github.com/xvirobotics/metabot.git
+# 1. Fork & clone
+git clone https://github.com/<your-username>/metabot.git
 cd metabot
 
 # 2. Install dependencies
 npm install
 
-# 3. Copy environment config
+# 3. Configure environment
 cp .env.example .env
-# Edit .env with your Feishu app credentials
+# Edit .env with your Feishu app credentials (see CLAUDE.md for setup guide)
 
 # 4. Build
 npm run build
 
-# 5. Run in development
+# 5. Run tests
+npm test
+
+# 6. Start development server (hot reload)
 npm run dev
 ```
 
-**Prerequisites:** Node.js 20+, Claude Code CLI installed.
+### Verifying Your Setup
 
-## Project Structure
+A successful setup looks like this:
 
-```
-src/
-  bridge/        # Message routing & task management
-  claude/        # Claude Agent SDK integration
-  feishu/        # Feishu API client & card builder
-  memory/        # Memory server client
-  utils/         # Logger, helpers
+```bash
+npm run build    # No errors
+npm test         # All 14 test suites pass
+npm run lint     # No lint errors
 ```
 
-## How to Contribute
+## Project Architecture
 
-### Reporting Bugs
+### Message Flow
 
-- Use the [Bug Report](https://github.com/xvirobotics/metabot/issues/new?template=bug_report.md) template
-- Include logs (redact sensitive info) and steps to reproduce
+```
+Feishu WSClient
+  -> EventHandler (parse message, @mention filter)
+    -> MessageBridge (route commands, manage tasks)
+      -> ClaudeExecutor (Agent SDK query)
+        -> StreamProcessor (transform to card state)
+          -> Feishu card updates (streaming)
+```
 
-### Suggesting Features
+### Module Map
 
-- Use the [Feature Request](https://github.com/xvirobotics/metabot/issues/new?template=feature_request.md) template
-- Describe the use case, not just the solution
+| Directory | Purpose |
+|-----------|---------|
+| `src/bridge/` | Message routing, task management, rate limiting, outputs |
+| `src/claude/` | Claude Agent SDK integration, session management, streaming |
+| `src/feishu/` | Feishu API client, card builder, message sender, doc reader |
+| `src/memory/` | MetaMemory server client |
+| `src/sync/` | Wiki sync (MetaMemory -> Feishu Wiki) |
+| `src/utils/` | Logger (pino), helpers |
+| `tests/` | Vitest test suites |
 
-### Submitting Pull Requests
+For detailed architecture docs, see [CLAUDE.md](./CLAUDE.md).
 
-1. Fork the repo and create a branch from `main`
-2. Make your changes with clear commit messages
-3. Ensure `npm run build` passes with no errors
-4. Open a PR with a clear description of what changed and why
+## Finding Issues
+
+- Look for issues labeled [`good first issue`](https://github.com/xvirobotics/metabot/labels/good%20first%20issue) or [`help wanted`](https://github.com/xvirobotics/metabot/labels/help%20wanted)
+- Comment on the issue to claim it before starting work
+- If you want to work on something without an existing issue, open one first to discuss the approach
+
+## Development Workflow
+
+### Branch Strategy
+
+```
+main (stable, production)
+  └── dev (active development)
+       ├── feat/your-feature
+       ├── fix/your-bugfix
+       └── docs/your-docs-change
+```
+
+- **`main`** — Stable branch. Only receives merges from `dev` or hotfix PRs.
+- **`dev`** — Active development. All day-to-day work happens here.
+- Create feature branches from `dev`, not `main`.
+
+### Branch Naming
+
+| Prefix | Use |
+|--------|-----|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation changes |
+| `refactor/` | Code restructuring |
+| `test/` | Adding or updating tests |
+| `ci/` | CI/CD changes |
+
+### Keeping Up to Date
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout feat/your-feature
+git rebase dev
+```
+
+## Commit Conventions
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/). Every commit message should have this format:
+
+```
+<type>(<optional scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+### Types
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `ci` | CI/CD changes |
+| `chore` | Maintenance tasks |
+
+### Examples from Our Git Log
+
+```
+feat: remote URL config for CLI tools (#48)
+fix: replace grep -oP with sed for macOS compatibility (#50)
+docs: add Star History chart to READMEs (#51)
+refactor: rename MEMORY_SERVER_URL to META_MEMORY_URL (#49)
+fix: mb CLI auth reads .env instead of stale env vars (#44)
+feat: auto-reply in 2-member group chats without @mention (#35)
+```
+
+### Rules
+
+- Use imperative mood: "add feature" not "added feature"
+- Keep the subject line under 72 characters
+- Reference issue numbers in the subject when applicable: `fix: crash on empty message (#42)`
+- Use the body for context on _why_, not _what_ (the diff shows what)
+
+## Pull Request Process
+
+### Before Submitting
+
+1. Ensure all checks pass locally:
+   ```bash
+   npx tsc --noEmit    # Type check
+   npm test             # Tests
+   npm run lint         # Lint
+   npm run build        # Build
+   ```
+2. Rebase on latest `dev` to avoid merge conflicts
+3. Update documentation if your change affects user-facing behavior
+
+### Submitting
+
+1. Push your branch and open a PR targeting `dev` (or `main` for hotfixes only)
+2. Fill in the [PR template](./.github/pull_request_template.md) — all sections
+3. Ensure CI is green (the pipeline runs: type check -> test -> lint -> build)
+4. Request a review
+
+### Review Process
+
+- Reviews are typically completed within 48 hours
+- Address all review comments before re-requesting review
+- PRs are squash-merged to keep `main` history clean
+- One approval is required to merge
+
+## Testing Guide
+
+### What to Test
+
+- Pure logic modules (parsers, builders, processors, utilities)
+- State management (session manager, sync store)
+- Edge cases in data transformation (card builder, markdown-to-blocks)
+
+### What NOT to Test
+
+- Feishu API calls (external service — mock at the boundary)
+- Claude Agent SDK calls (external service)
+- Simple config loading or re-exports
+
+### Testing Patterns
+
+We use [Vitest](https://vitest.dev/) with ESM imports:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock external modules
+vi.mock('../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('MyModule', () => {
+  it('should do the expected thing', () => {
+    // Arrange, Act, Assert
+  });
+});
+```
+
+Key conventions:
+- Test files go in `tests/` with `.test.ts` extension
+- Use `.js` extensions in imports (ESM project)
+- Mock external dependencies, not internal logic
+- Run tests with `npm test` (runs `vitest run`)
 
 ## Code Style
 
-- TypeScript strict mode
+### TypeScript
+
+- **Strict mode** enabled (`"strict": true` in tsconfig)
+- **ESM project** — all imports use `.js` extensions (even for `.ts` files)
+- **Target**: ES2022, **Module**: Node16
 - Use `async/await` over raw promises
-- Keep functions small and focused
-- Add JSDoc comments for public APIs
+- Use `pino` for logging (not `console.log`)
+
+### Formatting & Linting
+
+Formatting is handled by Prettier, linting by ESLint:
+
+```bash
+npm run format        # Auto-format
+npm run format:check  # Check formatting (CI uses this)
+npm run lint          # Run ESLint
+npm run lint:fix      # Auto-fix lint issues
+```
+
+**Prettier config** (`.prettierrc`):
+- Single quotes, trailing commas, 120 char line width, 2-space indent, semicolons
+
+**ESLint config** (`eslint.config.js`):
+- TypeScript-ESLint recommended rules
+- `@typescript-eslint/no-explicit-any`: off
+- Unused vars warning (with `_` prefix exception)
+- Empty functions allowed
+
+### EditorConfig
+
+Install the [EditorConfig plugin](https://editorconfig.org/#download) for your editor to automatically apply consistent whitespace settings.
+
+## CI Pipeline
+
+Every push and PR triggers the CI pipeline (`.github/workflows/ci.yml`):
+
+```
+Job: check (Node 20 + 22 matrix)
+  1. Type check    — npx tsc --noEmit
+  2. Run tests     — npm test
+  3. Lint           — npm run lint
+
+Job: build (Node 22, depends on check)
+  4. Full build    — npm run build
+```
+
+All four steps must pass for a PR to be mergeable.
+
+## Release Process
+
+MetaBot follows a manual release process:
+
+1. Merge PRs into `dev` during development
+2. When ready for release, create a PR from `dev` to `main`
+3. After merge, deploy via PM2 on the production server
+4. Sync back: `git checkout dev && git merge main && git push`
+
+## Agent Contributor Guidance
+
+This section is for **AI agents** (Claude Code, Codex, Cursor, Copilot, Devin, etc.) contributing to MetaBot. Whether you're working autonomously or pair-programming with a human, follow these guidelines.
+
+### Before You Start
+
+1. **Read CLAUDE.md first.** It contains the full architecture, message flow, module descriptions, and configuration details. It is the single source of truth for how this project works.
+2. **Read this CONTRIBUTING.md.** You're doing that now — good.
+3. **Check existing issues and PRs.** Don't duplicate work that's already in progress.
+
+### Agent PR Requirements
+
+Agent-authored PRs must meet the same quality bar as human PRs, plus:
+
+- **All CI checks must pass** — type check, test, lint, build. No exceptions.
+- **Include `Co-Authored-By` in commit messages:**
+  ```
+  feat: add widget support
+
+  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  ```
+- **Fill in the PR template completely** — the What/Why/How sections help reviewers understand your reasoning.
+- **Keep changes focused.** One PR = one logical change. Don't bundle unrelated fixes.
+
+### Agent Context Files
+
+| File | Purpose | When to Read |
+|------|---------|--------------|
+| `CLAUDE.md` | Full architecture, module map, config reference | Always — before any code change |
+| `CONTRIBUTING.md` | Development workflow, conventions, CI | Always — before submitting |
+| `.env.example` | All environment variables with descriptions | When touching config |
+| `bots.example.json` | Multi-bot configuration format | When touching bot config |
+| `SECURITY.md` | Security policy and scope | When touching auth, sessions, or input handling |
+
+### Working with the Codebase
+
+- **ESM imports**: Always use `.js` extensions in imports, even for TypeScript files. This is the #1 agent mistake.
+  ```typescript
+  // Correct
+  import { something } from './my-module.js';
+  // Wrong — will fail at runtime
+  import { something } from './my-module';
+  import { something } from './my-module.ts';
+  ```
+
+- **Logger**: Use `pino` via `createLogger()`, never `console.log`.
+  ```typescript
+  import { createLogger } from '../utils/logger.js';
+  const logger = createLogger('my-module');
+  logger.info({ data }, 'Something happened');
+  ```
+
+- **Feishu card content limit**: Card content is truncated at 28KB. If you're modifying card builder logic, keep this in mind.
+
+- **Session isolation**: Sessions are keyed by `chatId`, not `userId`. Each chat gets its own session, working directory, and conversation history.
+
+### Common Agent Pitfalls
+
+| Mistake | How to Avoid |
+|---------|--------------|
+| Missing `.js` import extensions | Always add `.js` to relative imports |
+| Using `console.log` | Use `createLogger()` from `src/utils/logger.js` |
+| Modifying `main` directly | Work on `dev` branch or feature branches |
+| Skipping tests | Run `npm test` before every commit |
+| Overly broad changes | Keep PRs focused on one concern |
+| Not updating docs | If behavior changes, update README.md, README_zh.md, and CLAUDE.md |
+| Adding unnecessary dependencies | Prefer built-in Node.js APIs and existing deps |
+| Hardcoding URLs or credentials | Use environment variables via `src/config.ts` |
+| Ignoring TypeScript errors | `strict: true` is non-negotiable — fix all type errors |
+
+### Agent Testing Checklist
+
+Before submitting your PR, verify:
+
+```bash
+# 1. Type check passes
+npx tsc --noEmit
+
+# 2. All tests pass
+npm test
+
+# 3. No lint errors
+npm run lint
+
+# 4. Build succeeds
+npm run build
+
+# 5. If you added new features, did you add tests?
+# 6. If you changed behavior, did you update docs?
+# 7. Is your PR targeting the correct branch (dev)?
+```
+
+### Agent Autonomy Guidelines
+
+- **Safe to do without asking**: Read files, run tests, run lint, run build, create branches, write code
+- **Ask before doing**: Force-push, delete branches, modify CI config, change dependencies, alter `.env.example`
+- **Never do**: Commit secrets, push to `main` directly, skip CI checks, merge your own PR
+
+### Pair Programming with Agents
+
+If you're a human working with an AI agent on MetaBot:
+
+1. Point the agent to `CLAUDE.md` first — it has all the context needed
+2. Use the conventional commit format — agents can follow it consistently
+3. Let the agent run the full CI check locally before pushing
+4. Review agent PRs with the same rigor as human PRs — agents can make subtle errors in business logic
+5. Agent PRs should be squash-merged just like human PRs
+
+## Documentation
+
+### When to Update Docs
+
+| Change Type | Files to Update |
+|-------------|-----------------|
+| New feature | README.md, README_zh.md, CLAUDE.md |
+| New env variable | `.env.example`, CLAUDE.md |
+| Architecture change | CLAUDE.md |
+| New CLI command | README.md, README_zh.md |
+| API change | CLAUDE.md |
+| Bug fix | Usually none, unless it changes documented behavior |
+
+### Documentation Style
+
+- Keep READMEs user-focused (setup, usage, features)
+- Keep CLAUDE.md developer/agent-focused (architecture, internals, config reference)
+- Use bilingual docs: English (`README.md`) and Chinese (`README_zh.md`)
 
 ## Questions?
 
-Open an issue or start a discussion — we're happy to help!
+- Open an [issue](https://github.com/xvirobotics/metabot/issues/new) for bugs or feature requests
+- Use [GitHub Discussions](https://github.com/xvirobotics/metabot/discussions) for questions and ideas
+- Check existing issues before creating new ones

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -1,0 +1,427 @@
+# MetaBot 贡献指南
+
+感谢你对 MetaBot 项目的关注！本指南涵盖了开始贡献所需的一切 —— 无论你是人类开发者还是 AI 智能体。
+
+**[English version / 英文版](./CONTRIBUTING.md)**
+
+## 行为准则
+
+我们致力于为每个人提供友好和尊重的环境。请保持善意、建设性沟通，并假定他人出于好意。不容忍骚扰、歧视和人身攻击。
+
+## 前置要求
+
+| 工具 | 版本 | 说明 |
+|------|------|------|
+| Node.js | 20+ | 运行环境 |
+| npm | 10+ | 包管理器 |
+| Git | 2.x+ | 版本控制 |
+| Claude Code CLI | latest | `npm i -g @anthropic-ai/claude-code` — 需要完成认证 |
+| 飞书开发者账号 | — | 可选，仅在测试机器人集成时需要 |
+
+## 快速开始
+
+```bash
+# 1. Fork 并克隆
+git clone https://github.com/<your-username>/metabot.git
+cd metabot
+
+# 2. 安装依赖
+npm install
+
+# 3. 配置环境变量
+cp .env.example .env
+# 编辑 .env，填入你的飞书应用凭证（详见 CLAUDE.md 中的配置指南）
+
+# 4. 构建
+npm run build
+
+# 5. 运行测试
+npm test
+
+# 6. 启动开发服务器（热重载）
+npm run dev
+```
+
+### 验证环境
+
+成功的环境配置应如下所示：
+
+```bash
+npm run build    # 无错误
+npm test         # 所有 14 个测试套件通过
+npm run lint     # 无 lint 错误
+```
+
+## 项目架构
+
+### 消息流
+
+```
+飞书 WSClient
+  -> EventHandler（解析消息，@提及过滤）
+    -> MessageBridge（路由命令，管理任务）
+      -> ClaudeExecutor（Agent SDK 查询）
+        -> StreamProcessor（转换为卡片状态）
+          -> 飞书卡片更新（流式）
+```
+
+### 模块概览
+
+| 目录 | 用途 |
+|------|------|
+| `src/bridge/` | 消息路由、任务管理、限流、输出管理 |
+| `src/claude/` | Claude Agent SDK 集成、会话管理、流式处理 |
+| `src/feishu/` | 飞书 API 客户端、卡片构建、消息发送、文档读取 |
+| `src/memory/` | MetaMemory 服务端客户端 |
+| `src/sync/` | Wiki 同步（MetaMemory -> 飞书 Wiki） |
+| `src/utils/` | 日志（pino）、工具函数 |
+| `tests/` | Vitest 测试套件 |
+
+详细架构文档请参阅 [CLAUDE.md](./CLAUDE.md)。
+
+## 寻找 Issue
+
+- 查找标记为 [`good first issue`](https://github.com/xvirobotics/metabot/labels/good%20first%20issue) 或 [`help wanted`](https://github.com/xvirobotics/metabot/labels/help%20wanted) 的 Issue
+- 在开始工作前，先在 Issue 中留言认领
+- 如果你想做的事情没有现有 Issue，请先创建一个来讨论方案
+
+## 开发工作流
+
+### 分支策略
+
+```
+main（稳定分支，生产环境）
+  └── dev（活跃开发）
+       ├── feat/your-feature
+       ├── fix/your-bugfix
+       └── docs/your-docs-change
+```
+
+- **`main`** — 稳定分支。只接收来自 `dev` 的合并或热修复 PR。
+- **`dev`** — 活跃开发。所有日常工作在此进行。
+- 从 `dev` 创建功能分支，而不是 `main`。
+
+### 分支命名
+
+| 前缀 | 用途 |
+|------|------|
+| `feat/` | 新功能 |
+| `fix/` | Bug 修复 |
+| `docs/` | 文档变更 |
+| `refactor/` | 代码重构 |
+| `test/` | 添加或更新测试 |
+| `ci/` | CI/CD 变更 |
+
+### 保持同步
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout feat/your-feature
+git rebase dev
+```
+
+## 提交规范
+
+我们遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范。每条提交信息应符合以下格式：
+
+```
+<type>(<可选 scope>): <描述>
+
+[可选正文]
+
+[可选页脚]
+```
+
+### 类型
+
+| 类型 | 使用场景 |
+|------|---------|
+| `feat` | 新功能 |
+| `fix` | Bug 修复 |
+| `docs` | 仅文档变更 |
+| `refactor` | 既不修复 bug 也不添加功能的代码变更 |
+| `test` | 添加或更新测试 |
+| `ci` | CI/CD 变更 |
+| `chore` | 维护性任务 |
+
+### 来自我们 Git 日志的示例
+
+```
+feat: remote URL config for CLI tools (#48)
+fix: replace grep -oP with sed for macOS compatibility (#50)
+docs: add Star History chart to READMEs (#51)
+refactor: rename MEMORY_SERVER_URL to META_MEMORY_URL (#49)
+fix: mb CLI auth reads .env instead of stale env vars (#44)
+feat: auto-reply in 2-member group chats without @mention (#35)
+```
+
+### 规则
+
+- 使用祈使语气："add feature" 而不是 "added feature"
+- 主题行不超过 72 个字符
+- 在主题中引用 Issue 编号：`fix: crash on empty message (#42)`
+- 正文部分说明 _为什么_，而不是 _做了什么_（diff 会展示做了什么）
+
+## Pull Request 流程
+
+### 提交前
+
+1. 确保所有检查在本地通过：
+   ```bash
+   npx tsc --noEmit    # 类型检查
+   npm test             # 测试
+   npm run lint         # Lint
+   npm run build        # 构建
+   ```
+2. 在最新的 `dev` 上 rebase 以避免合并冲突
+3. 如果你的变更影响了用户可见的行为，更新文档
+
+### 提交 PR
+
+1. 推送你的分支并创建 PR，目标分支为 `dev`（仅热修复才用 `main`）
+2. 填写 [PR 模板](./.github/pull_request_template.md) 的所有部分
+3. 确保 CI 通过（流水线包括：类型检查 -> 测试 -> lint -> 构建）
+4. 请求审核
+
+### 审核流程
+
+- 通常在 48 小时内完成审核
+- 在重新请求审核前，处理所有审核意见
+- PR 使用 squash merge 以保持 `main` 历史整洁
+- 合并需要至少一个批准
+
+## 测试指南
+
+### 应该测试什么
+
+- 纯逻辑模块（解析器、构建器、处理器、工具函数）
+- 状态管理（会话管理器、同步存储）
+- 数据转换中的边缘情况（卡片构建器、markdown-to-blocks）
+
+### 不需要测试什么
+
+- 飞书 API 调用（外部服务 — 在边界处 mock）
+- Claude Agent SDK 调用（外部服务）
+- 简单的配置加载或重导出
+
+### 测试模式
+
+我们使用 [Vitest](https://vitest.dev/) 和 ESM 导入：
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock 外部模块
+vi.mock('../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('MyModule', () => {
+  it('should do the expected thing', () => {
+    // 准备、执行、断言
+  });
+});
+```
+
+关键约定：
+- 测试文件放在 `tests/` 目录下，使用 `.test.ts` 扩展名
+- 导入路径使用 `.js` 扩展名（ESM 项目）
+- Mock 外部依赖，而不是内部逻辑
+- 使用 `npm test` 运行测试（执行 `vitest run`）
+
+## 代码风格
+
+### TypeScript
+
+- **严格模式**已启用（tsconfig 中 `"strict": true`）
+- **ESM 项目** — 所有导入使用 `.js` 扩展名（即使是 `.ts` 文件）
+- **Target**: ES2022, **Module**: Node16
+- 使用 `async/await` 而非原始 Promise
+- 使用 `pino` 记录日志（不用 `console.log`）
+
+### 格式化与 Lint
+
+格式化由 Prettier 处理，lint 由 ESLint 处理：
+
+```bash
+npm run format        # 自动格式化
+npm run format:check  # 检查格式化（CI 使用此命令）
+npm run lint          # 运行 ESLint
+npm run lint:fix      # 自动修复 lint 问题
+```
+
+**Prettier 配置**（`.prettierrc`）：
+- 单引号、尾逗号、120 字符行宽、2 空格缩进、分号
+
+**ESLint 配置**（`eslint.config.js`）：
+- TypeScript-ESLint 推荐规则
+- `@typescript-eslint/no-explicit-any`: 关闭
+- 未使用变量警告（`_` 前缀例外）
+- 允许空函数
+
+### EditorConfig
+
+为你的编辑器安装 [EditorConfig 插件](https://editorconfig.org/#download) 以自动应用一致的空白设置。
+
+## CI 流水线
+
+每次推送和 PR 都会触发 CI 流水线（`.github/workflows/ci.yml`）：
+
+```
+Job: check（Node 20 + 22 矩阵）
+  1. 类型检查    — npx tsc --noEmit
+  2. 运行测试    — npm test
+  3. Lint        — npm run lint
+
+Job: build（Node 22，依赖 check）
+  4. 完整构建    — npm run build
+```
+
+所有四个步骤必须通过才能合并 PR。
+
+## 发布流程
+
+MetaBot 采用手动发布流程：
+
+1. 开发期间将 PR 合并到 `dev`
+2. 准备发布时，从 `dev` 创建 PR 到 `main`
+3. 合并后，通过 PM2 在生产服务器上部署
+4. 回同步：`git checkout dev && git merge main && git push`
+
+## AI 智能体贡献指南
+
+本节面向**AI 智能体**（Claude Code、Codex、Cursor、Copilot、Devin 等）。无论你是自主工作还是与人类协作编程，请遵循以下指南。
+
+### 开始之前
+
+1. **首先阅读 CLAUDE.md。** 它包含完整的架构、消息流、模块描述和配置细节，是了解本项目工作方式的唯一权威来源。
+2. **阅读本 CONTRIBUTING.md。** 你现在正在做的事 — 很好。
+3. **检查现有 Issue 和 PR。** 不要重复已在进行中的工作。
+
+### 智能体 PR 要求
+
+智能体创建的 PR 必须达到与人类 PR 相同的质量标准，此外还需：
+
+- **所有 CI 检查必须通过** — 类型检查、测试、lint、构建。没有例外。
+- **在提交信息中包含 `Co-Authored-By`：**
+  ```
+  feat: add widget support
+
+  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  ```
+- **完整填写 PR 模板** — What/Why/How 部分帮助审核者理解你的推理过程。
+- **保持变更聚焦。** 一个 PR = 一个逻辑变更。不要捆绑不相关的修复。
+
+### 智能体上下文文件
+
+| 文件 | 用途 | 何时阅读 |
+|------|------|---------|
+| `CLAUDE.md` | 完整架构、模块映射、配置参考 | 始终 — 在任何代码变更之前 |
+| `CONTRIBUTING.md` | 开发工作流、规范、CI | 始终 — 在提交之前 |
+| `.env.example` | 所有环境变量及其描述 | 涉及配置变更时 |
+| `bots.example.json` | 多机器人配置格式 | 涉及机器人配置时 |
+| `SECURITY.md` | 安全策略和范围 | 涉及认证、会话或输入处理时 |
+
+### 代码库使用指南
+
+- **ESM 导入**：导入路径必须使用 `.js` 扩展名，即使是 TypeScript 文件。这是智能体最常犯的错误。
+  ```typescript
+  // 正确
+  import { something } from './my-module.js';
+  // 错误 — 运行时会失败
+  import { something } from './my-module';
+  import { something } from './my-module.ts';
+  ```
+
+- **日志**：通过 `createLogger()` 使用 `pino`，绝不使用 `console.log`。
+  ```typescript
+  import { createLogger } from '../utils/logger.js';
+  const logger = createLogger('my-module');
+  logger.info({ data }, 'Something happened');
+  ```
+
+- **飞书卡片内容限制**：卡片内容在 28KB 处截断。如果你在修改卡片构建器逻辑，请记住这一点。
+
+- **会话隔离**：会话以 `chatId` 为键，而非 `userId`。每个聊天有独立的会话、工作目录和对话历史。
+
+### 常见智能体错误
+
+| 错误 | 如何避免 |
+|------|---------|
+| 缺少 `.js` 导入扩展名 | 始终在相对导入中添加 `.js` |
+| 使用 `console.log` | 使用 `src/utils/logger.js` 中的 `createLogger()` |
+| 直接修改 `main` 分支 | 在 `dev` 或功能分支上工作 |
+| 跳过测试 | 每次提交前运行 `npm test` |
+| 变更范围过大 | 保持 PR 聚焦于单一关注点 |
+| 未更新文档 | 如果行为变更，更新 README.md、README_zh.md 和 CLAUDE.md |
+| 添加不必要的依赖 | 优先使用 Node.js 内置 API 和现有依赖 |
+| 硬编码 URL 或凭证 | 通过 `src/config.ts` 使用环境变量 |
+| 忽略 TypeScript 错误 | `strict: true` 不可商量 — 修复所有类型错误 |
+
+### 智能体测试清单
+
+提交 PR 之前，请验证：
+
+```bash
+# 1. 类型检查通过
+npx tsc --noEmit
+
+# 2. 所有测试通过
+npm test
+
+# 3. 无 lint 错误
+npm run lint
+
+# 4. 构建成功
+npm run build
+
+# 5. 如果添加了新功能，是否添加了测试？
+# 6. 如果修改了行为，是否更新了文档？
+# 7. PR 是否指向正确的分支（dev）？
+```
+
+### 智能体自主权指南
+
+- **可以直接做的事**：读取文件、运行测试、运行 lint、运行构建、创建分支、编写代码
+- **需要先询问的事**：强制推送、删除分支、修改 CI 配置、变更依赖、修改 `.env.example`
+- **绝不可以做的事**：提交密钥、直接推送到 `main`、跳过 CI 检查、合并自己的 PR
+
+### 与智能体协作编程
+
+如果你是与 AI 智能体协作开发 MetaBot 的人类开发者：
+
+1. 首先将智能体指向 `CLAUDE.md` — 它包含所有必要的上下文
+2. 使用 Conventional Commits 格式 — 智能体可以很好地遵循它
+3. 让智能体在推送之前在本地运行完整的 CI 检查
+4. 以与审核人类 PR 相同的严格度审核智能体 PR — 智能体可能在业务逻辑上犯细微错误
+5. 智能体 PR 应与人类 PR 一样使用 squash merge
+
+## 文档维护
+
+### 何时更新文档
+
+| 变更类型 | 需要更新的文件 |
+|---------|---------------|
+| 新功能 | README.md, README_zh.md, CLAUDE.md |
+| 新环境变量 | `.env.example`, CLAUDE.md |
+| 架构变更 | CLAUDE.md |
+| 新 CLI 命令 | README.md, README_zh.md |
+| API 变更 | CLAUDE.md |
+| Bug 修复 | 通常无需更新，除非改变了已记录的行为 |
+
+### 文档风格
+
+- README 面向用户（安装、使用、功能）
+- CLAUDE.md 面向开发者/智能体（架构、内部实现、配置参考）
+- 使用双语文档：英文（`README.md`）和中文（`README_zh.md`）
+
+## 有问题？
+
+- 在 [Issue](https://github.com/xvirobotics/metabot/issues/new) 中报告 bug 或提出功能请求
+- 在 [GitHub Discussions](https://github.com/xvirobotics/metabot/discussions) 中提问和讨论想法
+- 创建新 Issue 前，请先检查是否已有相关 Issue

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.x     | Yes       |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, use [GitHub Security Advisories](https://github.com/xvirobotics/metabot/security/advisories/new) to report vulnerabilities privately.
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### Response Timeline
+
+| Stage | Timeline |
+|-------|----------|
+| Acknowledgment | Within 48 hours |
+| Initial assessment | Within 1 week |
+| Fix & disclosure | Coordinated with reporter |
+
+## Scope
+
+The following are in scope for security reports:
+
+- **Credential exposure** — Bot tokens, API keys, or secrets leaked through logs, error messages, or responses
+- **Command injection** — Ability to execute unintended commands through user input
+- **Session isolation bypass** — Accessing another chat's session data or working directory
+- **Unauthorized file access** — Reading or writing files outside the configured working directory
+- **Memory server data leakage** — Accessing other users' stored memories
+
+## Out of Scope
+
+- Vulnerabilities in upstream platforms (Claude API, Feishu/Lark API)
+- Vulnerabilities in third-party dependencies (report these to the dependency maintainer)
+- Social engineering attacks
+- Denial of service attacks against the bot
+
+## Security Best Practices for Contributors
+
+- Never commit credentials, tokens, or secrets — use `.env` files (already in `.gitignore`)
+- Never log sensitive data (API keys, user messages with PII)
+- Validate and sanitize all external input (Feishu events, API parameters)
+- Use parameterized queries for any database operations
+- Review the [OWASP Top 10](https://owasp.org/www-project-top-ten/) before submitting security-sensitive code
+
+## Acknowledgments
+
+We appreciate responsible disclosure. Contributors who report valid security issues will be acknowledged in the project (unless they prefer to remain anonymous).


### PR DESCRIPTION
## What

- Rewrite CONTRIBUTING.md with full development workflow, conventions, and agent guidance
- Add CONTRIBUTING_zh.md (Chinese translation)
- Add .github/pull_request_template.md with What/Why/How + checklist
- Add SECURITY.md with GitHub Security Advisories reporting process
- Add .editorconfig aligned with existing Prettier config

## Why

The project has matured (51+ merged PRs, CI pipeline, 14 test files) but lacked comprehensive contributor documentation. This is especially important for AI agent contributors who need clear context files and conventions.

## How

Followed the plan in PLAN-developer-manual.md. All content is verified against actual project config (.prettierrc, eslint.config.js, tsconfig.json, ci.yml).

## Type of Change

- [x] Documentation (changes to docs only)

## Checklist

- [x] `npm run build` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run lint` reports no errors
- [x] PR targets the correct branch (`dev`)