### PR TITLE
Add Docker support with multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules/
+web/node_modules/
+dist/
+.env
+bots.json
+data/
+logs/
+site/
+.git/
+.claude/
+*.log
+nohup.out
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# ---- Build stage ----
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+# Install build dependencies for native modules (better-sqlite3)
+RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
+
+# Install backend dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Install web dependencies
+COPY web/package.json web/package-lock.json ./web/
+RUN cd web && npm ci --include=dev
+
+# Copy source and build
+COPY tsconfig.json ./
+COPY src/ ./src/
+COPY web/ ./web/
+
+RUN npm run build
+
+# ---- Runtime stage ----
+FROM node:20-slim
+
+WORKDIR /app
+
+# Install runtime deps for better-sqlite3 and Claude CLI
+RUN apt-get update && apt-get install -y python3 make g++ git curl && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI
+RUN npm install -g @anthropic-ai/claude-code
+
+# Install production dependencies (rebuilds native modules for this stage)
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy built output from builder
+COPY --from=builder /app/dist ./dist
+
+# Copy supporting files
+COPY bin/ ./bin/
+COPY .env.example ./
+
+# Default environment
+ENV NODE_ENV=production
+ENV API_PORT=9100
+
+EXPOSE 9100
+
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  metabot:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "${API_PORT:-9100}:9100"
+    env_file: .env
+    environment:
+      - META_MEMORY_URL=http://localhost:8100
+      - MEMORY_ENABLED=true
+      - MEMORY_PORT=8100
+      - MEMORY_DATABASE_DIR=/app/data
+    volumes:
+      # Persist MetaMemory database
+      - metabot-data:/app/data
+      # Persist Claude auth (run `claude login` inside container first)
+      - claude-config:/root/.claude
+      # Mount working directory for Claude to operate on
+      - ${CLAUDE_DEFAULT_WORKING_DIRECTORY:-.}:/workspace
+    working_dir: /app
+
+volumes:
+  metabot-data:
+  claude-config:


### PR DESCRIPTION
## Summary

- Adds Dockerfile with multi-stage build (deps → build → runtime) for optimized image size
- Adds docker-compose.yml for easy one-command deployment
- Adds .dockerignore to exclude unnecessary files from build context

## Test plan

- [ ] `docker build -t metabot .` succeeds
- [ ] `docker compose up` starts the service correctly
- [ ] Container runs with proper env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)