### PR TITLE
Add metabot update command to Install section in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
 
 The installer walks you through: working directory → Claude auth → IM credentials → auto-start with PM2.
 
+**Update anytime** — already installed? One command to pull, rebuild, and restart:
+
+```bash
+metabot update
+```
+
 > **Windows notes:** The PowerShell installer auto-detects `winget`/`choco`/`scoop` for Node.js installation. CLI tools (`mm`, `mb`, `metabot`, `fd`) are installed with `.cmd` wrappers and require [Git for Windows](https://git-scm.com) (provides Git Bash).
 
 <details>

--- a/README_zh.md
+++ b/README_zh.md
@@ -78,6 +78,12 @@ irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
 
 安装器引导：工作目录 → Claude 认证 → IM 平台凭证 → PM2 自动启动。
 
+**随时更新** — 已安装？一条命令拉取、构建、重启：
+
+```bash
+metabot update
+```
+
 > **Windows 说明：** PowerShell 安装器自动检测 `winget`/`choco`/`scoop` 来安装 Node.js。CLI 工具（`mm`、`mb`、`metabot`、`fd`）通过 `.cmd` 包装器安装，需要 [Git for Windows](https://git-scm.com)（提供 Git Bash）。
 
 <details>


### PR DESCRIPTION
## Summary
- Add `metabot update` command prominently in the Install section of both READMEs
- Makes the one-command update workflow more discoverable for existing users

## Test plan
- [x] Documentation-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)