### PR TITLE
Fix MetaMemory request limits and timeout messages

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -24,6 +24,8 @@ const MAX_QUEUE_SIZE = 5; // max queued messages per chat
 const IDLE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour idle → abort
 const FINAL_CARD_RETRIES = 3;
 const FINAL_CARD_BASE_DELAY_MS = 2000;
+const TASK_TIMEOUT_MESSAGE = 'Task timed out (24 hour limit)';
+const IDLE_TIMEOUT_MESSAGE = 'Task aborted: no activity for 1 hour';
 
 interface RunningTask {
   abortController: AbortController;
@@ -324,7 +326,7 @@ export class MessageBridge {
     const resetIdleTimer = () => {
       if (idleTimerId) clearTimeout(idleTimerId);
       idleTimerId = setTimeout(() => {
-        this.logger.warn({ chatId, userId }, 'Task idle timeout (5min no stream), aborting');
+        this.logger.warn({ chatId, userId }, 'Task idle timeout (1h no stream), aborting');
         idledOut = true;
         executionHandle.finish();
         abortController.abort();
@@ -407,9 +409,9 @@ export class MessageBridge {
       // Force terminal state if stream ended without one
       if (lastState.status !== 'complete' && lastState.status !== 'error') {
         if (timedOut) {
-          lastState = { ...lastState, status: 'error', errorMessage: 'Task timed out (1 hour limit)' };
+          lastState = { ...lastState, status: 'error', errorMessage: TASK_TIMEOUT_MESSAGE };
         } else if (idledOut) {
-          lastState = { ...lastState, status: 'error', errorMessage: 'Task aborted: no activity for 5 minutes' };
+          lastState = { ...lastState, status: 'error', errorMessage: IDLE_TIMEOUT_MESSAGE };
         } else if (abortController.signal.aborted) {
           lastState = { ...lastState, status: 'error', errorMessage: 'Task was stopped' };
         } else {
@@ -565,7 +567,7 @@ export class MessageBridge {
     const resetIdleTimer = () => {
       if (idleTimerId) clearTimeout(idleTimerId);
       idleTimerId = setTimeout(() => {
-        this.logger.warn({ chatId, userId }, 'API task idle timeout (5min no stream), aborting');
+        this.logger.warn({ chatId, userId }, 'API task idle timeout (1h no stream), aborting');
         idledOut = true;
         executionHandle.finish();
         abortController.abort();
@@ -631,9 +633,9 @@ export class MessageBridge {
 
       if (lastState.status !== 'complete' && lastState.status !== 'error') {
         if (timedOut) {
-          lastState = { ...lastState, status: 'error', errorMessage: 'Task timed out (1 hour limit)' };
+          lastState = { ...lastState, status: 'error', errorMessage: TASK_TIMEOUT_MESSAGE };
         } else if (idledOut) {
-          lastState = { ...lastState, status: 'error', errorMessage: 'Task aborted: no activity for 5 minutes' };
+          lastState = { ...lastState, status: 'error', errorMessage: IDLE_TIMEOUT_MESSAGE };
         } else if (abortController.signal.aborted) {
           lastState = { ...lastState, status: 'error', errorMessage: 'Task was stopped' };
         } else {

--- a/src/memory/memory-server.ts
+++ b/src/memory/memory-server.ts
@@ -51,19 +51,48 @@ function jsonResponse(res: http.ServerResponse, status: number, body: unknown): 
   res.end(json);
 }
 
+const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10 MB
+
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
-    req.on('end', () => resolve(Buffer.concat(chunks).toString()));
+    let totalSize = 0;
+    let tooLarge = false;
+    req.on('data', (chunk: Buffer) => {
+      if (tooLarge) return;
+      totalSize += chunk.length;
+      if (totalSize > MAX_BODY_SIZE) {
+        tooLarge = true;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (tooLarge) {
+        reject(new PayloadTooLargeError());
+        return;
+      }
+      resolve(Buffer.concat(chunks).toString());
+    });
     req.on('error', reject);
   });
+}
+
+class PayloadTooLargeError extends Error {
+  statusCode = 413;
+  constructor() {
+    super('Request body too large (max 10 MB)');
+  }
 }
 
 async function parseJsonBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
   const raw = await readBody(req);
   if (!raw) return {};
-  return JSON.parse(raw) as Record<string, unknown>;
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    throw Object.assign(new Error('Invalid JSON in request body'), { statusCode: 400 });
+  }
 }
 
 // Resolve the static directory — works for both src/ (tsx) and dist/ (compiled)
@@ -253,6 +282,10 @@ export function startMemoryServer(options: MemoryServerOptions): { server: http.
       // 404 fallback
       jsonResponse(res, 404, { detail: 'Not found' });
     } catch (err: any) {
+      if (typeof err?.statusCode === 'number') {
+        jsonResponse(res, err.statusCode, { detail: err.message || 'Request error' });
+        return;
+      }
       logger.error({ err, method, url: rawUrl }, 'MetaMemory request error');
       jsonResponse(res, 500, { detail: err.message || 'Internal server error' });
     }

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -31,12 +31,12 @@ const messages = {
     zh: '有任务正在运行。使用 `/stop` 终止它，或等待完成。',
   },
   timeout_1h: {
-    en: 'Task timed out (1 hour limit)',
-    zh: '任务超时（1小时限制）',
+    en: 'Task timed out (24 hour limit)',
+    zh: '任务超时（24小时限制）',
   },
   idle_timeout: {
-    en: 'Task aborted: no activity for 5 minutes',
-    zh: '任务终止：5分钟无活动',
+    en: 'Task aborted: no activity for 1 hour',
+    zh: '任务终止：1小时无活动',
   },
   task_stopped: {
     en: 'Task was stopped',

--- a/tests/memory-server.test.ts
+++ b/tests/memory-server.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { startMemoryServer } from '../src/memory/memory-server.js';
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(), child: vi.fn() } as any;
+}
+
+describe('MetaMemory server request limits', () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      const cleanup = cleanups.pop();
+      cleanup?.();
+    }
+  });
+
+  async function startTestServer() {
+    const databaseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metamemory-test-'));
+    cleanups.push(() => fs.rmSync(databaseDir, { recursive: true, force: true }));
+
+    const { server, storage } = startMemoryServer({
+      port: 0,
+      databaseDir,
+      logger: createLogger(),
+    });
+
+    cleanups.push(() => storage.close());
+    cleanups.push(() => server.close());
+
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const address = server.address() as AddressInfo;
+
+    return {
+      url: `http://127.0.0.1:${address.port}`,
+    };
+  }
+
+  it('returns 400 for invalid JSON bodies', async () => {
+    const { url } = await startTestServer();
+
+    const response = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"name":',
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Invalid JSON in request body',
+    });
+  });
+
+  it('returns 413 for oversized JSON bodies', async () => {
+    const { url } = await startTestServer();
+    const oversizedPayload = JSON.stringify({
+      name: 'x',
+      description: 'a'.repeat(10 * 1024 * 1024),
+    });
+
+    const response = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: oversizedPayload,
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Request body too large (max 10 MB)',
+    });
+  });
+});

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -14,7 +14,7 @@ describe('isStaleSessionError', () => {
   });
 
   it('does not match unrelated errors', () => {
-    expect(isStaleSessionError('Task timed out (1 hour limit)')).toBe(false);
+    expect(isStaleSessionError('Task timed out (24 hour limit)')).toBe(false);
     expect(isStaleSessionError('permission denied')).toBe(false);
     expect(isStaleSessionError(undefined)).toBe(false);
   });


### PR DESCRIPTION
## Summary\n- return structured 400/413 responses from MetaMemory for invalid or oversized JSON bodies\n- cap MetaMemory request bodies at 10MB\n- align task timeout and idle-timeout messages with actual runtime behavior\n- add/request-limit coverage tests\n\n## Verification\n- npm test -- --run tests/memory-server.test.ts tests/message-bridge.test.ts tests/i18n.test.ts\n- npm test