### PR TITLE
Fix MetaMemory health auth and remove broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/clau
 1. Message [@BotFather](https://t.me/BotFather) → `/newbot` → copy token
 2. Add to `bots.json` → done (long polling, no webhooks)
 
-**Feishu/Lark** ([detailed guide](docs/feishu-setup.md)):
+**Feishu/Lark**:
 1. Create app at [open.feishu.cn](https://open.feishu.cn/) → add Bot capability
 2. Enable permissions: `im:message`, `im:message:readonly`, `im:resource`, `docx:document:readonly`, `wiki:wiki` (for doc reading & wiki sync)
 3. Start MetaBot, then enable persistent connection + `im.message.receive_v1` event

--- a/README_zh.md
+++ b/README_zh.md
@@ -101,7 +101,7 @@ npm run dev
 1. 找 [@BotFather](https://t.me/BotFather) → `/newbot` → 复制 token
 2. 写入 `bots.json` → 完成（长轮询，无需 Webhook）
 
-**飞书**（[详细指南](docs/feishu-setup.md)）：
+**飞书**：
 1. [open.feishu.cn](https://open.feishu.cn/) 创建应用 → 添加「机器人」能力
 2. 开通权限：`im:message`、`im:message:readonly`、`im:resource`、`docx:document:readonly`、`wiki:wiki`（文档阅读和知识库同步）
 3. 先启动 MetaBot，再开启「长连接」+ `im.message.receive_v1` 事件

--- a/src/memory/memory-server.ts
+++ b/src/memory/memory-server.ts
@@ -157,17 +157,6 @@ export function startMemoryServer(options: MemoryServerOptions): { server: http.
       return;
     }
 
-    // Resolve role for API routes
-    let role: Role = 'admin';
-    if (pathname.startsWith('/api/')) {
-      const resolved = resolveRole(req);
-      if (resolved === null) {
-        jsonResponse(res, 401, { detail: 'Unauthorized' });
-        return;
-      }
-      role = resolved;
-    }
-
     try {
       // --- API Routes ---
 
@@ -176,6 +165,17 @@ export function startMemoryServer(options: MemoryServerOptions): { server: http.
         const result = handleHealth(storage);
         jsonResponse(res, result.status, result.body);
         return;
+      }
+
+      // Resolve role for authenticated API routes
+      let role: Role = 'admin';
+      if (pathname.startsWith('/api/')) {
+        const resolved = resolveRole(req);
+        if (resolved === null) {
+          jsonResponse(res, 401, { detail: 'Unauthorized' });
+          return;
+        }
+        role = resolved;
       }
 
       // Folders

--- a/tests/memory-server.test.ts
+++ b/tests/memory-server.test.ts
@@ -40,6 +40,28 @@ describe('MetaMemory server request limits', () => {
     };
   }
 
+  async function startAuthenticatedTestServer() {
+    const databaseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metamemory-auth-test-'));
+    cleanups.push(() => fs.rmSync(databaseDir, { recursive: true, force: true }));
+
+    const { server, storage } = startMemoryServer({
+      port: 0,
+      databaseDir,
+      secret: 'test-secret',
+      logger: createLogger(),
+    });
+
+    cleanups.push(() => storage.close());
+    cleanups.push(() => server.close());
+
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const address = server.address() as AddressInfo;
+
+    return {
+      url: `http://127.0.0.1:${address.port}`,
+    };
+  }
+
   it('returns 400 for invalid JSON bodies', async () => {
     const { url } = await startTestServer();
 
@@ -71,6 +93,19 @@ describe('MetaMemory server request limits', () => {
     expect(response.status).toBe(413);
     await expect(response.json()).resolves.toEqual({
       detail: 'Request body too large (max 10 MB)',
+    });
+  });
+
+  it('allows unauthenticated health checks while keeping other API routes protected', async () => {
+    const { url } = await startAuthenticatedTestServer();
+
+    const healthResponse = await fetch(`${url}/api/health`);
+    expect(healthResponse.status).toBe(200);
+
+    const foldersResponse = await fetch(`${url}/api/folders`);
+    expect(foldersResponse.status).toBe(401);
+    await expect(foldersResponse.json()).resolves.toEqual({
+      detail: 'Unauthorized',
     });
   });
 });


### PR DESCRIPTION
## Summary\n- allow unauthenticated MetaMemory health checks while keeping other API routes protected\n- add coverage for authenticated and unauthenticated MetaMemory health behavior\n- remove broken Feishu setup links from the English and Chinese READMEs\n\n## Verification\n- npm test