### PR TITLE
Add Voice Assistant (Jarvis Mode) docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/clau
 - **Multi-agent team** — frontend bot, backend bot, infra bot, each in their own workspace, talking via the Agent Bus
 - **Self-growing organization** — a manager bot that creates new agents on demand, assigns tasks, schedules follow-ups
 - **Autonomous research pipeline** — agents that search, analyze, save findings to MetaMemory, and schedule next steps
+- **Voice assistant (Jarvis mode)** — "Hey Siri, Jarvis" from AirPods, hands-free voice control of any agent via iOS Shortcuts. See [Voice Setup Guide](docs/features/voice-jarvis.md)
 
 ## Example Prompts
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -120,6 +120,7 @@ npm run dev
 - **多 Agent 团队** — 前端 Bot、后端 Bot、运维 Bot，各自独立工作空间，通过 Agent 总线协作
 - **自生长的组织** — 管理者 Bot 按需创建新 Agent，分配任务，安排后续跟进
 - **自主研究流水线** — Agent 搜索、分析、将发现存入 MetaMemory、安排下一步
+- **语音助手（Jarvis 模式）** — AirPods 说 "Hey Siri, Jarvis"，免手免屏语音控制任意 Agent。见 [语音设置指南](docs/features/voice-jarvis.zh.md)
 
 ## 示例 Prompt
 

