### PR TITLE
Add TTS API and mb voice docs to GitHub Pages

### DIFF
--- a/docs/features/voice-jarvis.md
+++ b/docs/features/voice-jarvis.md
@@ -234,6 +234,43 @@ Server-side STT (Doubao or Whisper) + Agent execution + optional TTS. Defaults t
 | `ELEVENLABS_API_KEY` | Required for ElevenLabs TTS |
 | `VOICE_MODEL` | Override Claude model for voice mode (optional) |
 
+### POST `/api/tts`
+
+Lightweight text-to-speech endpoint — no STT, no agent. Just text in, audio out.
+
+**Request:**
+
+```bash
+curl -X POST http://localhost:9100/api/tts \
+  -H "Authorization: Bearer YOUR_API_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello world", "provider": "doubao", "voice": "zh_female_wanqudashu_moon_bigtts"}'
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `text` | Yes | Text to convert to speech |
+| `provider` | No | `doubao`, `openai`, or `elevenlabs` (auto-selects based on available keys) |
+| `voice` | No | Voice/speaker ID (defaults per provider) |
+
+**Response:** `audio/mpeg` binary with headers:
+
+- `X-Text-Length`: original text length
+- `X-Provider`: TTS provider used
+- `X-Voice`: voice/speaker ID used
+
+**CLI shortcut:**
+
+```bash
+mb voice "Hello world"              # generate MP3, print file path
+mb voice "Hello" --play             # generate and play audio
+mb voice "Hello" -o greeting.mp3    # save to specific file
+echo "Long text" | mb voice         # read from stdin
+mb voice "Hello" --provider openai --voice nova  # override provider/voice
+```
+
+See [mb CLI — Voice](../reference/cli-mb.md#voice) for full CLI reference.
+
 ## Limitations
 
 - Each interaction requires saying "Hey Siri, Jarvis" again (no continuous conversation loop)

--- a/docs/features/voice-jarvis.zh.md
+++ b/docs/features/voice-jarvis.zh.md
@@ -238,6 +238,43 @@
 | `ELEVENLABS_API_KEY` | ElevenLabs TTS 必需 |
 | `VOICE_MODEL` | 语音模式使用的 Claude 模型（可选覆盖） |
 
+### POST `/api/tts`
+
+轻量级文字转语音端点 — 无 STT，无 Agent 执行。纯文本输入，音频输出。
+
+**请求：**
+
+```bash
+curl -X POST http://localhost:9100/api/tts \
+  -H "Authorization: Bearer YOUR_API_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "你好世界", "provider": "doubao", "voice": "zh_female_wanqudashu_moon_bigtts"}'
+```
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `text` | 是 | 要转换的文本 |
+| `provider` | 否 | `doubao`、`openai` 或 `elevenlabs`（根据已配置密钥自动选择） |
+| `voice` | 否 | 声音/音色 ID（各服务商有默认值） |
+
+**响应：** `audio/mpeg` 二进制数据，附带响应头：
+
+- `X-Text-Length`：原始文本长度
+- `X-Provider`：使用的 TTS 服务商
+- `X-Voice`：使用的声音 ID
+
+**CLI 快捷命令：**
+
+```bash
+mb voice "你好世界"                   # 生成 MP3，输出文件路径
+mb voice "你好" --play               # 生成并播放音频
+mb voice "你好" -o greeting.mp3      # 保存到指定文件
+echo "长文本" | mb voice             # 从标准输入读取
+mb voice "你好" --provider openai --voice nova  # 指定服务商/声音
+```
+
+详见 [mb CLI — 语音](../reference/cli-mb.md#语音) 完整 CLI 参考。
+
 ## 限制
 
 - 每次交互需要重新说 "Hey Siri, Jarvis"（无法持续对话循环）

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -98,6 +98,30 @@ For one-time tasks, use `delayMs` instead of `cron`:
 | `GET` | `/api/sync` | Sync status |
 | `POST` | `/api/sync/document` | Sync single document by ID |
 
+### Text-to-Speech
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/tts` | Convert text to speech (returns MP3 audio) |
+
+**Request body:**
+
+```json
+{
+  "text": "Hello world",
+  "provider": "doubao",
+  "voice": "zh_female_wanqudashu_moon_bigtts"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `text` | Yes | Text to convert to speech |
+| `provider` | No | `doubao`, `openai`, or `elevenlabs` (auto-selects based on available keys) |
+| `voice` | No | Voice/speaker ID (defaults per provider) |
+
+**Response:** `audio/mpeg` binary with headers `X-Text-Length`, `X-Provider`, `X-Voice`.
+
 ### Feishu Documents
 
 | Method | Path | Description |

--- a/docs/reference/api.zh.md
+++ b/docs/reference/api.zh.md
@@ -98,6 +98,30 @@ Authorization: Bearer <API_SECRET>
 | `GET` | `/api/sync` | 同步状态 |
 | `POST` | `/api/sync/document` | 按 ID 同步单个文档 |
 
+### 文字转语音
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `POST` | `/api/tts` | 文字转语音（返回 MP3 音频） |
+
+**请求体：**
+
+```json
+{
+  "text": "你好世界",
+  "provider": "doubao",
+  "voice": "zh_female_wanqudashu_moon_bigtts"
+}
+```
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `text` | 是 | 要转换的文本 |
+| `provider` | 否 | `doubao`、`openai` 或 `elevenlabs`（根据已配置密钥自动选择） |
+| `voice` | 否 | 声音/音色 ID（各服务商有默认值） |
+
+**响应：** `audio/mpeg` 二进制数据，附带 `X-Text-Length`、`X-Provider`、`X-Voice` 响应头。
+
 ### 飞书文档
 
 | 方法 | 路径 | 说明 |

--- a/docs/reference/cli-mb.md
+++ b/docs/reference/cli-mb.md
@@ -48,6 +48,24 @@ mb stats                            # cost & usage statistics
 mb health                           # health check
 ```
 
