### PR TITLE
fix(web): prevent accidental send during IME composition

### DIFF
--- a/web/src/components/chat/InputBar.tsx
+++ b/web/src/components/chat/InputBar.tsx
@@ -438,7 +438,7 @@ export function InputBar({ connected, isRunning, onSend, onStop, onStartCall, ca
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault();
         handleSend();
       }


### PR DESCRIPTION
## Summary
- Add `!e.nativeEvent.isComposing` guard to Enter key handler in `InputBar.tsx`
- Fixes Chinese/Japanese/Korean IME users accidentally sending messages when pressing Enter to confirm character selection
- Also prevents the "send one then accidentally send another segment" issue caused by IME confirmation Enter leaking through

## Test plan
- [ ] Type Chinese characters in the web chat input, press Enter to confirm IME selection — should NOT send
- [ ] Press Enter without IME active — should send as before
- [ ] Shift+Enter still inserts newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)