### PR TITLE
Add skills update to mb update command

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -172,6 +172,42 @@ print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'cronExpr': sys
       fi
     done
 
+    echo "==> Updating skills..."
+    SKILLS_DIR="$HOME/.claude/skills"
+    if [[ -d "$SKILLS_DIR" ]]; then
+      for skill in metaskill metamemory metabot feishu-doc; do
+        case "$skill" in
+          metaskill)  src="$METABOT_SRC/src/skills/metaskill" ;;
+          metamemory) src="$METABOT_SRC/src/memory/skill" ;;
+          metabot)    src="$METABOT_SRC/src/skills/metabot" ;;
+          feishu-doc) src="$METABOT_SRC/src/skills/feishu-doc" ;;
+          *)          src="" ;;
+        esac
+        if [[ -n "$src" && -d "$src" && -d "$SKILLS_DIR/$skill" ]]; then
+          cp -r "$src/." "$SKILLS_DIR/$skill/"
+          echo "    Updated: $skill"
+        fi
+      done
+      # Also update workspace skills if bots.json exists
+      if [[ -f "$METABOT_SRC/bots.json" ]] && command -v node &>/dev/null; then
+        work_dir=$(node -e "
+          const c=JSON.parse(require('fs').readFileSync('$METABOT_SRC/bots.json','utf-8'));
+          const b=[...(c.feishuBots||[]),...(c.telegramBots||[])];
+          if(b[0])console.log(b[0].defaultWorkingDirectory);
+        " 2>/dev/null || true)
+        if [[ -n "${work_dir:-}" && -d "$work_dir/.claude/skills" ]]; then
+          for skill in metaskill metamemory metabot feishu-doc; do
+            if [[ -d "$SKILLS_DIR/$skill" && -d "$work_dir/.claude/skills/$skill" ]]; then
+              cp -r "$SKILLS_DIR/$skill/." "$work_dir/.claude/skills/$skill/"
+            fi
+          done
+          if [[ -f "$METABOT_SRC/src/workspace/CLAUDE.md" ]]; then
+            cp "$METABOT_SRC/src/workspace/CLAUDE.md" "$work_dir/CLAUDE.md"
+          fi
+        fi
+      fi
+    fi
+
     echo "==> Restarting service..."
     if command -v pm2 &>/dev/null && pm2 list 2>/dev/null | grep -q metabot; then
       pm2 restart metabot && echo "    Restarted via pm2"


### PR DESCRIPTION
## Summary
- `mb update` previously only updated CLI tools but skipped skill files, causing bots to have stale SKILL.md content after update
- Now syncs skills to `~/.claude/skills/` and workspace `.claude/skills/` directory, matching `metabot update` behavior
- Also copies workspace CLAUDE.md when bots.json is present

## Root cause
User's MacBook bot gave outdated response about peer routing because `mb update` didn't update the metabot SKILL.md which describes `mb talk` peer auto-routing.

## Test plan
- [x] Build passes
- [x] All 174 tests pass
- [x] Lint passes (no new warnings)
- [ ] Run `mb update` on a machine and verify skills are copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)