### PR TITLE
fix: handle stale Claude sessions in API path

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -423,8 +423,7 @@ export class MessageBridge {
       }
 
       // Auto-clear stale session when Claude can't find the conversation
-      if (lastState.status === 'error' && lastState.errorMessage &&
-          (lastState.errorMessage.includes('No conversation found') || lastState.errorMessage.includes('session'))) {
+      if (lastState.status === 'error' && isStaleSessionError(lastState.errorMessage)) {
         this.logger.info({ chatId }, 'Clearing stale session ID due to conversation not found');
         this.sessionManager.resetSession(chatId);
       }
@@ -455,7 +454,7 @@ export class MessageBridge {
 
       // Auto-clear stale session when Claude can't find the conversation
       const errMsg: string = err.message || '';
-      if (errMsg.includes('No conversation found') || errMsg.includes('session')) {
+      if (isStaleSessionError(errMsg)) {
         this.logger.info({ chatId }, 'Clearing stale session ID due to conversation not found');
         this.sessionManager.resetSession(chatId);
       }
@@ -646,6 +645,11 @@ export class MessageBridge {
         }
       }
 
+      if (lastState.status === 'error' && isStaleSessionError(lastState.errorMessage)) {
+        this.logger.info({ chatId }, 'Clearing stale session ID due to conversation not found');
+        this.sessionManager.resetSession(chatId);
+      }
+
       if (sendCards && messageId) {
         await this.sendFinalCard(messageId, lastState, chatId);
       }
@@ -672,6 +676,12 @@ export class MessageBridge {
       };
     } catch (err: any) {
       this.logger.error({ err, chatId, userId }, 'API task execution error');
+
+      const errMsg: string = err.message || '';
+      if (isStaleSessionError(errMsg)) {
+        this.logger.info({ chatId }, 'Clearing stale session ID due to conversation not found');
+        this.sessionManager.resetSession(chatId);
+      }
 
       if (sendCards && messageId) {
         const errorState: CardState = {
@@ -763,6 +773,11 @@ export class MessageBridge {
     this.runningTasks.clear();
     this.sessionManager.destroy();
   }
+}
+
+export function isStaleSessionError(errorMessage?: string): boolean {
+  if (!errorMessage) return false;
+  return /no conversation found|conversation not found|session id|invalid session/i.test(errorMessage);
 }
 
 /**

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isStaleSessionError } from '../src/bridge/message-bridge.js';
+
+describe('isStaleSessionError', () => {
+  it('matches the GitHub issue error text', () => {
+    expect(
+      isStaleSessionError('Error: No conversation found with session ID: d0cfbde2-1357-4da0-acd6-ee36d1da056c'),
+    ).toBe(true);
+  });
+
+  it('matches other stale session variants', () => {
+    expect(isStaleSessionError('invalid session provided')).toBe(true);
+    expect(isStaleSessionError('Conversation not found')).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isStaleSessionError('Task timed out (1 hour limit)')).toBe(false);
+    expect(isStaleSessionError('permission denied')).toBe(false);
+    expect(isStaleSessionError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- reuse a shared stale-session detector instead of ad-hoc string checks
- clear persisted Claude sessions when API tasks hit resume failures
- add coverage for the issue #58 error text and related stale-session variants

## Testing
- npm test -- --run tests/message-bridge.test.ts tests/session-manager.test.ts tests/stream-processor.test.ts
- npm run build