### PR TITLE
Self-update metabot CLI via re-exec on update

### DIFF
--- a/bin/metabot
+++ b/bin/metabot
@@ -25,7 +25,16 @@ cmd_update() {
 
   info "Pulling latest code..."
   cd "$METABOT_HOME"
+  local old_head
+  old_head="$(git rev-parse HEAD)"
   git pull --ff-only || { error "git pull failed"; exit 1; }
+
+  # Re-exec with the updated script if bin/metabot changed (avoids running stale code)
+  if [[ -z "${METABOT_REEXEC:-}" ]] && ! git diff --quiet "$old_head" HEAD -- bin/metabot 2>/dev/null; then
+    info "metabot CLI updated, re-launching with new version..."
+    export METABOT_REEXEC=1
+    exec "$METABOT_HOME/bin/metabot" update
+  fi
 
   info "Installing dependencies..."
   npm install --production=false


### PR DESCRIPTION
## Summary
- When `metabot update` pulls new code and detects that `bin/metabot` itself changed, it re-executes with the new version via `exec`
- This solves the bootstrap problem: the first time a user runs `metabot update` after this change lands, the old script pulls the new code, detects the change, and re-launches — so all new features (CLI tool copying, skill updates) work immediately
- Same pattern already used by `install.sh` (line 243)

Without this, users needed to manually `cp bin/metabot ~/.local/bin/metabot` for the first update.

## Test plan
- [ ] First `metabot update` from an old version should auto-relaunch and update everything
- [ ] Subsequent updates should work normally (no re-exec if bin/metabot unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)