### PR TITLE
This ensure metabot always use claude code returing session ID

### DIFF
--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -32,7 +32,7 @@ export class StreamProcessor {
 
   processMessage(message: SDKMessage): CardState {
     // Capture session_id from any message
-    if (message.session_id && !this.sessionId) {
+    if (message.session_id) {
       this.sessionId = message.session_id;
     }
 


### PR DESCRIPTION
This solve the bug sometimes session ID not found issue in Feishu when Claude Code returning a new Session ID to metabot then pass error to Feishu (I guess also apply to other channels too). So not need to delete old session file and restart metabot everytime error received