### PR TITLE
feat: cache group chat media for later @mention retrieval

### DIFF
--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -13,6 +13,40 @@ export type MessageHandler = (msg: IncomingMessage) => void;
 const MEMBER_COUNT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const memberCountCache = new Map<string, { count: number; ts: number }>();
 
+// Cache for recent media messages in group chats (file/image sent without @mention).
+// When a user later @mentions the bot, cached media is attached automatically.
+const MEDIA_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+interface CachedMedia {
+  messageId: string;
+  imageKey?: string;
+  fileKey?: string;
+  fileName?: string;
+  ts: number;
+}
+const pendingMediaCache = new Map<string, CachedMedia[]>(); // key: chatId:userId
+
+function cacheMediaKey(chatId: string, userId: string): string {
+  return `${chatId}:${userId}`;
+}
+
+function getCachedMedia(chatId: string, userId: string): CachedMedia[] {
+  const key = cacheMediaKey(chatId, userId);
+  const items = pendingMediaCache.get(key);
+  if (!items) return [];
+  const now = Date.now();
+  const valid = items.filter(m => now - m.ts < MEDIA_CACHE_TTL_MS);
+  if (valid.length === 0) {
+    pendingMediaCache.delete(key);
+    return [];
+  }
+  pendingMediaCache.set(key, valid);
+  return valid;
+}
+
+function clearCachedMedia(chatId: string, userId: string): void {
+  pendingMediaCache.delete(cacheMediaKey(chatId, userId));
+}
+
 async function isPrivateLikeGroup(chatId: string, sender: MessageSender): Promise<boolean> {
   const cached = memberCountCache.get(chatId);
   if (cached && Date.now() - cached.ts < MEMBER_COUNT_CACHE_TTL_MS) {
@@ -71,6 +105,17 @@ export function createEventDispatcher(
             // Check if this is a private-like group (only 2 members)
             if (messageSender && await isPrivateLikeGroup(chatId, messageSender)) {
               logger.debug({ chatId }, 'Private-like group (2 members), processing without @mention');
+            } else if (msgType === 'image' || msgType === 'file') {
+              // Cache media messages for later retrieval when user @mentions bot
+              const media = parseMediaMessage(message, msgType, logger);
+              if (media) {
+                const key = cacheMediaKey(chatId, userId);
+                const items = pendingMediaCache.get(key) || [];
+                items.push({ ...media, messageId, ts: Date.now() });
+                pendingMediaCache.set(key, items);
+                logger.info({ chatId, userId, msgType, ...media }, 'Cached group media for later @mention');
+              }
+              return;
             } else {
               logger.debug('Ignoring group message without @mention');
               return;
@@ -158,7 +203,23 @@ export function createEventDispatcher(
           logger.info({ userId, chatId, chatType, text: text.slice(0, 100), imageKey }, 'Received message');
         }
 
-        onMessage({ messageId, chatId, chatType, userId, text, imageKey, fileKey, fileName });
+        // In group chats, attach any cached media from this user
+        let extraMedia: IncomingMessage['extraMedia'];
+        if (chatType === 'group') {
+          const cached = getCachedMedia(chatId, userId);
+          if (cached.length > 0) {
+            extraMedia = cached.map(m => ({
+              messageId: m.messageId,
+              imageKey: m.imageKey,
+              fileKey: m.fileKey,
+              fileName: m.fileName,
+            }));
+            clearCachedMedia(chatId, userId);
+            logger.info({ chatId, userId, mediaCount: cached.length }, 'Attached cached media to @mention message');
+          }
+        }
+
+        onMessage({ messageId, chatId, chatType, userId, text, imageKey, fileKey, fileName, extraMedia });
       } catch (err) {
         logger.error({ err }, 'Error handling message event');
       }
@@ -166,6 +227,27 @@ export function createEventDispatcher(
   });
 
   return dispatcher;
+}
+
+/** Parse image/file message content, returning media fields or undefined on failure. */
+function parseMediaMessage(
+  message: any, msgType: string, logger: Logger,
+): { imageKey?: string; fileKey?: string; fileName?: string } | undefined {
+  try {
+    const content = JSON.parse(message.content);
+    if (msgType === 'image') {
+      const imageKey = content.image_key;
+      return imageKey ? { imageKey } : undefined;
+    }
+    if (msgType === 'file') {
+      const fileKey = content.file_key;
+      const fileName = content.file_name;
+      return (fileKey && fileName) ? { fileKey, fileName } : undefined;
+    }
+  } catch {
+    logger.warn({ msgType }, 'Failed to parse media message for caching');
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- In Feishu group chats, file/image messages can't include @mention (especially on mobile)
- Now media messages without @mention are cached per user for 5 minutes
- When the user later @mentions the bot, cached media is automatically attached via `extraMedia`
- Enables "upload first, @bot later" workflow

## Test plan
- [ ] In group chat: upload a file without @mention, then @bot "分析一下" → should process the file
- [ ] Verify regular @mention without prior upload still works
- [ ] Upload file, wait >5 min, @bot → file should NOT be attached (TTL expired)
- [ ] Multiple files cached then @bot → all files attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)