+### Voice
+
+```bash
+mb voice "Hello world"              # generate MP3, print file path
+mb voice "Hello" --play             # generate and play audio
+mb voice "Hello" -o greeting.mp3    # save to specific file
+echo "Long text" | mb voice         # read from stdin
+mb voice "Hello" --provider doubao  # use specific TTS provider
+mb voice "Hello" --voice nova       # use specific voice
+```
+
+| Flag | Description |
+|------|-------------|
+| `--play` | Play audio after generating (macOS: afplay, Linux: mpv/ffplay/play) |
+| `-o FILE` | Save to specific file (default: `/tmp/mb-voice-<timestamp>.mp3`) |
+| `--provider NAME` | TTS provider: `doubao`, `openai`, or `elevenlabs` |
+| `--voice ID` | Voice/speaker ID (provider-specific) |
+
 ### Management
 
 ```bash

--- a/docs/reference/cli-mb.zh.md
+++ b/docs/reference/cli-mb.zh.md
@@ -48,6 +48,24 @@ mb stats                            # 费用与使用统计
 mb health                           # 健康检查
 ```
 
+### 语音
+
+```bash
+mb voice "你好世界"                   # 生成 MP3，输出文件路径
+mb voice "你好" --play               # 生成并播放音频
+mb voice "你好" -o greeting.mp3      # 保存到指定文件
+echo "长文本" | mb voice             # 从标准输入读取
+mb voice "你好" --provider doubao    # 指定 TTS 服务商
+mb voice "你好" --voice nova         # 指定声音
+```
+
+| 参数 | 说明 |
+|------|------|
+| `--play` | 生成后播放（macOS: afplay, Linux: mpv/ffplay/play） |
+| `-o FILE` | 保存到指定文件（默认: `/tmp/mb-voice-<时间戳>.mp3`） |
+| `--provider NAME` | TTS 服务商: `doubao`、`openai`、`elevenlabs` |
+| `--voice ID` | 声音/音色 ID（各服务商不同） |
+
 ### 管理
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `POST /api/tts` endpoint docs to Voice Assistant page (EN + ZH)
- Add `mb voice` CLI section to mb CLI reference page (EN + ZH)
- Add Text-to-Speech section to REST API reference (EN + ZH)

Follows PR #104 which added the actual implementation.

## Test plan
- [ ] Verify docs render correctly on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)