### PR TITLE
docs: harden peer remote access guidance

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -234,7 +234,7 @@ Supported: text, images (Claude multimodal), files (PDF/code/docs), rich text (P
 |----------|---------|-------------|
 | `BOTS_CONFIG` | — | Path to `bots.json` |
 | `API_PORT` | 9100 | HTTP API port |
-| `API_SECRET` | — | Bearer token auth |
+| `API_SECRET` | — | Bearer token auth. Generate one with `openssl rand -hex 32` |
 | `MEMORY_ENABLED` | true | Enable MetaMemory |
 | `MEMORY_PORT` | 8100 | MetaMemory port |
 | `MEMORY_ADMIN_TOKEN` | — | Admin token (full access) |
@@ -242,9 +242,9 @@ Supported: text, images (Claude multimodal), files (PDF/code/docs), rich text (P
 | `WIKI_SYNC_ENABLED` | true | Enable MetaMemory→Wiki sync |
 | `WIKI_SPACE_NAME` | MetaMemory | Wiki space name |
 | `WIKI_AUTO_SYNC` | true | Auto-sync on changes |
-| `METABOT_URL` | `http://localhost:9100` | MetaBot API URL |
-| `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory server URL |
-| `METABOT_PEERS` | — | Peer MetaBot URLs (comma-separated) |
+| `METABOT_URL` | `http://localhost:9100` | MetaBot API URL. Default is local HTTP; for remote access prefer HTTPS or a private-network address |
+| `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory server URL. Default is local HTTP; for remote access prefer HTTPS or a private-network address |
+| `METABOT_PEERS` | — | Peer MetaBot URLs (comma-separated). Prefer HTTPS for internet-reachable peers |
 | `LOG_LEVEL` | info | Log level |
 
 </details>

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -19,7 +19,13 @@ Use `maxBudgetUsd` (per bot in `bots.json` or via `CLAUDE_MAX_BUDGET_USD` env va
 
 ## API Authentication
 
-Set `API_SECRET` in `.env` to enable Bearer token authentication on both the HTTP API server and MetaMemory:
+Set `API_SECRET` in `.env` to enable Bearer token authentication on both the HTTP API server and MetaMemory. Generate a strong random secret first:
+
+```bash
+openssl rand -hex 32
+```
+
+Then put the generated value in `.env`:
 
 ```bash
 API_SECRET=your-secret-token

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -10,7 +10,7 @@ All configuration is via `.env` file or system environment variables. Copy `.env
 | `FEISHU_APP_ID` | — | Feishu app ID (single-bot mode) |
 | `FEISHU_APP_SECRET` | — | Feishu app secret (single-bot mode) |
 | `API_PORT` | `9100` | HTTP API port |
-| `API_SECRET` | — | Bearer token auth for API and MetaMemory |
+| `API_SECRET` | — | Bearer token auth for API and MetaMemory. Generate one with `openssl rand -hex 32` |
 | `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
 
 ## Claude Code
@@ -58,7 +58,7 @@ Falls back to the first Feishu bot's credentials if not set.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `METABOT_PEERS` | — | Comma-separated peer URLs |
+| `METABOT_PEERS` | — | Comma-separated peer URLs. Prefer HTTPS for internet-reachable peers; use plain HTTP only for localhost or a private overlay network |
 | `METABOT_PEER_SECRETS` | — | Comma-separated peer secrets (positional match) |
 | `METABOT_PEER_NAMES` | auto | Comma-separated peer names |
 | `METABOT_PEER_POLL_INTERVAL_MS` | `30000` | Peer poll interval |
@@ -67,8 +67,8 @@ Falls back to the first Feishu bot's credentials if not set.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `METABOT_URL` | `http://localhost:9100` | MetaBot API URL (for CLI) |
-| `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory URL (for CLI) |
+| `METABOT_URL` | `http://localhost:9100` | MetaBot API URL for CLI. The default is local HTTP; for remote access prefer an HTTPS reverse proxy or a private-network address |
+| `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory URL for CLI. The default is local HTTP; for remote access prefer an HTTPS reverse proxy or a private-network address |
 
 ## Voice
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -39,24 +39,30 @@ npm start                            # run compiled output (dist/index.js)
 - **Feishu** uses WebSocket (persistent connection) — no incoming port needed
 - **Telegram** uses long polling — no incoming port needed
 
-The only port that needs to be accessible is the API port (`9100` by default) if you want remote CLI access or Peers federation.
+For remote CLI access or Peers federation, do not expose the raw API ports (`9100` / `8100`) directly on the public internet. Prefer HTTPS behind Caddy, or keep the services on a private network such as Tailscale or WireGuard.
 
 ## Remote CLI Access
 
-Configure CLI tools to connect to a remote MetaBot instance:
+Generate a strong API secret first:
+
+```bash
+openssl rand -hex 32
+```
+
+Then configure CLI tools to connect through your HTTPS reverse proxy for internet-reachable deployments:
 
 ```bash
 # In ~/.metabot/.env
-METABOT_URL=http://your-server:9100
-META_MEMORY_URL=http://your-server:8100
+METABOT_URL=https://metabot.yourdomain.com
+META_MEMORY_URL=https://memory.yourdomain.com
 API_SECRET=your-secret
 ```
 
-This allows `mb` and `mm` commands to work from any machine.
+This allows `mb` and `mm` commands to work from any machine while keeping TLS termination at the proxy. If your servers are reachable only over a private network such as Tailscale or WireGuard, use those private addresses instead.
 
 ## HTTPS with Caddy
 
-HTTPS is required for the Web UI's phone call voice mode on mobile browsers (microphone access needs a secure context). [Caddy](https://caddyserver.com/) is the recommended reverse proxy — it handles Let's Encrypt certificates automatically.
+HTTPS is required for the Web UI's phone call voice mode on mobile browsers (microphone access needs a secure context), and it is also the recommended default for remote CLI access and Peers federation. [Caddy](https://caddyserver.com/) is the recommended reverse proxy — it handles Let's Encrypt certificates automatically.
 
 ```bash
 # Install Caddy
@@ -69,6 +75,10 @@ sudo tee /etc/caddy/Caddyfile > /dev/null << 'EOF'
 metabot.yourdomain.com {
     reverse_proxy localhost:9100
 }
+
+memory.yourdomain.com {
+    reverse_proxy localhost:8100
+}
 EOF
 sudo systemctl restart caddy
 ```
@@ -78,6 +88,6 @@ sudo systemctl restart caddy
 - A domain with an A record pointing to your server's public IP
 - Ports 80 and 443 open for Let's Encrypt validation
 
-Caddy automatically obtains and renews certificates. WebSocket connections (`/ws`) are proxied transparently — no additional configuration needed.
+Caddy automatically obtains and renews certificates. WebSocket connections (`/ws`) are proxied transparently — no additional configuration needed. Use the same HTTPS hostnames for `METABOT_URL`, `META_MEMORY_URL`, and remote peer entries in `METABOT_PEERS`.
 
 For full setup details, see the [Web UI docs](../features/web-ui.md#https-setup).

--- a/docs/features/peers.md
+++ b/docs/features/peers.md
@@ -22,6 +22,8 @@ Peers enables a **federated architecture** where multiple MetaBot instances disc
 
 Configure peers via **either** method — or use both (they are merged and deduplicated by URL):
 
+For peers on remote servers, prefer HTTPS URLs fronted by Caddy or another TLS reverse proxy. Plain `http://` is best kept to `localhost` or a private overlay network such as Tailscale or WireGuard.
+
 === "Environment Variables (.env)"
 
     The simplest way — just add to your `.env` file. Works with both single-bot and multi-bot mode.

--- a/docs/reference/cli-mb.md
+++ b/docs/reference/cli-mb.md
@@ -75,9 +75,10 @@ mb help                             # show help
 
 ## Remote Access
 
-By default, `mb` connects to `http://localhost:9100`. Configure remote access:
+By default, `mb` connects to `http://localhost:9100`. For internet-reachable deployments, point it at your HTTPS reverse proxy. If you use a private network such as Tailscale or WireGuard, you can use that private address instead.
 
 ```bash
+# Generate a secret once: openssl rand -hex 32
 # In ~/.metabot/.env or ~/metabot/.env
 METABOT_URL=http://your-server:9100
 API_SECRET=your-secret

--- a/docs/reference/cli-mm.md
+++ b/docs/reference/cli-mm.md
@@ -26,9 +26,10 @@ mm delete DOC_ID                    # delete document
 
 ## Remote Access
 
-By default, `mm` connects to `http://localhost:8100`. Configure remote access:
+By default, `mm` connects to `http://localhost:8100`. For internet-reachable deployments, point it at your HTTPS reverse proxy. If you use a private network such as Tailscale or WireGuard, you can use that private address instead.
 
 ```bash
+# Generate a secret once: openssl rand -hex 32
 # In ~/.metabot/.env or ~/metabot/.env
 META_MEMORY_URL=http://your-server:8100
 API_SECRET=your-secret


### PR DESCRIPTION
## Summary

Improve the English docs for remote access security.

## Changes

- Recommend HTTPS via Caddy for internet-facing remote access
- Stop implying raw `9100` / `8100` public exposure is the default
- Update peer examples to prefer HTTPS URLs
- Add `openssl rand -hex 32` for generating `API_SECRET`
- Align README, deployment, security, env var, and CLI reference docs

## Why

The previous guidance made public HTTP access look more normal than it should be. This updates the docs to make safer deployment patterns the default recommendation.

## Scope

Docs only. No runtime changes.
