### PR TITLE
Fix duplicate tool_result for plan mode tools

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -372,19 +372,15 @@ export class MessageBridge {
           continue;
         }
 
-        // Auto-respond to interactive tools that don't need user input (ExitPlanMode, etc.)
-        const autoTools = processor.drainAutoRespondTools();
-        for (const tool of autoTools) {
-          const sid = processor.getSessionId() || '';
-          const response = getAutoResponse(tool.name);
-          this.logger.info({ chatId, toolName: tool.name, toolUseId: tool.toolUseId }, 'Auto-responding to interactive tool');
-
-          // ExitPlanMode: send plan content to user before auto-responding
+        // Detect SDK-handled tools for side effects (plan content display).
+        // Do NOT call sendAnswer — the SDK auto-responds in bypassPermissions mode.
+        // Sending a duplicate tool_result causes API 400 errors.
+        const sdkTools = processor.drainSdkHandledTools();
+        for (const tool of sdkTools) {
+          this.logger.info({ chatId, toolName: tool.name, toolUseId: tool.toolUseId }, 'Detected SDK-handled tool');
           if (tool.name === 'ExitPlanMode') {
             await this.sendPlanContent(chatId, processor, state);
           }
-
-          executionHandle.sendAnswer(tool.toolUseId, sid, response);
         }
 
         // If we just got a message after answering a question, clear timeout state
@@ -663,18 +659,13 @@ export class MessageBridge {
           continue;
         }
 
-        // Auto-respond to interactive tools (ExitPlanMode, etc.)
-        const autoTools = processor.drainAutoRespondTools();
-        for (const tool of autoTools) {
-          const sid = processor.getSessionId() || '';
-          const response = getAutoResponse(tool.name);
-          this.logger.info({ chatId, toolName: tool.name, toolUseId: tool.toolUseId }, 'API task: auto-responding to interactive tool');
-
+        // Detect SDK-handled tools for side effects only (no sendAnswer).
+        const sdkTools = processor.drainSdkHandledTools();
+        for (const tool of sdkTools) {
+          this.logger.info({ chatId, toolName: tool.name, toolUseId: tool.toolUseId }, 'API task: detected SDK-handled tool');
           if (tool.name === 'ExitPlanMode' && sendCards) {
             await this.sendPlanContent(chatId, processor, state);
           }
-
-          executionHandle.sendAnswer(tool.toolUseId, sid, response);
         }
 
         if (state.status === 'complete' || state.status === 'error') {
@@ -909,17 +900,3 @@ export function isStaleSessionError(errorMessage?: string): boolean {
   return /no conversation found|conversation not found|session id|invalid session|multiple.*tool_result.*blocks|each tool_use must have a single result/i.test(errorMessage);
 }
 
-/**
- * Generate auto-response content for interactive tools that the bridge
- * handles without user input (plan mode, etc.).
- */
-function getAutoResponse(toolName: string): string {
-  switch (toolName) {
-    case 'ExitPlanMode':
-      return 'User approved the plan. Proceed with implementation.';
-    case 'EnterPlanMode':
-      return 'Plan mode approved. Explore the codebase and design your approach.';
-    default:
-      return 'Approved. Please continue.';
-  }
-}

--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -4,14 +4,14 @@ import type { CardState, ToolCall, PendingQuestion } from '../feishu/card-builde
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.tiff']);
 
 /**
- * Tools that require user interaction in the Agent SDK.
- * These tools cause the SDK stream to pause waiting for a tool_result.
- * The bridge must detect them and respond (either by asking the user
- * or auto-responding) to prevent the stream from hanging.
+ * Tools handled by the SDK in bypassPermissions mode.
+ * The SDK auto-responds to these; we only detect them for side effects
+ * (e.g. sending plan content to the user) — we must NOT call sendAnswer
+ * or we'll create duplicate tool_results that cause API 400 errors.
  */
-const AUTO_RESPOND_TOOLS = new Set(['ExitPlanMode', 'EnterPlanMode']);
+const SDK_HANDLED_TOOLS = new Set(['ExitPlanMode', 'EnterPlanMode']);
 
-export interface AutoRespondTool {
+export interface DetectedTool {
   toolUseId: string;
   name: string;
 }
@@ -25,7 +25,7 @@ export class StreamProcessor {
   private durationMs: number | undefined;
   private _imagePaths: Set<string> = new Set();
   private _pendingQuestion: PendingQuestion | null = null;
-  private _autoRespondTools: AutoRespondTool[] = [];
+  private _sdkHandledTools: DetectedTool[] = [];
   private _planFilePath: string | null = null;
 
   constructor(private userPrompt: string) {}
@@ -91,8 +91,8 @@ export class StreamProcessor {
         if (message.parent_tool_use_id === null || message.parent_tool_use_id === undefined) {
           if (block.name === 'AskUserQuestion' && block.id && block.input) {
             this.extractPendingQuestion(block.id, block.input);
-          } else if (AUTO_RESPOND_TOOLS.has(block.name) && block.id) {
-            this._autoRespondTools.push({ toolUseId: block.id, name: block.name });
+          } else if (SDK_HANDLED_TOOLS.has(block.name) && block.id) {
+            this._sdkHandledTools.push({ toolUseId: block.id, name: block.name });
           }
         }
       } else if (block.type === 'tool_result') {
@@ -218,14 +218,15 @@ export class StreamProcessor {
   }
 
   /**
-   * Get and clear any tools that need auto-response (e.g. ExitPlanMode).
-   * These tools cause the SDK stream to pause; we must push a tool_result
-   * to unblock them.
+   * Get and clear any SDK-handled tools detected in the stream.
+   * These tools are auto-responded to by the SDK in bypassPermissions mode;
+   * the bridge should NOT call sendAnswer for them, only perform side effects
+   * like sending plan content to the user.
    */
-  drainAutoRespondTools(): AutoRespondTool[] {
-    if (this._autoRespondTools.length === 0) return [];
-    const tools = [...this._autoRespondTools];
-    this._autoRespondTools = [];
+  drainSdkHandledTools(): DetectedTool[] {
+    if (this._sdkHandledTools.length === 0) return [];
+    const tools = [...this._sdkHandledTools];
+    this._sdkHandledTools = [];
     return tools;
   }
 

--- a/tests/stream-processor.test.ts
+++ b/tests/stream-processor.test.ts
@@ -152,7 +152,7 @@ describe('StreamProcessor', () => {
     expect(p.getImagePaths()).toEqual([]);
   });
 
-  it('detects ExitPlanMode for auto-response', () => {
+  it('detects ExitPlanMode as SDK-handled tool', () => {
     const p = new StreamProcessor('hi');
     p.processMessage(msg({
       type: 'assistant',
@@ -166,12 +166,12 @@ describe('StreamProcessor', () => {
         }],
       },
     }));
-    const tools = p.drainAutoRespondTools();
+    const tools = p.drainSdkHandledTools();
     expect(tools).toHaveLength(1);
     expect(tools[0].toolUseId).toBe('tool-plan1');
     expect(tools[0].name).toBe('ExitPlanMode');
     // Second drain should be empty
-    expect(p.drainAutoRespondTools()).toHaveLength(0);
+    expect(p.drainSdkHandledTools()).toHaveLength(0);
   });
 
   it('does not detect ExitPlanMode from subagent', () => {
@@ -188,7 +188,7 @@ describe('StreamProcessor', () => {
         }],
       },
     }));
-    expect(p.drainAutoRespondTools()).toHaveLength(0);
+    expect(p.drainSdkHandledTools()).toHaveLength(0);
   });
 
   it('marks all tools as done on result', () => {


### PR DESCRIPTION
## Summary
- **Root cause**: In `bypassPermissions` mode, the Claude Agent SDK auto-responds to `ExitPlanMode`/`EnterPlanMode` tools. MetaBot's code **also** called `sendAnswer()` for these tools, creating duplicate `tool_result` blocks for the same `tool_use_id`. This caused Claude API 400 errors: `"each tool_use must have a single result. Found multiple tool_result blocks with id"`
- **Fix**: Stop calling `sendAnswer` for SDK-handled tools. We still detect `ExitPlanMode` for sending plan content to the user, but let the SDK handle the `tool_result` response
- Renamed `AUTO_RESPOND_TOOLS` → `SDK_HANDLED_TOOLS`, `drainAutoRespondTools()` → `drainSdkHandledTools()` to reflect the new semantics
- Removed unused `getAutoResponse()` function

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Verify `npm test` passes (174 tests)
- [ ] Verify `npm run lint` passes
- [ ] Use plan mode in Feishu — should no longer get "multiple tool_result blocks" error after plan completes
- [ ] Plan content should still be sent to user when ExitPlanMode triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)