### PR TITLE
feat: make lark-cli skills optional during install

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -195,49 +195,10 @@ print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'cronExpr': sys
       echo "    Removed legacy: feishu-doc"
     fi
 
-    # Detect Feishu bots and install/update lark-cli skills
-    has_feishu=false
-    if [[ -f "$METABOT_SRC/bots.json" ]] && command -v node &>/dev/null; then
-      if node -e "const c=JSON.parse(require('fs').readFileSync('$METABOT_SRC/bots.json','utf-8')); process.exit((c.feishuBots||[]).length>0?0:1)" 2>/dev/null; then
-        has_feishu=true
-      fi
-    fi
-
-    if [[ "$has_feishu" == "true" ]]; then
-      # Install lark-cli if not present
-      if ! command -v lark-cli &>/dev/null; then
-        echo "    Installing lark-cli..."
-        if npm install -g @larksuite/cli 2>/dev/null; then
-          echo "    lark-cli installed globally"
-        else
-          mkdir -p "$HOME/.npm-global"
-          npm config set prefix "$HOME/.npm-global" 2>/dev/null || true
-          npm install -g @larksuite/cli 2>/dev/null && \
-            echo "    lark-cli installed to ~/.npm-global/bin" || \
-            echo "    lark-cli install failed — run: npm install -g @larksuite/cli"
-          if ! echo "$PATH" | grep -q "$HOME/.npm-global/bin"; then
-            export PATH="$HOME/.npm-global/bin:$PATH"
-          fi
-        fi
-      fi
-
-      # Configure lark-cli if not configured
-      if [[ ! -f "$HOME/.lark-cli/config.json" && -f "$METABOT_SRC/bots.json" ]]; then
-        app_id=$(node -e "const c=JSON.parse(require('fs').readFileSync('$METABOT_SRC/bots.json','utf-8')); console.log((c.feishuBots||[])[0]?.feishuAppId||'')" 2>/dev/null)
-        app_secret=$(node -e "const c=JSON.parse(require('fs').readFileSync('$METABOT_SRC/bots.json','utf-8')); console.log((c.feishuBots||[])[0]?.feishuAppSecret||'')" 2>/dev/null)
-        if [[ -n "${app_id:-}" && -n "${app_secret:-}" ]]; then
-          echo "$app_secret" | lark-cli config init --app-id "$app_id" --app-secret-stdin --brand feishu 2>/dev/null && \
-            echo "    lark-cli configured" || true
-        fi
-      fi
-
-      # Install lark-cli AI Agent skills if missing
-      if [[ ! -d "$SKILLS_DIR/lark-doc" ]]; then
-        echo "    Installing lark-cli AI Agent skills..."
-        npx skills add larksuite/cli --all -y -g 2>/dev/null && \
-          echo "    lark-cli skills installed" || \
-          echo "    lark-cli skills failed — run: npx skills add larksuite/cli --all -y -g"
-      fi
+    # Check if lark-cli skills were previously installed (opt-in via install.sh)
+    has_lark_skills=false
+    if [[ -d "$SKILLS_DIR/lark-doc" ]]; then
+      has_lark_skills=true
     fi
 
     # Update workspace skills if bots.json exists
