### PR TITLE
Detect API errors wrapped as success and auto-retry

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -906,7 +906,7 @@ export class MessageBridge {
 
 export function isStaleSessionError(errorMessage?: string): boolean {
   if (!errorMessage) return false;
-  return /no conversation found|conversation not found|session id|invalid session/i.test(errorMessage);
+  return /no conversation found|conversation not found|session id|invalid session|multiple.*tool_result.*blocks|each tool_use must have a single result/i.test(errorMessage);
 }
 
 /**

--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -138,18 +138,21 @@ export class StreamProcessor {
       tool.status = 'done';
     }
 
+    const resultText = message.result || this.responseText;
     const isError = message.subtype !== 'success';
+    // SDK sometimes wraps API errors as "success" with the error text as result
+    const isApiError = !isError && isApiErrorResult(resultText);
 
     return {
-      status: isError ? 'error' : 'complete',
+      status: (isError || isApiError) ? 'error' : 'complete',
       userPrompt: this.userPrompt,
-      responseText: message.result || this.responseText,
+      responseText: isApiError ? '' : resultText,
       toolCalls: [...this.toolCalls],
       costUsd: this.costUsd,
       durationMs: this.durationMs,
       errorMessage: isError
         ? (message.errors?.join('; ') || `Ended with: ${message.subtype}`)
-        : undefined,
+        : isApiError ? resultText : undefined,
     };
   }
 
@@ -297,4 +300,10 @@ function shortenPath(filePath: string): string {
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return text.slice(0, max) + '...';
+}
+
+/** Detect API error responses that the SDK wraps as successful results */
+function isApiErrorResult(text: string): boolean {
+  if (!text) return false;
+  return /^API Error:\s*\d{3}\s/i.test(text);
 }

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -13,6 +13,18 @@ describe('isStaleSessionError', () => {
     expect(isStaleSessionError('Conversation not found')).toBe(true);
   });
 
+  it('matches conversation corruption errors (duplicate tool_result)', () => {
+    expect(
+      isStaleSessionError('API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.148.content.1: each tool_use must have a single result. Found multiple `tool_result` blocks with id: toolu_01TPsHXcmpuz5cAY97fM5vXv"}}'),
+    ).toBe(true);
+    expect(
+      isStaleSessionError('each tool_use must have a single result'),
+    ).toBe(true);
+    expect(
+      isStaleSessionError('Found multiple tool_result blocks with id: toolu_abc'),
+    ).toBe(true);
+  });
+
   it('does not match unrelated errors', () => {
     expect(isStaleSessionError('Task timed out (24 hour limit)')).toBe(false);
     expect(isStaleSessionError('permission denied')).toBe(false);


### PR DESCRIPTION
## Summary
- **stream-processor**: Detect `API Error: NNN` results that the Claude SDK wraps as successful completions and force them to `error` status (red card instead of misleading green "Complete")
- **message-bridge**: Expand `isStaleSessionError()` to also match conversation corruption errors (`multiple tool_result blocks`, `each tool_use must have a single result`), triggering auto-retry with a fresh session
- Added test cases for the new error patterns

Fixes the issue where a 400 API error about duplicate `tool_result` blocks was shown to the user as a green "Complete" card instead of being auto-retried.

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Verify `npm test` passes (174 tests)
- [ ] Verify `npm run lint` passes
- [ ] When a session has corrupted history (duplicate tool_results), the bot should auto-retry instead of showing the raw API error

🤖 Generated with [Claude Code](https://claude.com/claude-code)