### PR TITLE
feat: show model, token usage and context % in completion notice

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -1075,8 +1075,30 @@ export class MessageBridge {
       ? `${(durationMs / 60_000).toFixed(1)}min`
       : `${(durationMs / 1000).toFixed(0)}s`;
     const costStr = state.costUsd ? ` · $${state.costUsd.toFixed(2)}` : '';
-    const statusWord = state.status === 'complete' ? 'Task completed' : 'Task failed';
-    const message = `${statusEmoji} ${statusWord} (${durationStr}${costStr})`;
+    const statusWord = state.status === 'complete' ? 'Done' : 'Failed';
+
+    // Model display name: strip "claude-" prefix for brevity (e.g. "opus-4-6")
+    const modelStr = state.model
+      ? ` · ${state.model.replace(/^claude-/, '')}`
+      : '';
+
+    // Context usage: show totalTokens / contextWindow as percentage
+    let usageStr = '';
+    if (state.totalTokens && state.contextWindow) {
+      const pct = Math.round((state.totalTokens / state.contextWindow) * 100);
+      const tokensK = state.totalTokens >= 1000
+        ? `${(state.totalTokens / 1000).toFixed(1)}k`
+        : `${state.totalTokens}`;
+      const ctxK = `${Math.round(state.contextWindow / 1000)}k`;
+      usageStr = ` · ${tokensK}/${ctxK} (${pct}%)`;
+    } else if (state.totalTokens) {
+      const tokensK = state.totalTokens >= 1000
+        ? `${(state.totalTokens / 1000).toFixed(1)}k`
+        : `${state.totalTokens}`;
+      usageStr = ` · ${tokensK} tokens`;
+    }
+
+    const message = `${statusEmoji} ${statusWord} (${durationStr}${costStr}${modelStr}${usageStr})`;
 
     try {
       await this.sender.sendText(chatId, message);

--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -89,6 +89,8 @@ export type SDKMessage = {
   is_error?: boolean;
   num_turns?: number;
   errors?: string[];
+  // Model usage from result message (per-model breakdown)
+  modelUsage?: Record<string, { inputTokens: number; outputTokens: number; contextWindow: number; costUSD: number }>;
   // Stream event fields
   event?: {
     type: string;

--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -27,6 +27,9 @@ export class StreamProcessor {
   private _pendingQuestion: PendingQuestion | null = null;
   private _sdkHandledTools: DetectedTool[] = [];
   private _planFilePath: string | null = null;
+  private _model: string | undefined;
+  private _totalTokens: number | undefined;
+  private _contextWindow: number | undefined;
 
   constructor(private userPrompt: string) {}
 
@@ -133,6 +136,26 @@ export class StreamProcessor {
     this.costUsd = message.total_cost_usd;
     this.durationMs = message.duration_ms;
 
+    // Extract model usage info (per-model breakdown from SDK)
+    if (message.modelUsage) {
+      const models = Object.keys(message.modelUsage);
+      if (models.length > 0) {
+        // Primary model is the one with highest cost
+        const primaryModel = models.reduce((a, b) =>
+          (message.modelUsage![a].costUSD ?? 0) >= (message.modelUsage![b].costUSD ?? 0) ? a : b
+        );
+        const mu = message.modelUsage[primaryModel];
+        this._model = primaryModel;
+        this._contextWindow = mu.contextWindow;
+        // Sum tokens across all models
+        let totalTokens = 0;
+        for (const m of models) {
+          totalTokens += (message.modelUsage![m].inputTokens ?? 0) + (message.modelUsage![m].outputTokens ?? 0);
+        }
+        this._totalTokens = totalTokens;
+      }
+    }
+
     // Mark all tools as done
     for (const tool of this.toolCalls) {
       tool.status = 'done';
@@ -153,6 +176,9 @@ export class StreamProcessor {
       errorMessage: isError
         ? (message.errors?.join('; ') || `Ended with: ${message.subtype}`)
         : isApiError ? resultText : undefined,
+      model: this._model,
+      totalTokens: this._totalTokens,
+      contextWindow: this._contextWindow,
     };
   }
 

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -83,8 +83,22 @@ export function buildCard(state: CardState): string {
   // Stats note
   if (state.status === 'complete' || state.status === 'error') {
     const parts: string[] = [];
+    if (state.model) {
+      parts.push(state.model.replace(/^claude-/, ''));
+    }
     if (state.durationMs !== undefined) {
-      parts.push(`Duration: ${(state.durationMs / 1000).toFixed(1)}s`);
+      parts.push(`${(state.durationMs / 1000).toFixed(1)}s`);
+    }
+    if (state.costUsd !== undefined) {
+      parts.push(`$${state.costUsd.toFixed(2)}`);
+    }
+    if (state.totalTokens && state.contextWindow) {
+      const pct = Math.round((state.totalTokens / state.contextWindow) * 100);
+      const tokensK = state.totalTokens >= 1000
+        ? `${(state.totalTokens / 1000).toFixed(1)}k`
+        : `${state.totalTokens}`;
+      const ctxK = `${Math.round(state.contextWindow / 1000)}k`;
+      parts.push(`${tokensK}/${ctxK} (${pct}%)`);
     }
     if (parts.length > 0) {
       elements.push({

--- a/src/telegram/telegram-sender.ts
+++ b/src/telegram/telegram-sender.ts
@@ -79,8 +79,22 @@ function renderCardHtml(state: CardState): string {
   // Stats
   if (state.status === 'complete' || state.status === 'error') {
     const statParts: string[] = [];
+    if (state.model) {
+      statParts.push(state.model.replace(/^claude-/, ''));
+    }
     if (state.durationMs !== undefined) {
-      statParts.push(`Duration: ${(state.durationMs / 1000).toFixed(1)}s`);
+      statParts.push(`${(state.durationMs / 1000).toFixed(1)}s`);
+    }
+    if (state.costUsd !== undefined) {
+      statParts.push(`$${state.costUsd.toFixed(2)}`);
+    }
+    if (state.totalTokens && state.contextWindow) {
+      const pct = Math.round((state.totalTokens / state.contextWindow) * 100);
+      const tokensK = state.totalTokens >= 1000
+        ? `${(state.totalTokens / 1000).toFixed(1)}k`
+        : `${state.totalTokens}`;
+      const ctxK = `${Math.round(state.contextWindow / 1000)}k`;
+      statParts.push(`${tokensK}/${ctxK} (${pct}%)`);
     }
     if (statParts.length > 0) {
       parts.push('');

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,12 @@ export interface CardState {
   durationMs?: number;
   errorMessage?: string;
   pendingQuestion?: PendingQuestion;
+  /** Primary model used (e.g. "claude-opus-4-6") */
+  model?: string;
+  /** Total input+output tokens consumed */
+  totalTokens?: number;
+  /** Context window size of the primary model */
+  contextWindow?: number;
 }
 
 export interface IncomingMessage {


### PR DESCRIPTION
## Summary
- Replace generic "Task completed (25s · $0.10)" with richer info: "Done (25s · $0.10 · opus-4-6 · 15.2k/200k (8%))"
- Show model name, cost, token usage and context window % in Feishu card and Telegram stats
- Extract `modelUsage` from Claude Agent SDK result messages

## Test plan
- [ ] Deploy and trigger a task, verify completion notice shows model + usage
- [ ] Check Feishu card footer shows the new stats
- [ ] Verify Telegram message stats updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)