### PR TITLE
fix: avoid crashes when Telegram API times out

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,13 +100,24 @@ async function main() {
   // Create bot registry
   const registry = new BotRegistry();
 
-  // Start all bots in parallel
-  const feishuHandles: FeishuBotHandle[] = feishuCount > 0
-    ? await Promise.all(appConfig.feishuBots.map((bot) => startFeishuBot(bot, logger, appConfig.memoryServerUrl, appConfig.memory.secret || undefined)))
+  // Start bots independently so a single platform/API timeout does not
+  // take down the whole MetaBot process.
+  const feishuHandles = feishuCount > 0
+    ? await startBotsSafely(
+      appConfig.feishuBots,
+      (bot) => startFeishuBot(bot, logger, appConfig.memoryServerUrl, appConfig.memory.secret || undefined),
+      logger,
+      'feishu',
+    )
     : [];
 
-  const telegramHandles: TelegramBotHandle[] = telegramCount > 0
-    ? await Promise.all(appConfig.telegramBots.map((bot) => startTelegramBot(bot, logger, appConfig.memoryServerUrl, appConfig.memory.secret || undefined)))
+  const telegramHandles = telegramCount > 0
+    ? await startBotsSafely(
+      appConfig.telegramBots,
+      (bot) => startTelegramBot(bot, logger, appConfig.memoryServerUrl, appConfig.memory.secret || undefined),
+      logger,
+      'telegram',
+    )
     : [];
 
   // Register all bots in the registry
@@ -232,6 +243,34 @@ async function main() {
 
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+}
+
+async function startBotsSafely<TConfig extends BotConfigBase, THandle>(
+  bots: TConfig[],
+  starter: (bot: TConfig) => Promise<THandle>,
+  logger: Logger,
+  platform: 'feishu' | 'telegram',
+): Promise<THandle[]> {
+  const results = await Promise.allSettled(bots.map((bot) => starter(bot)));
+  const handles: THandle[] = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    const bot = bots[i];
+    if (!result || !bot) continue;
+
+    if (result.status === 'fulfilled') {
+      handles.push(result.value);
+      continue;
+    }
+
+    logger.error(
+      { err: result.reason, botName: bot.name, platform },
+      'Failed to start bot; continuing with remaining bots',
+    );
+  }
+
+  return handles;
 }
 
 main().catch((err) => {

--- a/src/telegram/telegram-bot.ts
+++ b/src/telegram/telegram-bot.ts
@@ -38,9 +38,21 @@ export async function startTelegramBot(
   const sender = new TelegramSender(bot, botLogger);
   const bridge = new MessageBridge(config, botLogger, sender, memoryServerUrl, memorySecret);
 
-  // Get bot info for logging
-  const me = await bot.api.getMe();
-  botLogger.info({ botUsername: me.username, botId: me.id }, 'Telegram bot info fetched');
+  // Install grammY error handler before polling starts.
+  bot.catch((err) => {
+    botLogger.error({ err: err.error, ctx: err.ctx?.update?.update_id }, 'grammY error');
+  });
+
+  // getMe is useful for logging and @mention handling, but Telegram API
+  // timeouts during startup should not take down the whole service.
+  let botUsername: string | undefined;
+  try {
+    const me = await bot.api.getMe();
+    botUsername = me.username;
+    botLogger.info({ botUsername: me.username, botId: me.id }, 'Telegram bot info fetched');
+  } catch (err) {
+    botLogger.warn({ err }, 'Failed to fetch Telegram bot info during startup; continuing without username metadata');
+  }
 
   // Handle text messages
   bot.on('message:text', async (ctx) => {
@@ -52,9 +64,8 @@ export async function startTelegramBot(
 
     // In group chats, only respond when mentioned or when message starts with /
     if (chatType === 'group' || chatType === 'supergroup') {
-      const botUsername = me.username;
       const mentioned = ctx.message.entities?.some(
-        (e) => e.type === 'mention' && text.includes(`@${botUsername}`),
+        (e) => e.type === 'mention' && botUsername !== undefined && text.includes(`@${botUsername}`),
       );
       const isCommand = text.startsWith('/');
 
@@ -235,11 +246,6 @@ export async function startTelegramBot(
     bridge.handleMessage(msg).catch((err) => {
       botLogger.error({ err, chatId, userId }, 'Unhandled error in Telegram animation message bridge');
     });
-  });
-
-  // Handle errors
-  bot.catch((err) => {
-    botLogger.error({ err: err.error, ctx: err.ctx?.update?.update_id }, 'grammY error');
   });
 
   // Start long polling (non-blocking)


### PR DESCRIPTION
## Summary
- stop Telegram startup timeouts from crashing the whole MetaBot process
- treat  failure as non-fatal and continue without username metadata
- start bots with per-bot isolation so one failed startup does not take down others

## Testing
- npm run build