--- a/docs/features/voice-jarvis.md
+++ b/docs/features/voice-jarvis.md
@@ -1,0 +1,110 @@
+# Voice Assistant (Jarvis Mode)
+
+Talk to any MetaBot agent hands-free using AirPods and Siri. No app needed — just an iOS Shortcut.
+
+## How It Works
+
+```
+"Hey Siri, Jarvis"
+        ↓
+  Siri dictates your voice → text
+        ↓
+  HTTP POST to MetaBot /api/talk
+        ↓
+  Agent executes (Claude Code)
+        ↓
+  Response spoken back through AirPods
+```
+
+Zero screen interaction. Works while walking, hiking, driving.
+
+## Setup (5 minutes)
+
+### Prerequisites
+
+- iPhone with Siri enabled
+- AirPods (or any earphones with Siri support)
+- MetaBot server accessible from the internet (public IP + port 9100 open)
+- Your `API_SECRET` from MetaBot's `.env`
+
+### Step 1: Create the Shortcut
+
+Open **Shortcuts** app on iPhone → tap **+** → name it **Jarvis**.
+
+### Step 2: Add "Dictate Text"
+
+Search and add the **Dictate Text** action:
+- **Language**: Chinese (China) — or your preferred language
+- **Stop listening**: After pause
+
+### Step 3: Add "Get Contents of URL"
+
+Search and add **Get Contents of URL**:
+
+- **URL**: `http://YOUR_SERVER_IP:9100/api/talk`
+- **Method**: `POST`
+- **Headers**:
+  - `Authorization` = `Bearer YOUR_API_SECRET`
+  - `Content-Type` = `application/json`
+- **Request Body**: `JSON`
+  - `botName` → `quanwang` (or any bot name, text)
+  - `chatId` → `voice_jarvis` (text — this creates a persistent session)
+  - `prompt` → select the **Dictated Text** variable from step 2
+
+### Step 4: Add "Get Dictionary Value"
+
+Search and add **Get Dictionary Value**:
+- Get **Value** for key `responseText`
+- From: **Contents of URL** (previous step)
+
+### Step 5: Add "Speak Text"
+
+Search and add **Speak Text**:
+- Input: **Dictionary Value** (previous step)
+
+### Step 6: Test
+
+1. Put on AirPods
+2. Say **"Hey Siri, Jarvis"**
+3. Wait for the dictation prompt, then speak your command
+4. Wait a few seconds — the response will be spoken back
+
+## Tips
+
+### Talk to different bots
+
+Create multiple shortcuts with different `botName` values:
+- **"Hey Siri, Jarvis"** → `quanwang` (general assistant)
+- **"Hey Siri, Goku"** → `goku` (motion control specialist)
+- **"Hey Siri, Backend"** → `backend-bot` (backend developer)
+
+### Persistent sessions
+
+The `chatId` field (`voice_jarvis`) creates a persistent Claude session, just like a Feishu chat. Multi-turn conversations work — the agent remembers previous context.
+
+Use different `chatId` values for different conversation threads:
+- `voice_jarvis` — general tasks
+- `voice_code_review` — code review sessions
+- `voice_research` — research tasks
+
+### Remote peers
+
+If the bot is on a remote peer instance, use the qualified name syntax:
+- `botName` = `lanqi/some-bot` — routes to the `lanqi` peer automatically
+
+### Feishu cards
+
+Set `sendCards` to `true` (boolean) in the JSON body if you also want to see the response as a Feishu card in your chat. Useful for code-heavy responses you want to read later.
+
+## Limitations
+
+- Each interaction requires saying "Hey Siri, Jarvis" again (no continuous conversation loop)
+- Siri's dictation may truncate very long voice input
+- Long agent responses (code, detailed analysis) are better consumed as text in Feishu
+- Requires internet connectivity for both Siri STT and MetaBot API
+
+## Security
+
+- The API endpoint should be protected with `API_SECRET` (Bearer token auth)
+- Consider using HTTPS (reverse proxy with Let's Encrypt) for production
+- The `chatId` is fixed in the shortcut, so anyone with access to your phone could use it

--- a/docs/features/voice-jarvis.zh.md
+++ b/docs/features/voice-jarvis.zh.md
@@ -1,0 +1,112 @@
+# 语音助手（Jarvis 模式）
+
+通过 AirPods 和 Siri 免手免屏与任意 MetaBot Agent 语音交流。无需安装 App，只用 iOS 快捷指令。
+
+## 工作原理
+
+```
+"Hey Siri, Jarvis"
+        ↓
+  Siri 听写语音 → 文字
+        ↓
+  HTTP POST 到 MetaBot /api/talk
+        ↓
+  Agent 执行任务（Claude Code）
+        ↓
+  通过 AirPods 语音回复
+```
+
+全程不用看屏幕。走路、爬山、开车时都能用。
+
+## 设置方法（5 分钟）
+
+### 前置条件
+
+- 开启 Siri 的 iPhone
+- AirPods（或任何支持 Siri 的耳机）
+- MetaBot 服务器可从外网访问（公网 IP + 9100 端口开放）
+- MetaBot `.env` 中的 `API_SECRET`
+
+### 第 1 步：创建快捷指令
+
+打开 iPhone **快捷指令** App → 右上角 **+** → 命名为 **Jarvis**
+
+### 第 2 步：添加「听写文本」
+
+搜索添加 **听写文本** 动作：
+- **语言**：中文（中国）
+- **停止聆听**：暂停之后
+
+### 第 3 步：添加「获取 URL 内容」
+
+搜索添加 **获取 URL 内容** 动作：
+
+- **URL**：`http://你的服务器IP:9100/api/talk`
+- **方法**：`POST`
+- **头部**：
+  - `Authorization` = `Bearer 你的API_SECRET`
+  - `Content-Type` = `application/json`
+- **请求体**：`JSON`
+  - `botName` → `quanwang`（文本，或你想对话的 bot 名）
+  - `chatId` → `voice_jarvis`（文本，用于保持会话连续性）
+  - `prompt` → 选择上一步的 **听写的文本** 变量
+
+> **注意**：URL 字段填固定地址，不要把「听写的文本」放进 URL 里。「听写的文本」只放在请求体的 `prompt` 字段。
+
+### 第 4 步：添加「获取词典值」
+
+搜索添加 **获取词典值** 动作：
+- 获取 `responseText` 的 **值**
+- 从：**URL 的内容**（上一步结果）
+
+### 第 5 步：添加「朗读文本」
+
+搜索添加 **朗读文本** 动作：
+- 输入选择上一步的 **词典值**
+
+### 第 6 步：测试
+
+1. 戴上 AirPods
+2. 说 **"Hey Siri, Jarvis"**
+3. 等待听写提示，说出你的指令
+4. 等几秒 — 回复会通过耳机播放
+
+## 使用技巧
+
+### 跟不同的 Bot 对话
+
+创建多个快捷指令，设置不同的 `botName`：
+- **"Hey Siri, Jarvis"** → `quanwang`（通用助手）
+- **"Hey Siri, Goku"** → `goku`（运动控制专家）
+- **"Hey Siri, 后端"** → `backend-bot`（后端开发）
+
+### 持久会话
+
+`chatId`（`voice_jarvis`）创建持久的 Claude 会话，和飞书聊天一样。多轮对话有效 — Agent 记得上下文。
+
+不同场景用不同的 `chatId`：
+- `voice_jarvis` — 日常任务
+- `voice_code_review` — 代码审查
+- `voice_research` — 调研任务
+
+### 远程 Peer
+
+如果 Bot 在远程 Peer 实例上，使用限定名语法：
+- `botName` = `lanqi/some-bot` — 自动路由到 `lanqi` peer
+
+### 飞书卡片同步
+
+在 JSON 请求体中加 `sendCards` = `true`（布尔值），回复会同时发送到飞书聊天卡片。适合代码等需要稍后阅读的内容。
+
+## 限制
+
+- 每次交互需要重新说 "Hey Siri, Jarvis"（无法持续对话循环）
+- Siri 听写对很长的语音输入可能截断
+- 长回复（代码、详细分析）更适合在飞书中阅读
+- 需要网络连接（Siri STT + MetaBot API）
+
+## 安全
+
+- API 端点通过 `API_SECRET`（Bearer token）保护
+- 生产环境建议用 HTTPS（反向代理 + Let's Encrypt）
+- `chatId` 固定在快捷指令中，有手机权限即可使用


### PR DESCRIPTION
## Summary
- Added `docs/features/voice-jarvis.md` and `.zh.md` — step-by-step guide to set up iOS Siri Shortcuts for hands-free voice control of MetaBot agents via AirPods
- Updated README.md and README_zh.md "What You Can Build" sections with voice assistant use case

## How it works
1. "Hey Siri, Jarvis" → triggers iOS Shortcut
2. Siri dictates voice to text
3. Shortcut POSTs text to MetaBot `/api/talk`
4. Agent executes (Claude Code)
5. Response spoken back through AirPods

No app development, no server changes. Uses existing `/api/talk` endpoint.

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Docs render correctly (verified content)
- [x] Tested API endpoint accessibility from public IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)