### PR TITLE
fix: cc-switch compatibility for auth mode switching

### DIFF
--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -22,35 +22,53 @@ function resolveClaudePath(): string {
 const CLAUDE_EXECUTABLE = resolveClaudePath();
 
 /**
- * Custom spawn function for cross-platform compatibility.
- * - Uses process.execPath (current Node binary) to avoid PATH issues on Windows.
- * - Filters CLAUDE* env vars to prevent "nested session" errors.
- * - Merges process.env so child inherits system PATH, TEMP, etc.
+ * Env var prefixes to strip from the inherited process environment.
+ * - CLAUDE*: prevents "nested session" errors from the SDK.
+ * - ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN: ensures the child Claude Code
+ *   process resolves auth from ~/.claude/.credentials.json (written by
+ *   `cc switch`, `claude /login`, etc.) rather than stale PM2 env vars.
+ *   Users who need a fixed API key can set `apiKey` in bots.json instead.
  */
-function customSpawn(options: SpawnOptions): SpawnedProcess {
-  const nodePath = process.execPath;
+const FILTERED_ENV_PREFIXES = ['CLAUDE', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'];
 
-  // Merge provided env with process.env for a complete environment
-  const baseEnv = options.env && Object.keys(options.env).length > 0
-    ? { ...process.env, ...options.env }
-    : { ...process.env };
+/**
+ * Create a custom spawn function for cross-platform compatibility.
+ * - Uses process.execPath (current Node binary) to avoid PATH issues on Windows.
+ * - Filters CLAUDE* and ANTHROPIC auth env vars (see above).
+ * - Merges process.env so child inherits system PATH, TEMP, etc.
+ * - Optionally injects an explicit ANTHROPIC_API_KEY from bots.json config.
+ */
+function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => SpawnedProcess {
+  return (options: SpawnOptions): SpawnedProcess => {
+    const nodePath = process.execPath;
 
-  // Filter out CLAUDE* vars to avoid nested session detection
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(baseEnv)) {
-    if (!key.startsWith('CLAUDE') && value !== undefined) {
-      env[key] = value;
+    // Merge provided env with process.env for a complete environment
+    const baseEnv = options.env && Object.keys(options.env).length > 0
+      ? { ...process.env, ...options.env }
+      : { ...process.env };
+
+    // Filter out env vars that interfere with auth or cause nested session errors
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(baseEnv)) {
+      if (value !== undefined && !FILTERED_ENV_PREFIXES.some(p => key.startsWith(p))) {
+        env[key] = value;
+      }
     }
-  }
 
-  const child = spawn(nodePath, options.args, {
-    cwd: options.cwd,
-    env,
-    signal: options.signal,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
+    // Inject explicit API key from bots.json (after filtering, so it takes effect)
+    if (explicitApiKey) {
+      env.ANTHROPIC_API_KEY = explicitApiKey;
+    }
 
-  return child as unknown as SpawnedProcess;
+    const child = spawn(nodePath, options.args, {
+      cwd: options.cwd,
+      env,
+      signal: options.signal,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    return child as unknown as SpawnedProcess;
+  };
 }
 
 export interface ApiContext {
@@ -133,7 +151,7 @@ export class ClaudeExecutor {
       // Cross-platform spawn: custom spawn filters CLAUDE* env vars and uses
       // process.execPath to avoid PATH issues on Windows; fileURLToPath converts
       // file:// URLs to native paths for the SDK CLI entrypoint.
-      spawnClaudeCodeProcess: customSpawn,
+      spawnClaudeCodeProcess: createSpawnFn(this.config.claude.apiKey),
       executableArgs: [fileURLToPath(import.meta.resolve('@anthropic-ai/claude-agent-sdk/cli.js'))],
       pathToClaudeCodeExecutable: CLAUDE_EXECUTABLE,
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,10 @@ export interface BotConfigBase {
     maxTurns: number | undefined;
     maxBudgetUsd: number | undefined;
     model: string | undefined;
+    /** Explicit Anthropic API key. When set, child Claude Code processes use this
+     *  key instead of ~/.claude/.credentials.json. Supports cc-switch compatibility:
+     *  leave unset to let Claude Code resolve auth dynamically. */
+    apiKey: string | undefined;
     outputsBaseDir: string;
     downloadsDir: string;
   };
@@ -94,6 +98,7 @@ export interface FeishuBotJsonEntry {
   maxTurns?: number;
   maxBudgetUsd?: number;
   model?: string;
+  apiKey?: string;
   outputsBaseDir?: string;
   downloadsDir?: string;
 }
@@ -120,6 +125,7 @@ export interface TelegramBotJsonEntry {
   maxTurns?: number;
   maxBudgetUsd?: number;
   model?: string;
+  apiKey?: string;
   outputsBaseDir?: string;
   downloadsDir?: string;
 }
@@ -146,6 +152,7 @@ export interface WechatBotJsonEntry {
   maxTurns?: number;
   maxBudgetUsd?: number;
   model?: string;
+  apiKey?: string;
   outputsBaseDir?: string;
   downloadsDir?: string;
 }
@@ -169,6 +176,7 @@ function buildClaudeConfig(entry: {
   maxTurns?: number;
   maxBudgetUsd?: number;
   model?: string;
+  apiKey?: string;
   outputsBaseDir?: string;
   downloadsDir?: string;
 }): BotConfigBase['claude'] {
@@ -177,6 +185,7 @@ function buildClaudeConfig(entry: {
     maxTurns: entry.maxTurns ?? (process.env.CLAUDE_MAX_TURNS ? parseInt(process.env.CLAUDE_MAX_TURNS, 10) : undefined),
     maxBudgetUsd: entry.maxBudgetUsd ?? (process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined),
     model: entry.model || process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || 'claude-opus-4-6',
+    apiKey: entry.apiKey || undefined,
     outputsBaseDir: entry.outputsBaseDir || process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), 'metabot-outputs'),
     downloadsDir: entry.downloadsDir || process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
   };
@@ -196,6 +205,7 @@ function feishuBotFromEnv(): BotConfig {
       maxTurns: process.env.CLAUDE_MAX_TURNS ? parseInt(process.env.CLAUDE_MAX_TURNS, 10) : undefined,
       maxBudgetUsd: process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined,
       model: process.env.CLAUDE_MODEL || 'claude-opus-4-6',
+      apiKey: undefined,
       outputsBaseDir: process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), 'metabot-outputs'),
       downloadsDir: process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
     },
@@ -213,6 +223,7 @@ function telegramBotFromEnv(): TelegramBotConfig {
       maxTurns: process.env.CLAUDE_MAX_TURNS ? parseInt(process.env.CLAUDE_MAX_TURNS, 10) : undefined,
       maxBudgetUsd: process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined,
       model: process.env.CLAUDE_MODEL || 'claude-opus-4-6',
+      apiKey: undefined,
       outputsBaseDir: process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), 'metabot-outputs'),
       downloadsDir: process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
     },
@@ -230,6 +241,7 @@ function wechatBotFromEnv(): WechatBotConfig {
       maxTurns: process.env.CLAUDE_MAX_TURNS ? parseInt(process.env.CLAUDE_MAX_TURNS, 10) : undefined,
       maxBudgetUsd: process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined,
       model: process.env.CLAUDE_MODEL || 'claude-opus-4-6',
+      apiKey: undefined,
       outputsBaseDir: process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), 'metabot-outputs'),
       downloadsDir: process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
     },


### PR DESCRIPTION
## Summary
- Filter `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from inherited process env in child Claude Code processes
- This lets Claude Code resolve auth dynamically from `~/.claude/.credentials.json` instead of stale PM2 env vars
- Add optional `apiKey` field in bots.json for users who want to pin a specific API key
- Compatible with [cc-switch](https://github.com/farion1231/cc-switch), [cc-switch-cli](https://github.com/SaladDay/cc-switch-cli), [CCS](https://github.com/kaitranntt/ccs), and `claude /login`

## Root cause
MetaBot runs via PM2, which captures env vars at startup. When `cc switch` changes auth mode (e.g. removes `ANTHROPIC_API_KEY`), PM2 still holds the old value. Child processes inherit it and stay in API mode.

## How it works now
1. **Default** (no `apiKey` in bots.json): env vars are filtered → Claude Code reads `~/.claude/.credentials.json` → `cc switch` works
2. **Explicit API key** (`"apiKey": "sk-ant-..."` in bots.json): injected after filtering → always uses that key

Closes #124

## Test plan
- [ ] Start MetaBot with `ANTHROPIC_API_KEY` set → verify Claude Code still works (reads from credentials file)
- [ ] Use `cc switch` to toggle between API/subscription → verify MetaBot respects the switch after restart
- [ ] Set `apiKey` in bots.json → verify it overrides credential file auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)