### PR TITLE
Add im:chat:readonly permission to Feishu setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/clau
 
 **Feishu/Lark**:
 1. Create app at [open.feishu.cn](https://open.feishu.cn/) → add Bot capability
-2. Enable permissions: `im:message`, `im:message:readonly`, `im:resource`, `docx:document:readonly`, `wiki:wiki` (for doc reading & wiki sync)
+2. Enable permissions: `im:message`, `im:message:readonly`, `im:resource`, `im:chat:readonly` (for group chat detection), `docx:document:readonly`, `wiki:wiki` (for doc reading & wiki sync)
 3. Start MetaBot, then enable persistent connection + `im.message.receive_v1` event
 4. Publish the app
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -103,7 +103,7 @@ npm run dev
 
 **飞书**：
 1. [open.feishu.cn](https://open.feishu.cn/) 创建应用 → 添加「机器人」能力
-2. 开通权限：`im:message`、`im:message:readonly`、`im:resource`、`docx:document:readonly`、`wiki:wiki`（文档阅读和知识库同步）
+2. 开通权限：`im:message`、`im:message:readonly`、`im:resource`、`im:chat:readonly`（群聊检测）、`docx:document:readonly`、`wiki:wiki`（文档阅读和知识库同步）
 3. 先启动 MetaBot，再开启「长连接」+ `im.message.receive_v1` 事件
 4. 发布应用
 


### PR DESCRIPTION
## Summary
- Add missing `im:chat:readonly` permission to Feishu setup instructions in both READMEs
- This permission is required for 2-member group chat detection (fork group feature)

## Test plan
- [x] Documentation-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)