### PR TITLE
Fix metabot update self-overwrite crash on macOS

### DIFF
--- a/bin/metabot
+++ b/bin/metabot
@@ -23,16 +23,23 @@ cmd_update() {
     exit 1
   fi
 
+  # Always re-exec from the repo copy before doing anything.
+  # This prevents the running script (e.g. ~/.local/bin/metabot) from being
+  # overwritten mid-execution when we copy CLI tools later.
+  if [[ -z "${METABOT_REEXEC:-}" ]] && [[ -f "$METABOT_HOME/bin/metabot" ]]; then
+    export METABOT_REEXEC=1
+    exec "$METABOT_HOME/bin/metabot" update
+  fi
+
   info "Pulling latest code..."
   cd "$METABOT_HOME"
   local old_head
   old_head="$(git rev-parse HEAD)"
   git pull --ff-only || { error "git pull failed"; exit 1; }
 
-  # Re-exec with the updated script if bin/metabot changed (avoids running stale code)
-  if [[ -z "${METABOT_REEXEC:-}" ]] && ! git diff --quiet "$old_head" HEAD -- bin/metabot 2>/dev/null; then
+  # Re-exec if git pull updated this script (the repo copy we're running from)
+  if ! git diff --quiet "$old_head" HEAD -- bin/metabot 2>/dev/null; then
     info "metabot CLI updated, re-launching with new version..."
-    export METABOT_REEXEC=1
     exec "$METABOT_HOME/bin/metabot" update
   fi
 


### PR DESCRIPTION
## Summary
- `metabot update` running from `~/.local/bin/metabot` would crash with `syntax error near unexpected token '('` after update completes
- Root cause: the script overwrites itself during CLI copy step, causing bash to read misaligned bytes
- Fix: always re-exec to the repo copy (`$METABOT_HOME/bin/metabot`) **before** git pull, not after
- Post-pull re-exec no longer gated by `METABOT_REEXEC`, so it correctly handles git pull updating the repo script

## Re-exec flow
1. `~/.local/bin/metabot update` → exec to `$METABOT_HOME/bin/metabot update` (safe: running from repo)
2. `git pull` updates repo → if `bin/metabot` changed → exec again (picks up new version)
3. Second exec → `git pull` is no-op → continue normally → CLI copy is safe

## Test plan
- [x] Build passes
- [x] All 174 tests pass
- [ ] Run `metabot update` on macOS — no more syntax error

🤖 Generated with [Claude Code](https://claude.com/claude-code)