### PR TITLE
Fix docs site_url and add workflow_dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: MetaBot
-site_url: https://xvirobotics.github.io/metabot
+site_url: https://xvirobotics.com/metabot
 site_description: Infrastructure for building a supervised, self-improving agent organization
 repo_url: https://github.com/xvirobotics/metabot
 repo_name: xvirobotics/metabot


### PR DESCRIPTION
## Summary
- Fix `site_url` in mkdocs.yml to match actual custom domain (`xvirobotics.com` instead of `github.io`)
- Add `workflow_dispatch` trigger to docs workflow for manual re-deploys
- Add workflow file itself to paths trigger

## Test plan
- [ ] After merge, verify pages at `https://xvirobotics.com/metabot/getting-started/installation/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)