@@ -256,8 +217,8 @@ print(json.dumps({'botName': sys.argv[1], 'chatId': sys.argv[2], 'cronExpr': sys
             cp -r "$SKILLS_DIR/$skill/." "$ws_skills_dir/$skill/"
           fi
         done
-        # Copy lark-cli skills for Feishu
-        if [[ "${has_feishu:-false}" == "true" ]]; then
+        # Copy lark-cli skills if previously installed
+        if [[ "${has_lark_skills:-false}" == "true" ]]; then
           for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
             if [[ -d "$SKILLS_DIR/$lark_skill" ]]; then
               mkdir -p "$ws_skills_dir/$lark_skill"

--- a/bin/metabot
+++ b/bin/metabot
@@ -86,57 +86,10 @@ cmd_update() {
     info "Removed legacy feishu-doc skill"
   fi
 
-  # Detect Feishu bots and install/update lark-cli skills
-  local has_feishu=false
-  if [[ -f "$METABOT_HOME/bots.json" ]] && command -v node &>/dev/null; then
-    if node -e "const c=JSON.parse(require('fs').readFileSync('$METABOT_HOME/bots.json','utf-8')); process.exit((c.feishuBots||[]).length>0?0:1)" 2>/dev/null; then
-      has_feishu=true
-    fi
-  fi
-
-  if [[ "$has_feishu" == "true" ]]; then
-    # Install/update lark-cli if not present
-    if ! command -v lark-cli &>/dev/null; then
-      info "Installing lark-cli..."
-      if npm install -g @larksuite/cli 2>/dev/null; then
-        success "lark-cli installed globally"
-      else
-        mkdir -p "$HOME/.npm-global"
-        npm config set prefix "$HOME/.npm-global" 2>/dev/null || true
-        npm install -g @larksuite/cli 2>/dev/null && \
-          success "lark-cli installed to ~/.npm-global/bin" || \
-          error "lark-cli install failed — run manually: npm install -g @larksuite/cli"
-        if ! echo "$PATH" | grep -q "$HOME/.npm-global/bin"; then
-          export PATH="$HOME/.npm-global/bin:$PATH"
-        fi
-      fi
-    fi
-
-    # Configure lark-cli if not configured
-    if [[ ! -f "$HOME/.lark-cli/config.json" && -f "$METABOT_HOME/bots.json" ]]; then
-      local app_id app_secret
-      app_id=$(node -e "const c=JSON.parse(require('fs').readFileSync('$METABOT_HOME/bots.json','utf-8')); console.log((c.feishuBots||[])[0]?.feishuAppId||'')" 2>/dev/null)
-      app_secret=$(node -e "const c=JSON.parse(require('fs').readFileSync('$METABOT_HOME/bots.json','utf-8')); console.log((c.feishuBots||[])[0]?.feishuAppSecret||'')" 2>/dev/null)
-      if [[ -n "$app_id" && -n "$app_secret" ]]; then
-        echo "$app_secret" | lark-cli config init --app-id "$app_id" --app-secret-stdin --brand feishu 2>/dev/null && \
-          success "lark-cli configured with app $app_id" || \
-          info "lark-cli config skipped (run manually: lark-cli config init)"
-      fi
-    fi
-
-    # Install/update lark-cli AI Agent skills
-    local lark_skills_missing=false
-    if [[ ! -d "$SKILLS_DIR/lark-doc" ]]; then
-      lark_skills_missing=true
-    fi
-    if [[ "$lark_skills_missing" == "true" ]]; then
-      info "Installing lark-cli AI Agent skills..."
-      if npx skills add larksuite/cli --all -y -g 2>/dev/null; then
-        success "lark-cli AI Agent skills installed"
-      else
-        info "lark-cli skills install failed — run manually: npx skills add larksuite/cli --all -y -g"
-      fi
-    fi
+  # Update lark-cli skills only if previously installed (opt-in via install.sh)
+  local has_lark_skills=false
+  if [[ -d "$SKILLS_DIR/lark-doc" ]]; then
+    has_lark_skills=true
   fi
   success "Skills updated"
 
@@ -159,8 +112,8 @@ cmd_update() {
           cp -r "$SKILLS_DIR/$skill/." "$ws_skills_dir/$skill/"
         fi
       done
-      # Copy lark-cli skills for Feishu
-      if [[ "$has_feishu" == "true" ]]; then
+      # Copy lark-cli skills if previously installed
+      if [[ "$has_lark_skills" == "true" ]]; then
         for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
           if [[ -d "$SKILLS_DIR/$lark_skill" ]]; then
             mkdir -p "$ws_skills_dir/$lark_skill"

--- a/install.sh
+++ b/install.sh
@@ -604,7 +604,16 @@ elif [[ "$SKIP_CONFIG" == "true" && -f "$METABOT_HOME/bots.json" ]]; then
 fi
 
 # Install lark-cli and AI Agent skills — only when Feishu is configured
+SETUP_LARK_CLI=false
 if [[ "$HAS_FEISHU" == "true" ]]; then
+  echo ""
+  info "lark-cli provides 19 AI Agent skills for Feishu (docs, sheets, calendar, IM, etc.)"
+  if prompt_yn "Install lark-cli and Feishu AI Agent skills?" "y"; then
+    SETUP_LARK_CLI=true
+  fi
+fi
+
+if [[ "$SETUP_LARK_CLI" == "true" ]]; then
   info "Installing lark-cli (Feishu official CLI)..."
   if command -v lark-cli &>/dev/null; then
     success "lark-cli already installed ($(lark-cli --version 2>/dev/null || echo 'unknown'))"
@@ -644,12 +653,12 @@ if [[ "$HAS_FEISHU" == "true" ]]; then
   else
     warn "lark-cli skills install failed — you can run manually: npx skills add larksuite/cli --all -y -g"
   fi
+fi
 
-  # Clean up old feishu-doc skill if present
-  if [[ -d "$SKILLS_DIR/feishu-doc" ]]; then
-    rm -rf "$SKILLS_DIR/feishu-doc"
-    info "Removed legacy feishu-doc skill (replaced by lark-cli skills)"
-  fi
+# Clean up old feishu-doc skill if present
+if [[ -d "$SKILLS_DIR/feishu-doc" ]]; then
+  rm -rf "$SKILLS_DIR/feishu-doc"
+  info "Removed legacy feishu-doc skill (replaced by lark-cli skills)"
 fi
 
 # Determine working directory
@@ -674,7 +683,7 @@ if [[ -n "${DEPLOY_WORK_DIR:-}" ]]; then
 
   # Copy skills (common + lark-cli skills if Feishu)
   DEPLOY_SKILLS="metaskill metamemory metabot voice"
-  if [[ "$HAS_FEISHU" == "true" ]]; then
+  if [[ "$SETUP_LARK_CLI" == "true" ]]; then
     for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
       [[ -d "$SKILLS_DIR/$lark_skill" ]] && DEPLOY_SKILLS="$DEPLOY_SKILLS $lark_skill"
     done


### PR DESCRIPTION
## Summary
- Install 时增加交互式选择：检测到飞书 bot 后询问是否安装 lark-cli + 19 个 AI Agent skills
- Update 时不再强制安装 lark-cli，只在之前已安装（`lark-doc` 目录存在）时更新
- 简化了 update 逻辑，去掉了 Feishu bot 检测 + lark-cli 安装/配置代码

## Test plan
- [ ] Fresh install with Feishu → prompted to install lark-cli, answer Y → skills installed
- [ ] Fresh install with Feishu → answer N → lark-cli skipped, common skills still installed
- [ ] `metabot update` with lark-cli previously installed → skills updated to workspace
- [ ] `metabot update` without lark-cli → no lark-cli install attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)