### PR TITLE
Fix /stop command failing to interrupt running tasks

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -105,7 +105,9 @@ export class MessageBridge {
     if (task.questionTimeoutId) clearTimeout(task.questionTimeoutId);
     task.executionHandle.finish();
     task.abortController.abort();
-    this.runningTasks.delete(chatId);
+    // Don't delete from runningTasks here — the finally block in executeQuery will
+    // handle cleanup. Deleting early creates a race: if the user sends a new message
+    // before the old loop exits, the old finally block would delete the NEW task entry.
   }
 
   private processQueue(chatId: string): void {
@@ -404,10 +406,14 @@ export class MessageBridge {
           break;
         }
 
-        // Throttled card update for non-final states
-        rateLimiter.schedule(() => {
-          this.sender.updateCard(messageId, state);
-        });
+        // Throttled card update for non-final states (skip if aborted)
+        if (!abortController.signal.aborted) {
+          rateLimiter.schedule(() => {
+            if (!abortController.signal.aborted) {
+              this.sender.updateCard(messageId, state);
+            }
+          });
+        }
       }
 
       await rateLimiter.cancelAndWait();
@@ -452,7 +458,11 @@ export class MessageBridge {
           const newSid = processor.getSessionId();
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
           if (state.status === 'complete' || state.status === 'error') break;
-          rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
+          if (!abortController.signal.aborted) {
+            rateLimiter.schedule(() => {
+              if (!abortController.signal.aborted) this.sender.updateCard(messageId, state);
+            });
+          }
         }
         await rateLimiter.cancelAndWait();
       }
@@ -555,9 +565,12 @@ export class MessageBridge {
         clearTimeout(runningTask.questionTimeoutId);
       }
       try { executionHandle.finish(); } catch (e) { this.logger.warn({ err: e, chatId }, 'Error finishing execution handle'); }
-      this.runningTasks.delete(chatId);
-      metrics.setGauge('metabot_active_tasks', this.runningTasks.size);
-      this.processQueue(chatId);
+      // Only delete if this is still our task (guards against stopTask race condition)
+      if (this.runningTasks.get(chatId) === runningTask) {
+        this.runningTasks.delete(chatId);
+        metrics.setGauge('metabot_active_tasks', this.runningTasks.size);
+        this.processQueue(chatId);
+      }
       if (imagePath) {
         try { fs.unlinkSync(imagePath); } catch { /* ignore */ }
       }

--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -208,13 +208,33 @@ export class ClaudeExecutor {
     const logger = this.logger;
 
     async function* wrapStream(): AsyncGenerator<SDKMessage> {
+      // Race each stream.next() against the abort signal so we exit immediately on /stop
+      const abortPromise = new Promise<never>((_, reject) => {
+        if (abortController.signal.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        abortController.signal.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        }, { once: true });
+      });
+
+      const iterator = stream[Symbol.asyncIterator]();
+
       try {
-        for await (const message of stream) {
-          yield message as SDKMessage;
+        while (true) {
+          const result = await Promise.race([
+            iterator.next(),
+            abortPromise,
+          ]);
+          if (result.done) break;
+          yield result.value as SDKMessage;
         }
       } catch (err: any) {
         if (err.name === 'AbortError' || abortController.signal.aborted) {
           logger.info('Claude execution aborted');
+          // Clean up the underlying iterator (non-blocking)
+          try { iterator.return?.(undefined); } catch { /* ignore */ }
           return;
         }
         throw err;
@@ -260,13 +280,31 @@ export class ClaudeExecutor {
       options: queryOptions as any,
     });
 
+    const abortPromise = new Promise<never>((_, reject) => {
+      if (abortController.signal.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+      abortController.signal.addEventListener('abort', () => {
+        reject(new DOMException('Aborted', 'AbortError'));
+      }, { once: true });
+    });
+
+    const iterator = stream[Symbol.asyncIterator]();
+
     try {
-      for await (const message of stream) {
-        yield message as SDKMessage;
+      while (true) {
+        const result = await Promise.race([
+          iterator.next(),
+          abortPromise,
+        ]);
+        if (result.done) break;
+        yield result.value as SDKMessage;
       }
     } catch (err: any) {
       if (err.name === 'AbortError' || abortController.signal.aborted) {
         this.logger.info('Claude execution aborted');
+        try { iterator.return?.(undefined); } catch { /* ignore */ }
         return;
       }
       throw err;


### PR DESCRIPTION
## Summary
- Fix `wrapStream()` blocking on `stream.next()` by using `Promise.race` with abort signal for immediate exit
- Fix race condition in `stopTask()` where early deletion from `runningTasks` could cause new task entries to be deleted by old finally blocks
- Add abort checks before card updates to prevent stale updates after `/stop`

## Test plan
- [ ] Send a message to the bot in Feishu, then immediately send `/stop` — task should stop within 1-2 seconds
- [ ] Send `/stop` mid-execution — card should stop updating
- [ ] After `/stop`, send a new message — should work normally without interference from the stopped task

🤖 Generated with [Claude Code](https://claude.com/claude-code)