### PR TITLE
feat(web): add 2D pixel office for agent team visualization

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import { ChatView } from './components/ChatView';
 import { MemoryView } from './components/MemoryView';
 import { VoiceView } from './components/VoiceView';
 import { SettingsView } from './components/SettingsView';
-import { TeamDashboard } from './components/TeamDashboard';
+import { PixelOffice } from './components/office';
 import { ErrorBoundary } from './components/ErrorBoundary';
 
 export function App() {
@@ -25,7 +25,7 @@ export function App() {
             <Route path="/memory" element={<MemoryView />} />
             <Route path="/voice" element={<VoiceView />} />
             <Route path="/settings" element={<SettingsView />} />
-            <Route path="/team" element={<TeamDashboard />} />
+            <Route path="/team" element={<PixelOffice />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </ErrorBoundary>

--- a/web/src/components/office/PixelOffice.module.css
+++ b/web/src/components/office/PixelOffice.module.css
@@ -1,0 +1,91 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #1a1a2e;
+  overflow: hidden;
+}
+
+.loading,
+.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-secondary, #999);
+  font-size: 14px;
+}
+
+.error {
+  color: #f44336;
+}
+
+/* ── Status Bar ── */
+
+.statusBar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 16px;
+  background: var(--bg-secondary, #16162a);
+  border-bottom: 1px solid var(--border-color, rgba(255,255,255,0.1));
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--text-secondary, #999);
+}
+
+.stat {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.statValue {
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.statBusy {
+  font-weight: 600;
+  color: #ff9800;
+}
+
+.statIdle {
+  font-weight: 600;
+  color: #4caf50;
+}
+
+.hint {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-tertiary, #666);
+}
+
+/* ── Main layout ── */
+
+.main {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.canvasArea {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+}
+
+/* ── Mobile ── */
+
+@media (max-width: 768px) {
+  .statusBar {
+    gap: 10px;
+    padding: 6px 12px;
+    font-size: 11px;
+    flex-wrap: wrap;
+  }
+
+  .hint {
+    display: none;
+  }
+}

--- a/web/src/components/office/PixelOffice.tsx
+++ b/web/src/components/office/PixelOffice.tsx
@@ -1,0 +1,205 @@
+/* ============================================================
+   PixelOffice — 2D Pixel art virtual office for the Team tab.
+   Replaces TeamDashboard with an interactive pixel office where
+   each agent sits at a desk and the user can walk around and chat.
+   ============================================================ */
+
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useStore, type BotStatus, type TeamStatus } from '../../store';
+import { OfficeCanvas } from './canvas/OfficeCanvas';
+import { generateLayout } from './engine/layout-generator';
+import { agentColor } from './canvas/sprites';
+import { worldToScreen } from './engine/interaction';
+import { ChatSidePanel } from './ui/ChatSidePanel';
+import { AgentTooltip } from './ui/AgentTooltip';
+import type { AgentSprite, Position } from './types';
+import { TILE_SIZE } from './types';
+import styles from './PixelOffice.module.css';
+
+/* ── Team status polling hook ── */
+
+function useTeamPoller(intervalMs = 5000) {
+  const token = useStore((s) => s.token);
+  const teamStatus = useStore((s) => s.teamStatus);
+  const setTeamStatus = useStore((s) => s.setTeamStatus);
+  const [loading, setLoading] = useState(!teamStatus);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch('/api/team/status', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: TeamStatus = await res.json();
+        if (active) {
+          setTeamStatus(data);
+          setError(null);
+          setLoading(false);
+        }
+      } catch (err: any) {
+        if (active) setError(err.message);
+      }
+    };
+    fetchStatus();
+    const timer = setInterval(fetchStatus, intervalMs);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, [token, setTeamStatus, intervalMs]);
+
+  return { teamStatus, loading, error };
+}
+
+/* ── Main component ── */
+
+export function PixelOffice() {
+  const { teamStatus, loading, error } = useTeamPoller();
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [hoveredAgent, setHoveredAgent] = useState<string | null>(null);
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+
+  // Generate layout from bot names
+  const layout = useMemo(() => {
+    if (!teamStatus) return null;
+    const bots = teamStatus.bots.map((b) => ({
+      name: b.name,
+      specialties: b.specialties,
+      platform: b.platform,
+    }));
+    return generateLayout(bots);
+  }, [teamStatus?.bots.length]); // only regenerate when bot count changes
+
+  // Build agent sprites from team status + layout positions
+  const agents = useMemo(() => {
+    const map = new Map<string, AgentSprite>();
+    if (!teamStatus || !layout) return map;
+
+    for (const bot of teamStatus.bots) {
+      const pos = layout.agentPositions.get(bot.name);
+      if (!pos) continue;
+      map.set(bot.name, {
+        botName: bot.name,
+        position: pos.seat,
+        deskPosition: pos.desk,
+        status: bot.status,
+        color: agentColor(bot.name),
+        description: bot.description,
+        specialties: bot.specialties,
+        platform: bot.platform,
+        currentTask: bot.currentTask
+          ? { durationMs: bot.currentTask.durationMs }
+          : undefined,
+        stats: bot.stats
+          ? {
+              totalTasks: bot.stats.totalTasks,
+              completedTasks: bot.stats.completedTasks,
+              totalCostUsd: bot.stats.totalCostUsd,
+            }
+          : undefined,
+      });
+    }
+    return map;
+  }, [teamStatus, layout]);
+
+  // Track mouse for tooltip positioning
+  useEffect(() => {
+    const handler = (e: MouseEvent) => setMousePos({ x: e.clientX, y: e.clientY });
+    window.addEventListener('mousemove', handler);
+    return () => window.removeEventListener('mousemove', handler);
+  }, []);
+
+  const handleSelectAgent = useCallback((name: string | null) => {
+    setSelectedAgent(name);
+  }, []);
+
+  const handleHoverAgent = useCallback((name: string | null) => {
+    setHoveredAgent(name);
+  }, []);
+
+  const handleCloseChat = useCallback(() => {
+    setSelectedAgent(null);
+  }, []);
+
+  // Find bot status for selected/hovered agent
+  const selectedBotStatus = teamStatus?.bots.find((b) => b.name === selectedAgent);
+  const hoveredAgentSprite = hoveredAgent ? agents.get(hoveredAgent) : null;
+
+  if (loading && !teamStatus) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>Loading office...</div>
+      </div>
+    );
+  }
+
+  if (error && !teamStatus) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.error}>Error: {error}</div>
+      </div>
+    );
+  }
+
+  if (!layout || !teamStatus) return null;
+
+  const { summary } = teamStatus;
+
+  return (
+    <div className={styles.container}>
+      {/* Status bar */}
+      <div className={styles.statusBar}>
+        <span className={styles.stat}>
+          <span className={styles.statValue}>{summary.totalBots}</span> Agents
+        </span>
+        <span className={styles.stat}>
+          <span className={styles.statBusy}>{summary.busyBots}</span> Busy
+        </span>
+        <span className={styles.stat}>
+          <span className={styles.statIdle}>{summary.idleBots}</span> Idle
+        </span>
+        <span className={styles.stat}>
+          ${summary.totalCostUsd.toFixed(2)} cost
+        </span>
+        <span className={styles.hint}>Click agent to chat | Click floor to move</span>
+      </div>
+
+      {/* Main content: canvas + optional side panel */}
+      <div className={styles.main}>
+        <div className={styles.canvasArea}>
+          <OfficeCanvas
+            tileMap={layout.tileMap}
+            rooms={layout.rooms}
+            agents={agents}
+            playerSpawn={layout.playerSpawn}
+            selectedAgent={selectedAgent}
+            onSelectAgent={handleSelectAgent}
+            onHoverAgent={handleHoverAgent}
+            hoveredAgent={hoveredAgent}
+          />
+        </div>
+
+        {/* Chat side panel */}
+        {selectedAgent && (
+          <ChatSidePanel
+            botName={selectedAgent}
+            botStatus={selectedBotStatus}
+            onClose={handleCloseChat}
+          />
+        )}
+      </div>
+
+      {/* Hover tooltip */}
+      {hoveredAgentSprite && hoveredAgent !== selectedAgent && (
+        <AgentTooltip
+          agent={hoveredAgentSprite}
+          screenX={mousePos.x}
+          screenY={mousePos.y}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/office/canvas/OfficeCanvas.tsx
+++ b/web/src/components/office/canvas/OfficeCanvas.tsx
@@ -1,0 +1,235 @@
+/* ============================================================
+   OfficeCanvas — React component wrapping the <canvas> element
+   with game loop, click/hover handling, and rendering.
+   ============================================================ */
+
+import { useRef, useEffect, useCallback } from 'react';
+import type { TileMap, AgentSprite, Room, Position } from '../types';
+import { TILE_SIZE } from '../types';
+import { createCamera, updateCamera, type Camera } from './camera';
+import { renderStaticLayer, renderFrame } from './renderer';
+import { createMovementState, setPath, updateMovement, type MovementState } from '../engine/movement';
+import { findPath, findNearestWalkable } from '../engine/pathfinding';
+import { detectClick, detectHover } from '../engine/interaction';
+
+interface OfficeCanvasProps {
+  tileMap: TileMap;
+  rooms: Room[];
+  agents: Map<string, AgentSprite>;
+  playerSpawn: Position;
+  selectedAgent: string | null;
+  onSelectAgent: (name: string | null) => void;
+  onHoverAgent: (name: string | null) => void;
+  hoveredAgent: string | null;
+}
+
+export function OfficeCanvas({
+  tileMap,
+  rooms,
+  agents,
+  playerSpawn,
+  selectedAgent,
+  onSelectAgent,
+  onHoverAgent,
+  hoveredAgent,
+}: OfficeCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cameraRef = useRef<Camera>(createCamera());
+  const movementRef = useRef<MovementState>(createMovementState(playerSpawn));
+  const staticLayerRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef(0);
+  const rafRef = useRef(0);
+  const lastTimeRef = useRef(0);
+
+  // Rebuild static layer when tileMap changes
+  useEffect(() => {
+    staticLayerRef.current = renderStaticLayer(tileMap, rooms);
+  }, [tileMap, rooms]);
+
+  // Reset player on spawn change
+  useEffect(() => {
+    const m = movementRef.current;
+    m.tileX = playerSpawn.x;
+    m.tileY = playerSpawn.y;
+    m.visualX = playerSpawn.x;
+    m.visualY = playerSpawn.y;
+    m.path = [];
+    m.isMoving = false;
+  }, [playerSpawn]);
+
+  // Canvas resize
+  useEffect(() => {
+    const resize = () => {
+      const canvas = canvasRef.current;
+      const container = containerRef.current;
+      if (!canvas || !container) return;
+      const rect = container.getBoundingClientRect();
+      canvas.width = rect.width;
+      canvas.height = rect.height;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, []);
+
+  // Main game loop
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    lastTimeRef.current = performance.now();
+
+    const loop = (time: number) => {
+      const dt = Math.min((time - lastTimeRef.current) / 1000, 0.1); // cap at 100ms
+      lastTimeRef.current = time;
+      frameRef.current++;
+
+      const camera = cameraRef.current;
+      const movement = movementRef.current;
+
+      // Update movement
+      updateMovement(movement, dt);
+
+      // Update camera
+      updateCamera(
+        camera,
+        movement.visualX,
+        movement.visualY,
+        canvas.width,
+        canvas.height,
+        tileMap.width,
+        tileMap.height,
+        dt,
+      );
+
+      // Render
+      if (staticLayerRef.current) {
+        renderFrame(
+          ctx,
+          canvas.width,
+          canvas.height,
+          camera,
+          staticLayerRef.current,
+          agents,
+          movement.visualX,
+          movement.visualY,
+          movement.direction,
+          movement.frame,
+          movement.isMoving,
+          selectedAgent,
+          hoveredAgent,
+          frameRef.current,
+        );
+      }
+
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [tileMap, agents, selectedAgent, hoveredAgent]);
+
+  // Click handler
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+      const camera = cameraRef.current;
+
+      const result = detectClick(sx, sy, camera.x, camera.y, agents);
+
+      if (result.type === 'agent' && result.agentName) {
+        onSelectAgent(result.agentName);
+        return;
+      }
+
+      // Move to clicked tile
+      if (result.type === 'floor') {
+        const movement = movementRef.current;
+        const start = { x: movement.tileX, y: movement.tileY };
+        let target = result.tilePos;
+
+        // If not walkable, find nearest walkable
+        const nearest = findNearestWalkable(tileMap, target);
+        if (!nearest) return;
+        target = nearest;
+
+        const path = findPath(tileMap, start, target);
+        if (path && path.length > 0) {
+          setPath(movement, path);
+        }
+      }
+    },
+    [tileMap, agents, onSelectAgent],
+  );
+
+  // Touch handler (mobile)
+  const handleTouch = useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      if (e.touches.length !== 1) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const touch = e.touches[0];
+      const sx = touch.clientX - rect.left;
+      const sy = touch.clientY - rect.top;
+      const camera = cameraRef.current;
+
+      const result = detectClick(sx, sy, camera.x, camera.y, agents);
+
+      if (result.type === 'agent' && result.agentName) {
+        onSelectAgent(result.agentName);
+        return;
+      }
+
+      if (result.type === 'floor') {
+        const movement = movementRef.current;
+        const start = { x: movement.tileX, y: movement.tileY };
+        const nearest = findNearestWalkable(tileMap, result.tilePos);
+        if (!nearest) return;
+        const path = findPath(tileMap, start, nearest);
+        if (path && path.length > 0) {
+          setPath(movement, path);
+        }
+      }
+    },
+    [tileMap, agents, onSelectAgent],
+  );
+
+  // Mouse move for hover detection
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+      const camera = cameraRef.current;
+
+      const hovered = detectHover(sx, sy, camera.x, camera.y, agents);
+      onHoverAgent(hovered);
+
+      // Change cursor
+      canvas.style.cursor = hovered ? 'pointer' : 'crosshair';
+    },
+    [agents, onHoverAgent],
+  );
+
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
+      <canvas
+        ref={canvasRef}
+        onClick={handleClick}
+        onTouchStart={handleTouch}
+        onMouseMove={handleMouseMove}
+        style={{ display: 'block', width: '100%', height: '100%' }}
+      />
+    </div>
+  );
+}

--- a/web/src/components/office/canvas/camera.ts
+++ b/web/src/components/office/canvas/camera.ts
@@ -1,0 +1,54 @@
+/* ============================================================
+   Camera — Viewport following the player
+   ============================================================ */
+
+import { TILE_SIZE } from '../types';
+
+export interface Camera {
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+}
+
+export function createCamera(): Camera {
+  return { x: 0, y: 0, targetX: 0, targetY: 0 };
+}
+
+/**
+ * Update camera to follow the player with smooth easing.
+ * Player is kept centered in the viewport.
+ */
+export function updateCamera(
+  camera: Camera,
+  playerX: number,
+  playerY: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  mapWidth: number,
+  mapHeight: number,
+  dt: number,
+): void {
+  // Target: center player in viewport
+  camera.targetX = playerX * TILE_SIZE + TILE_SIZE / 2 - canvasWidth / 2;
+  camera.targetY = playerY * TILE_SIZE + TILE_SIZE / 2 - canvasHeight / 2;
+
+  // Clamp to map bounds
+  const maxX = mapWidth * TILE_SIZE - canvasWidth;
+  const maxY = mapHeight * TILE_SIZE - canvasHeight;
+  camera.targetX = Math.max(0, Math.min(camera.targetX, maxX));
+  camera.targetY = Math.max(0, Math.min(camera.targetY, maxY));
+
+  // Allow negative if map is smaller than viewport (center the map)
+  if (mapWidth * TILE_SIZE < canvasWidth) {
+    camera.targetX = -(canvasWidth - mapWidth * TILE_SIZE) / 2;
+  }
+  if (mapHeight * TILE_SIZE < canvasHeight) {
+    camera.targetY = -(canvasHeight - mapHeight * TILE_SIZE) / 2;
+  }
+
+  // Smooth easing
+  const ease = 1 - Math.pow(0.001, dt);
+  camera.x += (camera.targetX - camera.x) * ease;
+  camera.y += (camera.targetY - camera.y) * ease;
+}

--- a/web/src/components/office/canvas/renderer.ts
+++ b/web/src/components/office/canvas/renderer.ts
@@ -1,0 +1,131 @@
+/* ============================================================
+   Office Renderer — Draws the full office scene each frame
+   ============================================================ */
+
+import type { TileMap, AgentSprite, Direction, Room } from '../types';
+import { TileType, TILE_SIZE } from '../types';
+import { drawTile, drawAgent, drawPlayer, drawRoomLabel, agentColor } from './sprites';
+import type { Camera } from './camera';
+
+/**
+ * Render the static tile map to an offscreen canvas (for caching).
+ */
+export function renderStaticLayer(
+  tileMap: TileMap,
+  rooms: Room[],
+): HTMLCanvasElement {
+  const offscreen = document.createElement('canvas');
+  offscreen.width = tileMap.width * TILE_SIZE;
+  offscreen.height = tileMap.height * TILE_SIZE;
+  const ctx = offscreen.getContext('2d')!;
+
+  // Background
+  ctx.fillStyle = '#1a1a2e';
+  ctx.fillRect(0, 0, offscreen.width, offscreen.height);
+
+  // Draw all tiles
+  for (let y = 0; y < tileMap.height; y++) {
+    for (let x = 0; x < tileMap.width; x++) {
+      const tile = tileMap.tiles[y][x];
+      if (tile !== TileType.VOID) {
+        drawTile(ctx, x, y, tile);
+      }
+    }
+  }
+
+  // Draw room labels
+  for (const room of rooms) {
+    drawRoomLabel(ctx, room.x, room.y, room.width, room.name);
+  }
+
+  return offscreen;
+}
+
+/**
+ * Render the full scene to the main canvas each frame.
+ */
+export function renderFrame(
+  ctx: CanvasRenderingContext2D,
+  canvasWidth: number,
+  canvasHeight: number,
+  camera: Camera,
+  staticLayer: HTMLCanvasElement,
+  agents: Map<string, AgentSprite>,
+  playerX: number,
+  playerY: number,
+  playerDirection: Direction,
+  playerFrame: number,
+  playerIsMoving: boolean,
+  selectedAgent: string | null,
+  hoveredAgent: string | null,
+  frame: number,
+): void {
+  // Clear
+  ctx.fillStyle = '#1a1a2e';
+  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+  // Draw static layer (tile map)
+  ctx.drawImage(staticLayer, -camera.x, -camera.y);
+
+  // Sort agents and player by Y for correct overlap
+  type Drawable = { type: 'agent'; name: string; agent: AgentSprite } | { type: 'player' };
+  const drawables: Drawable[] = [];
+
+  for (const [name, agent] of agents) {
+    drawables.push({ type: 'agent', name, agent });
+  }
+  drawables.push({ type: 'player' });
+
+  drawables.sort((a, b) => {
+    const ay = a.type === 'player' ? playerY : a.agent.position.y;
+    const by = b.type === 'player' ? playerY : b.agent.position.y;
+    return ay - by;
+  });
+
+  // Draw all entities
+  for (const d of drawables) {
+    if (d.type === 'agent') {
+      const a = d.agent;
+      const screenX = a.position.x * TILE_SIZE - camera.x;
+      const screenY = a.position.y * TILE_SIZE - camera.y;
+      // Frustum culling
+      if (
+        screenX > -TILE_SIZE * 2 &&
+        screenX < canvasWidth + TILE_SIZE * 2 &&
+        screenY > -TILE_SIZE * 2 &&
+        screenY < canvasHeight + TILE_SIZE * 2
+      ) {
+        ctx.save();
+        ctx.translate(-camera.x, -camera.y);
+        drawAgent(
+          ctx,
+          a.position.x,
+          a.position.y,
+          a.color,
+          a.status,
+          d.name,
+          frame,
+          d.name === selectedAgent,
+        );
+        // Hover highlight
+        if (d.name === hoveredAgent && d.name !== selectedAgent) {
+          const px = a.position.x * TILE_SIZE;
+          const py = a.position.y * TILE_SIZE;
+          ctx.strokeStyle = 'rgba(255,255,255,0.4)';
+          ctx.lineWidth = 1;
+          ctx.strokeRect(px - 2, py - 18, TILE_SIZE + 4, TILE_SIZE + 22);
+        }
+        ctx.restore();
+      }
+    } else {
+      // Draw player
+      ctx.save();
+      ctx.translate(-camera.x, -camera.y);
+      drawPlayer(ctx, playerX, playerY, playerDirection, playerFrame, playerIsMoving);
+      ctx.restore();
+    }
+  }
+
+  // Click target indicator (subtle)
+  // (Handled by interaction layer if needed)
+}

--- a/web/src/components/office/canvas/sprites.ts
+++ b/web/src/components/office/canvas/sprites.ts
@@ -1,0 +1,323 @@
+/* ============================================================
+   Pixel Sprites — Pure Canvas drawing (no image assets)
+   ============================================================ */
+
+import { TileType, TILE_SIZE, type AgentStatus, type Direction } from '../types';
+
+// ── Color Palette ──
+
+const COLORS = {
+  floorLight: '#3a3d4a',
+  floorDark: '#353845',
+  wall: '#2a2d3a',
+  wallTop: '#4a4d5a',
+  desk: '#6b5b45',
+  deskTop: '#7d6b52',
+  monitor: '#4a90d9',
+  monitorScreen: '#1a1a2e',
+  carpet: '#2e3448',
+  carpetStripe: '#343a50',
+  plant: '#3d8b37',
+  plantPot: '#8b6b4a',
+  door: '#5a4a3a',
+  doorKnob: '#d4a843',
+  chair: '#4a4a5a',
+  grid: 'rgba(255,255,255,0.03)',
+};
+
+const AGENT_PALETTE = [
+  '#e06060', '#e09040', '#e0d040', '#60c060',
+  '#40b0d0', '#6080e0', '#a060d0', '#d060a0',
+  '#c08060', '#60b0a0', '#b0b040', '#8080c0',
+];
+
+/** Deterministic color from bot name */
+export function agentColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  return AGENT_PALETTE[Math.abs(hash) % AGENT_PALETTE.length];
+}
+
+// ── Tile Drawing ──
+
+export function drawTile(ctx: CanvasRenderingContext2D, x: number, y: number, type: TileType): void {
+  const px = x * TILE_SIZE;
+  const py = y * TILE_SIZE;
+
+  switch (type) {
+    case TileType.FLOOR:
+      ctx.fillStyle = (x + y) % 2 === 0 ? COLORS.floorLight : COLORS.floorDark;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+      ctx.strokeStyle = COLORS.grid;
+      ctx.strokeRect(px, py, TILE_SIZE, TILE_SIZE);
+      break;
+
+    case TileType.WALL:
+      ctx.fillStyle = COLORS.wall;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+      // Top edge highlight for 3D effect
+      ctx.fillStyle = COLORS.wallTop;
+      ctx.fillRect(px, py, TILE_SIZE, 4);
+      break;
+
+    case TileType.DESK:
+      // Floor underneath
+      ctx.fillStyle = COLORS.floorLight;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+      // Desk body
+      ctx.fillStyle = COLORS.desk;
+      ctx.fillRect(px + 2, py + 4, TILE_SIZE - 4, TILE_SIZE - 6);
+      ctx.fillStyle = COLORS.deskTop;
+      ctx.fillRect(px + 2, py + 4, TILE_SIZE - 4, 3);
+      // Monitor
+      ctx.fillStyle = COLORS.monitorScreen;
+      ctx.fillRect(px + 10, py + 8, 12, 10);
+      ctx.fillStyle = COLORS.monitor;
+      ctx.fillRect(px + 9, py + 7, 14, 1);
+      ctx.fillRect(px + 9, py + 18, 14, 1);
+      ctx.fillRect(px + 14, py + 19, 4, 3);
+      break;
+
+    case TileType.CHAIR:
+      // Floor underneath
+      ctx.fillStyle = COLORS.floorLight;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+      // Chair
+      ctx.fillStyle = COLORS.chair;
+      ctx.fillRect(px + 8, py + 6, 16, 14);
+      ctx.fillStyle = '#5a5a6a';
+      ctx.fillRect(px + 10, py + 4, 12, 4); // backrest
+      break;
+
+    case TileType.DOOR:
+      ctx.fillStyle = COLORS.door;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+      ctx.fillStyle = COLORS.doorKnob;
+      ctx.beginPath();
+      ctx.arc(px + 22, py + TILE_SIZE / 2, 2, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+
+    case TileType.CARPET:
+      ctx.fillStyle = COLORS.carpet;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+      // Subtle stripe pattern
+      if (y % 2 === 0) {
+        ctx.fillStyle = COLORS.carpetStripe;
+        ctx.fillRect(px, py + 14, TILE_SIZE, 4);
+      }
+      break;
+
+    case TileType.PLANT:
+      ctx.fillStyle = COLORS.carpet;
+      ctx.fillRect(px, py, TILE_SIZE, TILE_SIZE);
+      // Pot
+      ctx.fillStyle = COLORS.plantPot;
+      ctx.fillRect(px + 10, py + 18, 12, 10);
+      ctx.fillRect(px + 8, py + 16, 16, 4);
+      // Leaves
+      ctx.fillStyle = COLORS.plant;
+      ctx.beginPath();
+      ctx.arc(px + 16, py + 12, 8, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = '#4da047';
+      ctx.beginPath();
+      ctx.arc(px + 12, py + 9, 5, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(px + 20, py + 10, 5, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+
+    case TileType.VOID:
+    default:
+      // Draw nothing (transparent / background)
+      break;
+  }
+}
+
+// ── Agent Sprite ──
+
+const STATUS_COLORS: Record<AgentStatus, string> = {
+  idle: '#4caf50',
+  busy: '#ff9800',
+  error: '#f44336',
+};
+
+export function drawAgent(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  color: string,
+  status: AgentStatus,
+  name: string,
+  frame: number,
+  isSelected: boolean,
+): void {
+  const px = x * TILE_SIZE;
+  const py = y * TILE_SIZE;
+  const cx = px + TILE_SIZE / 2;
+
+  // Selection highlight
+  if (isSelected) {
+    ctx.strokeStyle = '#ffd700';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(px - 2, py - 18, TILE_SIZE + 4, TILE_SIZE + 22);
+    ctx.lineWidth = 1;
+  }
+
+  // Body
+  ctx.fillStyle = color;
+  ctx.fillRect(cx - 6, py + 10, 12, 14);
+
+  // Head
+  ctx.fillStyle = '#f5d0a9';
+  ctx.beginPath();
+  ctx.arc(cx, py + 6, 6, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Hair
+  ctx.fillStyle = darken(color, 40);
+  ctx.beginPath();
+  ctx.arc(cx, py + 3, 6, Math.PI, Math.PI * 2);
+  ctx.fill();
+
+  // Eyes
+  ctx.fillStyle = '#222';
+  ctx.fillRect(cx - 3, py + 5, 2, 2);
+  ctx.fillRect(cx + 1, py + 5, 2, 2);
+
+  // Feet (walking animation)
+  ctx.fillStyle = '#333';
+  const footOffset = status === 'busy' ? Math.sin(frame * 0.5) * 2 : 0;
+  ctx.fillRect(cx - 5, py + 24 + footOffset, 4, 4);
+  ctx.fillRect(cx + 1, py + 24 - footOffset, 4, 4);
+
+  // Status indicator (circle above head)
+  const statusColor = STATUS_COLORS[status];
+  ctx.fillStyle = statusColor;
+  ctx.beginPath();
+  ctx.arc(cx, py - 4, 3, 0, Math.PI * 2);
+  ctx.fill();
+  // Pulse effect for busy
+  if (status === 'busy') {
+    const pulse = 0.3 + 0.7 * Math.abs(Math.sin(frame * 0.1));
+    ctx.globalAlpha = pulse;
+    ctx.beginPath();
+    ctx.arc(cx, py - 4, 5, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+
+  // Typing dots for busy agents
+  if (status === 'busy') {
+    const dotPhase = Math.floor(frame / 8) % 3;
+    for (let i = 0; i < 3; i++) {
+      ctx.fillStyle = i === dotPhase ? '#fff' : 'rgba(255,255,255,0.3)';
+      ctx.beginPath();
+      ctx.arc(cx - 6 + i * 6, py - 12, 2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  // Name label
+  ctx.fillStyle = '#fff';
+  ctx.font = '9px monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  const nameWidth = ctx.measureText(name).width;
+  ctx.fillStyle = 'rgba(0,0,0,0.6)';
+  ctx.fillRect(cx - nameWidth / 2 - 2, py + 30, nameWidth + 4, 11);
+  ctx.fillStyle = '#ddd';
+  ctx.fillText(name, cx, py + 31);
+}
+
+// ── Player Sprite ──
+
+export function drawPlayer(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  direction: Direction,
+  frame: number,
+  isMoving: boolean,
+): void {
+  const px = x * TILE_SIZE;
+  const py = y * TILE_SIZE;
+  const cx = px + TILE_SIZE / 2;
+
+  // Shadow
+  ctx.fillStyle = 'rgba(0,0,0,0.2)';
+  ctx.beginPath();
+  ctx.ellipse(cx, py + 28, 8, 3, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Body (green accent)
+  ctx.fillStyle = '#4caf50';
+  ctx.fillRect(cx - 6, py + 10, 12, 14);
+
+  // Head
+  ctx.fillStyle = '#f5d0a9';
+  ctx.beginPath();
+  ctx.arc(cx, py + 6, 6, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Hair
+  ctx.fillStyle = '#4a3520';
+  ctx.beginPath();
+  ctx.arc(cx, py + 3, 6, Math.PI, Math.PI * 2);
+  ctx.fill();
+
+  // Eyes (direction-aware)
+  ctx.fillStyle = '#222';
+  const eyeOffX = direction === 'left' ? -1 : direction === 'right' ? 1 : 0;
+  const eyeOffY = direction === 'up' ? -1 : 0;
+  ctx.fillRect(cx - 3 + eyeOffX, py + 5 + eyeOffY, 2, 2);
+  ctx.fillRect(cx + 1 + eyeOffX, py + 5 + eyeOffY, 2, 2);
+
+  // Feet (animated when moving)
+  ctx.fillStyle = '#333';
+  const footAnim = isMoving ? Math.sin(frame * 1.5) * 3 : 0;
+  ctx.fillRect(cx - 5, py + 24 + footAnim, 4, 4);
+  ctx.fillRect(cx + 1, py + 24 - footAnim, 4, 4);
+
+  // "You" label
+  ctx.fillStyle = 'rgba(76,175,80,0.7)';
+  ctx.font = 'bold 8px monospace';
+  ctx.textAlign = 'center';
+  const w = ctx.measureText('YOU').width;
+  ctx.fillStyle = 'rgba(0,0,0,0.5)';
+  ctx.fillRect(cx - w / 2 - 2, py - 6, w + 4, 10);
+  ctx.fillStyle = '#4caf50';
+  ctx.fillText('YOU', cx, py - 5);
+}
+
+// ── Room Label ──
+
+export function drawRoomLabel(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  name: string,
+): void {
+  const px = x * TILE_SIZE;
+  const py = y * TILE_SIZE;
+  const centerX = px + (width * TILE_SIZE) / 2;
+
+  ctx.fillStyle = 'rgba(255,255,255,0.08)';
+  ctx.font = 'bold 11px monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillText(name.toUpperCase(), centerX, py + 6);
+}
+
+// ── Helpers ──
+
+function darken(hex: string, amount: number): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.max(0, (num >> 16) - amount);
+  const g = Math.max(0, ((num >> 8) & 0xff) - amount);
+  const b = Math.max(0, (num & 0xff) - amount);
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}

--- a/web/src/components/office/engine/interaction.ts
+++ b/web/src/components/office/engine/interaction.ts
@@ -1,0 +1,96 @@
+/* ============================================================
+   Interaction — Click detection on canvas
+   ============================================================ */
+
+import type { Position, AgentSprite } from '../types';
+import { TILE_SIZE } from '../types';
+
+export interface ClickResult {
+  type: 'floor' | 'agent' | 'none';
+  tilePos: Position;
+  agentName?: string;
+}
+
+/**
+ * Convert screen (canvas) coordinates to world tile coordinates,
+ * accounting for camera offset.
+ */
+export function screenToWorld(
+  screenX: number,
+  screenY: number,
+  cameraX: number,
+  cameraY: number,
+): Position {
+  return {
+    x: Math.floor((screenX + cameraX) / TILE_SIZE),
+    y: Math.floor((screenY + cameraY) / TILE_SIZE),
+  };
+}
+
+export function worldToScreen(
+  worldX: number,
+  worldY: number,
+  cameraX: number,
+  cameraY: number,
+): { x: number; y: number } {
+  return {
+    x: worldX * TILE_SIZE - cameraX,
+    y: worldY * TILE_SIZE - cameraY,
+  };
+}
+
+/**
+ * Determine what was clicked: an agent, a floor tile, or nothing.
+ * Agents are checked first (priority over floor).
+ */
+export function detectClick(
+  screenX: number,
+  screenY: number,
+  cameraX: number,
+  cameraY: number,
+  agents: Map<string, AgentSprite>,
+): ClickResult {
+  const tilePos = screenToWorld(screenX, screenY, cameraX, cameraY);
+
+  // Check if click is on any agent (check seat position)
+  for (const [name, agent] of agents) {
+    const agentScreenX = agent.position.x * TILE_SIZE - cameraX;
+    const agentScreenY = agent.position.y * TILE_SIZE - cameraY;
+    // Hit test with a slightly generous bounding box
+    if (
+      screenX >= agentScreenX - 4 &&
+      screenX <= agentScreenX + TILE_SIZE + 4 &&
+      screenY >= agentScreenY - 16 && // name label above
+      screenY <= agentScreenY + TILE_SIZE + 4
+    ) {
+      return { type: 'agent', tilePos: agent.position, agentName: name };
+    }
+  }
+
+  return { type: 'floor', tilePos };
+}
+
+/**
+ * Detect which agent (if any) the mouse is hovering over.
+ */
+export function detectHover(
+  screenX: number,
+  screenY: number,
+  cameraX: number,
+  cameraY: number,
+  agents: Map<string, AgentSprite>,
+): string | null {
+  for (const [name, agent] of agents) {
+    const ax = agent.position.x * TILE_SIZE - cameraX;
+    const ay = agent.position.y * TILE_SIZE - cameraY;
+    if (
+      screenX >= ax - 4 &&
+      screenX <= ax + TILE_SIZE + 4 &&
+      screenY >= ay - 16 &&
+      screenY <= ay + TILE_SIZE + 4
+    ) {
+      return name;
+    }
+  }
+  return null;
+}

--- a/web/src/components/office/engine/layout-generator.ts
+++ b/web/src/components/office/engine/layout-generator.ts
@@ -1,0 +1,212 @@
+/* ============================================================
+   Office Layout Generator
+   Auto-generates a tile map from a list of bot names.
+   ============================================================ */
+
+import { TileType, type TileMap, type Room, type Position } from '../types';
+
+interface LayoutInput {
+  name: string;
+  specialties?: string[];
+  platform?: string;
+}
+
+interface LayoutResult {
+  tileMap: TileMap;
+  rooms: Room[];
+  agentPositions: Map<string, { seat: Position; desk: Position }>;
+  playerSpawn: Position;
+}
+
+/** Group bots into rooms by first specialty or platform */
+function groupBots(bots: LayoutInput[]): Map<string, LayoutInput[]> {
+  const groups = new Map<string, LayoutInput[]>();
+  for (const bot of bots) {
+    const key = bot.specialties?.[0] || bot.platform || 'general';
+    const arr = groups.get(key) || [];
+    arr.push(bot);
+    groups.set(key, arr);
+  }
+  return groups;
+}
+
+/** Create a single room with desks for n agents */
+function createRoom(
+  id: string,
+  name: string,
+  agentCount: number,
+  offsetX: number,
+  offsetY: number,
+): { room: Room; desks: Position[]; seats: Position[]; width: number; height: number } {
+  // Layout: 2 columns of desks, each desk takes 2x2 area (desk + seat)
+  const cols = 2;
+  const rows = Math.ceil(agentCount / cols);
+  // Room inner size: cols * 3 wide (desk spacing) + 1 padding, rows * 2 + 1 padding
+  const innerW = cols * 4;
+  const innerH = rows * 3 + 1;
+  const width = innerW + 2; // +2 for walls
+  const height = innerH + 2;
+
+  const desks: Position[] = [];
+  const seats: Position[] = [];
+
+  for (let i = 0; i < agentCount; i++) {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const dx = offsetX + 1 + col * 4 + 1;
+    const dy = offsetY + 1 + row * 3 + 1;
+    desks.push({ x: dx, y: dy });
+    seats.push({ x: dx, y: dy + 1 }); // agent sits south of desk
+  }
+
+  return {
+    room: {
+      id,
+      name,
+      x: offsetX,
+      y: offsetY,
+      width,
+      height,
+      agents: [],
+    },
+    desks,
+    seats,
+    width,
+    height,
+  };
+}
+
+export function generateLayout(bots: LayoutInput[]): LayoutResult {
+  if (bots.length === 0) {
+    return {
+      tileMap: { width: 10, height: 10, tiles: Array.from({ length: 10 }, () => Array(10).fill(TileType.FLOOR)) },
+      rooms: [],
+      agentPositions: new Map(),
+      playerSpawn: { x: 5, y: 5 },
+    };
+  }
+
+  const groups = groupBots(bots);
+  const roomDefs: { id: string; name: string; bots: LayoutInput[] }[] = [];
+  let i = 0;
+  for (const [name, members] of groups) {
+    roomDefs.push({ id: `room-${i}`, name, bots: members });
+    i++;
+  }
+
+  // Corridor height
+  const corridorH = 3;
+
+  // Calculate room sizes and total width
+  const roomResults: ReturnType<typeof createRoom>[] = [];
+  let totalWidth = 1; // left margin
+  const roomY = 1; // top margin
+
+  for (const def of roomDefs) {
+    const result = createRoom(def.id, def.name, def.bots.length, totalWidth, roomY);
+    roomResults.push(result);
+    totalWidth += result.width + 1; // gap between rooms
+  }
+  totalWidth = Math.max(totalWidth, 12);
+
+  const maxRoomHeight = Math.max(...roomResults.map((r) => r.height), 6);
+  const corridorY = roomY + maxRoomHeight;
+  const totalHeight = corridorY + corridorH + 2;
+
+  // Initialize tile map with VOID
+  const tiles: TileType[][] = Array.from({ length: totalHeight }, () =>
+    Array(totalWidth).fill(TileType.VOID),
+  );
+
+  const rooms: Room[] = [];
+  const agentPositions = new Map<string, { seat: Position; desk: Position }>();
+
+  // Draw each room
+  for (let ri = 0; ri < roomDefs.length; ri++) {
+    const def = roomDefs[ri];
+    const result = roomResults[ri];
+    const { room } = result;
+
+    // Draw room floor and walls
+    for (let ry = room.y; ry < room.y + result.height; ry++) {
+      for (let rx = room.x; rx < room.x + result.width; rx++) {
+        if (ry < 0 || ry >= totalHeight || rx < 0 || rx >= totalWidth) continue;
+        if (
+          ry === room.y ||
+          ry === room.y + result.height - 1 ||
+          rx === room.x ||
+          rx === room.x + result.width - 1
+        ) {
+          tiles[ry][rx] = TileType.WALL;
+        } else {
+          tiles[ry][rx] = TileType.FLOOR;
+        }
+      }
+    }
+
+    // Place door at bottom center of room
+    const doorX = room.x + Math.floor(result.width / 2);
+    const doorY = room.y + result.height - 1;
+    if (doorY < totalHeight && doorX < totalWidth) {
+      tiles[doorY][doorX] = TileType.DOOR;
+    }
+
+    // Place desks and chairs
+    for (let di = 0; di < result.desks.length; di++) {
+      const desk = result.desks[di];
+      const seat = result.seats[di];
+      if (desk.y < totalHeight && desk.x < totalWidth) tiles[desk.y][desk.x] = TileType.DESK;
+      if (seat.y < totalHeight && seat.x < totalWidth) tiles[seat.y][seat.x] = TileType.CHAIR;
+    }
+
+    // Assign agents to positions
+    const agentNames: string[] = [];
+    for (let ai = 0; ai < def.bots.length; ai++) {
+      agentPositions.set(def.bots[ai].name, {
+        seat: result.seats[ai],
+        desk: result.desks[ai],
+      });
+      agentNames.push(def.bots[ai].name);
+    }
+
+    rooms.push({ ...room, agents: agentNames });
+  }
+
+  // Draw corridor
+  for (let cy = corridorY; cy < corridorY + corridorH && cy < totalHeight; cy++) {
+    for (let cx = 0; cx < totalWidth; cx++) {
+      if (tiles[cy][cx] === TileType.VOID) {
+        tiles[cy][cx] = TileType.CARPET;
+      }
+    }
+  }
+
+  // Add some plants for decoration
+  const plantPositions = [
+    { x: 0, y: corridorY },
+    { x: totalWidth - 1, y: corridorY },
+    { x: 0, y: corridorY + corridorH - 1 },
+    { x: totalWidth - 1, y: corridorY + corridorH - 1 },
+  ];
+  for (const p of plantPositions) {
+    if (p.y < totalHeight && p.x < totalWidth && tiles[p.y][p.x] !== TileType.WALL) {
+      tiles[p.y][p.x] = TileType.PLANT;
+    }
+  }
+
+  const playerSpawn: Position = {
+    x: Math.floor(totalWidth / 2),
+    y: corridorY + 1,
+  };
+  // Ensure spawn tile is walkable
+  if (playerSpawn.y < totalHeight && playerSpawn.x < totalWidth) {
+    tiles[playerSpawn.y][playerSpawn.x] = TileType.CARPET;
+  }
+
+  return {
+    tileMap: { width: totalWidth, height: totalHeight, tiles },
+    rooms,
+    agentPositions,
+    playerSpawn,
+  };
+}

--- a/web/src/components/office/engine/movement.ts
+++ b/web/src/components/office/engine/movement.ts
@@ -1,0 +1,98 @@
+/* ============================================================
+   Player Movement — Lerp between tiles on a path
+   ============================================================ */
+
+import type { Position, Direction } from '../types';
+
+const MOVE_SPEED = 5; // tiles per second
+
+export interface MovementState {
+  /** Current visual position (fractional, for smooth animation) */
+  visualX: number;
+  visualY: number;
+  /** Current tile position (integer) */
+  tileX: number;
+  tileY: number;
+  /** Remaining path to walk */
+  path: Position[];
+  /** Current direction the player is facing */
+  direction: Direction;
+  /** Progress to next tile (0..1) */
+  progress: number;
+  /** Is the player currently moving? */
+  isMoving: boolean;
+  /** Animation frame counter */
+  frame: number;
+  frameTimer: number;
+}
+
+export function createMovementState(start: Position): MovementState {
+  return {
+    visualX: start.x,
+    visualY: start.y,
+    tileX: start.x,
+    tileY: start.y,
+    path: [],
+    direction: 'down',
+    progress: 0,
+    isMoving: false,
+    frame: 0,
+    frameTimer: 0,
+  };
+}
+
+export function setPath(state: MovementState, path: Position[]): void {
+  state.path = [...path];
+  state.progress = 0;
+  state.isMoving = path.length > 0;
+}
+
+/** Update movement each frame. Returns true if position changed. */
+export function updateMovement(state: MovementState, dt: number): boolean {
+  if (!state.isMoving || state.path.length === 0) {
+    state.isMoving = false;
+    return false;
+  }
+
+  // Advance animation frame
+  state.frameTimer += dt;
+  if (state.frameTimer > 0.15) {
+    state.frame = (state.frame + 1) % 4;
+    state.frameTimer = 0;
+  }
+
+  const target = state.path[0];
+
+  // Determine direction
+  const dx = target.x - state.tileX;
+  const dy = target.y - state.tileY;
+  if (Math.abs(dx) > Math.abs(dy)) {
+    state.direction = dx > 0 ? 'right' : 'left';
+  } else {
+    state.direction = dy > 0 ? 'down' : 'up';
+  }
+
+  // Advance progress
+  state.progress += MOVE_SPEED * dt;
+
+  if (state.progress >= 1) {
+    // Arrived at next tile
+    state.tileX = target.x;
+    state.tileY = target.y;
+    state.visualX = target.x;
+    state.visualY = target.y;
+    state.progress = 0;
+    state.path.shift();
+
+    if (state.path.length === 0) {
+      state.isMoving = false;
+      state.frame = 0;
+    }
+  } else {
+    // Lerp between current tile and target
+    state.visualX = state.tileX + dx * state.progress;
+    state.visualY = state.tileY + dy * state.progress;
+  }
+
+  return true;
+}

--- a/web/src/components/office/engine/pathfinding.ts
+++ b/web/src/components/office/engine/pathfinding.ts
@@ -1,0 +1,135 @@
+/* ============================================================
+   A* Pathfinding on Tile Grid (4-directional)
+   ============================================================ */
+
+import { type TileMap, type Position, WALKABLE_TILES, TileType } from '../types';
+
+interface Node {
+  x: number;
+  y: number;
+  g: number; // cost from start
+  h: number; // heuristic to end
+  f: number; // g + h
+  parent: Node | null;
+}
+
+function manhattan(a: Position, b: Position): number {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+const DIRS = [
+  { x: 0, y: -1 }, // up
+  { x: 0, y: 1 },  // down
+  { x: -1, y: 0 }, // left
+  { x: 1, y: 0 },  // right
+];
+
+function isWalkable(tileMap: TileMap, x: number, y: number): boolean {
+  if (x < 0 || x >= tileMap.width || y < 0 || y >= tileMap.height) return false;
+  return WALKABLE_TILES.has(tileMap.tiles[y][x]);
+}
+
+/**
+ * Find shortest path from start to end on a tile map.
+ * Returns array of positions (excluding start, including end), or null if no path.
+ */
+export function findPath(
+  tileMap: TileMap,
+  start: Position,
+  end: Position,
+): Position[] | null {
+  if (!isWalkable(tileMap, end.x, end.y)) return null;
+  if (start.x === end.x && start.y === end.y) return [];
+
+  const key = (x: number, y: number) => `${x},${y}`;
+  const open: Node[] = [];
+  const closed = new Set<string>();
+
+  const startNode: Node = {
+    x: start.x,
+    y: start.y,
+    g: 0,
+    h: manhattan(start, end),
+    f: manhattan(start, end),
+    parent: null,
+  };
+  open.push(startNode);
+
+  while (open.length > 0) {
+    // Find node with lowest f
+    let lowestIdx = 0;
+    for (let i = 1; i < open.length; i++) {
+      if (open[i].f < open[lowestIdx].f) lowestIdx = i;
+    }
+    const current = open[lowestIdx];
+    open.splice(lowestIdx, 1);
+
+    if (current.x === end.x && current.y === end.y) {
+      // Reconstruct path
+      const path: Position[] = [];
+      let node: Node | null = current;
+      while (node && !(node.x === start.x && node.y === start.y)) {
+        path.unshift({ x: node.x, y: node.y });
+        node = node.parent;
+      }
+      return path;
+    }
+
+    closed.add(key(current.x, current.y));
+
+    for (const dir of DIRS) {
+      const nx = current.x + dir.x;
+      const ny = current.y + dir.y;
+      const nk = key(nx, ny);
+
+      if (closed.has(nk) || !isWalkable(tileMap, nx, ny)) continue;
+
+      const g = current.g + 1;
+      const existing = open.find((n) => n.x === nx && n.y === ny);
+      if (existing) {
+        if (g < existing.g) {
+          existing.g = g;
+          existing.f = g + existing.h;
+          existing.parent = current;
+        }
+      } else {
+        const h = manhattan({ x: nx, y: ny }, end);
+        open.push({ x: nx, y: ny, g, h, f: g + h, parent: current });
+      }
+    }
+  }
+
+  return null; // no path found
+}
+
+/**
+ * Find the nearest walkable tile to the target.
+ * Useful when clicking on a non-walkable tile (desk, wall).
+ */
+export function findNearestWalkable(
+  tileMap: TileMap,
+  target: Position,
+): Position | null {
+  if (isWalkable(tileMap, target.x, target.y)) return target;
+
+  // BFS outward
+  const visited = new Set<string>();
+  const queue: Position[] = [target];
+  visited.add(`${target.x},${target.y}`);
+
+  while (queue.length > 0) {
+    const pos = queue.shift()!;
+    for (const dir of DIRS) {
+      const nx = pos.x + dir.x;
+      const ny = pos.y + dir.y;
+      const k = `${nx},${ny}`;
+      if (visited.has(k)) continue;
+      visited.add(k);
+      if (nx < 0 || nx >= tileMap.width || ny < 0 || ny >= tileMap.height) continue;
+      if (isWalkable(tileMap, nx, ny)) return { x: nx, y: ny };
+      queue.push({ x: nx, y: ny });
+    }
+  }
+
+  return null;
+}

--- a/web/src/components/office/index.ts
+++ b/web/src/components/office/index.ts
@@ -1,0 +1,1 @@
+export { PixelOffice } from './PixelOffice';

--- a/web/src/components/office/types.ts
+++ b/web/src/components/office/types.ts
@@ -1,0 +1,74 @@
+/* ============================================================
+   Pixel Office — Type Definitions
+   ============================================================ */
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export enum TileType {
+  VOID = 0,
+  FLOOR = 1,
+  WALL = 2,
+  DESK = 3,
+  DOOR = 4,
+  CARPET = 5,
+  PLANT = 6,
+  CHAIR = 7,
+}
+
+export interface TileMap {
+  width: number;
+  height: number;
+  tiles: TileType[][];
+}
+
+export type AgentStatus = 'idle' | 'busy' | 'error';
+
+export interface AgentSprite {
+  botName: string;
+  position: Position;
+  deskPosition: Position;
+  status: AgentStatus;
+  color: string;
+  description?: string;
+  specialties?: string[];
+  platform?: string;
+  currentTask?: { durationMs: number };
+  stats?: { totalTasks: number; completedTasks: number; totalCostUsd: number };
+}
+
+export interface Room {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  agents: string[];
+}
+
+export type Direction = 'up' | 'down' | 'left' | 'right';
+
+export interface OfficeState {
+  tileMap: TileMap | null;
+  rooms: Room[];
+  agents: Map<string, AgentSprite>;
+  playerPosition: Position;
+  playerTargetPath: Position[];
+  playerDirection: Direction;
+  isMoving: boolean;
+  selectedAgent: string | null;
+  hoveredAgent: string | null;
+  cameraOffset: Position;
+}
+
+export const TILE_SIZE = 32;
+
+/** Walkable tile types for pathfinding */
+export const WALKABLE_TILES = new Set([
+  TileType.FLOOR,
+  TileType.DOOR,
+  TileType.CARPET,
+]);

--- a/web/src/components/office/ui/AgentTooltip.module.css
+++ b/web/src/components/office/ui/AgentTooltip.module.css
@@ -1,0 +1,71 @@
+.tooltip {
+  position: fixed;
+  z-index: 50;
+  background: var(--bg-secondary, #1e1e3a);
+  border: 1px solid var(--border-color, rgba(255,255,255,0.15));
+  border-radius: 8px;
+  padding: 10px 14px;
+  min-width: 180px;
+  max-width: 240px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  pointer-events: none;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.status {
+  font-size: 11px;
+  color: var(--text-secondary, #999);
+}
+
+.desc {
+  font-size: 11px;
+  color: var(--text-secondary, #999);
+  margin-bottom: 6px;
+  line-height: 1.4;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.tag {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.08);
+  color: var(--text-secondary, #bbb);
+}
+
+.task {
+  font-size: 11px;
+  color: #ff9800;
+  margin-bottom: 4px;
+}
+
+.stats {
+  font-size: 11px;
+  color: var(--text-secondary, #999);
+  margin-bottom: 4px;
+}
+
+.hint {
+  font-size: 10px;
+  color: var(--text-tertiary, #666);
+  font-style: italic;
+}

--- a/web/src/components/office/ui/AgentTooltip.tsx
+++ b/web/src/components/office/ui/AgentTooltip.tsx
@@ -1,0 +1,60 @@
+/* ============================================================
+   AgentTooltip — Hover tooltip showing agent details
+   ============================================================ */
+
+import type { AgentSprite } from '../types';
+import styles from './AgentTooltip.module.css';
+
+interface AgentTooltipProps {
+  agent: AgentSprite;
+  screenX: number;
+  screenY: number;
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+export function AgentTooltip({ agent, screenX, screenY }: AgentTooltipProps) {
+  const statusEmoji = agent.status === 'busy' ? '\u{1F7E1}' : agent.status === 'error' ? '\u{1F534}' : '\u{1F7E2}';
+
+  return (
+    <div
+      className={styles.tooltip}
+      style={{
+        left: Math.min(screenX + 16, window.innerWidth - 220),
+        top: Math.max(screenY - 10, 10),
+      }}
+    >
+      <div className={styles.header}>
+        <span className={styles.name}>{agent.botName}</span>
+        <span className={styles.status}>{statusEmoji} {agent.status}</span>
+      </div>
+      {agent.description && <div className={styles.desc}>{agent.description}</div>}
+      {agent.specialties && agent.specialties.length > 0 && (
+        <div className={styles.tags}>
+          {agent.specialties.map((s) => (
+            <span key={s} className={styles.tag}>{s}</span>
+          ))}
+        </div>
+      )}
+      {agent.currentTask && (
+        <div className={styles.task}>
+          Working for {formatDuration(agent.currentTask.durationMs)}
+        </div>
+      )}
+      {agent.stats && (
+        <div className={styles.stats}>
+          {agent.stats.totalTasks} tasks | {formatCost(agent.stats.totalCostUsd)}
+        </div>
+      )}
+      <div className={styles.hint}>Click to chat</div>
+    </div>
+  );
+}

--- a/web/src/components/office/ui/ChatSidePanel.module.css
+++ b/web/src/components/office/ui/ChatSidePanel.module.css
@@ -1,0 +1,96 @@
+/* ChatSidePanel — Right-side chat overlay */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  height: 100%;
+  background: var(--bg-primary, #1a1a2e);
+  border-left: 1px solid var(--border-color, rgba(255,255,255,0.1));
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color, rgba(255,255,255,0.1));
+  background: var(--bg-secondary, #16162a);
+  flex-shrink: 0;
+}
+
+.headerInfo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.botIcon {
+  font-size: 20px;
+}
+
+.botMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.botName {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.statusBadge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  color: #fff;
+  width: fit-content;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #999);
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.closeBtn:hover {
+  color: var(--text-primary, #e0e0e0);
+}
+
+.description {
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--text-secondary, #999);
+  border-bottom: 1px solid var(--border-color, rgba(255,255,255,0.1));
+  flex-shrink: 0;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.inputArea {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-color, rgba(255,255,255,0.1));
+}
+
+/* Mobile: full screen overlay */
+@media (max-width: 768px) {
+  .panel {
+    width: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 100;
+  }
+}

--- a/web/src/components/office/ui/ChatSidePanel.tsx
+++ b/web/src/components/office/ui/ChatSidePanel.tsx
@@ -1,0 +1,150 @@
+/* ============================================================
+   ChatSidePanel — Right-side chat panel for talking to an agent
+   Reuses the existing chat infrastructure (MessageList + InputBar).
+   ============================================================ */
+
+import { useRef, useCallback, useMemo, useState } from 'react';
+import { useStore } from '../../../store';
+import { useWebSocket } from '../../../hooks/useWebSocket';
+import type { CardState } from '../../../types';
+import {
+  MessageList,
+  InputBar,
+  generateId,
+} from '../../chat';
+import type { BotStatus } from '../../../store';
+import styles from './ChatSidePanel.module.css';
+
+interface ChatSidePanelProps {
+  botName: string;
+  botStatus?: BotStatus;
+  onClose: () => void;
+}
+
+export function ChatSidePanel({ botName, botStatus, onClose }: ChatSidePanelProps) {
+  const sessions = useStore((s) => s.sessions);
+  const addMessage = useStore((s) => s.addMessage);
+  const getOrCreateBotSession = useStore((s) => s.getOrCreateBotSession);
+  const connected = useStore((s) => s.connected);
+  const updateMessageState = useStore((s) => s.updateMessageState);
+
+  const { send, sendBinary } = useWebSocket();
+  const autoScrollRef = useRef(true);
+
+  // Get or create a session for this bot
+  const sessionId = useMemo(() => getOrCreateBotSession(botName), [botName, getOrCreateBotSession]);
+  const session = sessions.get(sessionId);
+  const messages = session?.messages || [];
+
+  const isRunning = useMemo(() => {
+    if (!messages.length) return false;
+    const last = messages[messages.length - 1];
+    return last.type === 'assistant' && (last.state?.status === 'thinking' || last.state?.status === 'running');
+  }, [messages]);
+
+  const handleSend = useCallback(
+    async (text: string, files: Array<{ file: File; previewUrl?: string }>) => {
+      if (!text.trim() && files.length === 0) return;
+
+      const userMsgId = generateId();
+      addMessage(sessionId, {
+        id: userMsgId,
+        type: 'user',
+        text,
+        timestamp: Date.now(),
+      });
+
+      const assistantMsgId = generateId();
+      addMessage(sessionId, {
+        id: assistantMsgId,
+        type: 'assistant',
+        text: '',
+        state: { status: 'thinking', userPrompt: text, responseText: '', toolCalls: [] },
+        timestamp: Date.now(),
+      });
+
+      send({
+        type: 'chat',
+        botName,
+        chatId: sessionId,
+        text,
+        messageId: assistantMsgId,
+      });
+
+      autoScrollRef.current = true;
+    },
+    [sessionId, botName, addMessage, send],
+  );
+
+  const handleStop = useCallback(() => {
+    send({ type: 'stop', chatId: sessionId });
+    const sess = sessions.get(sessionId);
+    if (sess) {
+      const lastMsg = sess.messages[sess.messages.length - 1];
+      if (lastMsg?.type === 'assistant' && (lastMsg.state?.status === 'thinking' || lastMsg.state?.status === 'running')) {
+        const stoppedState: CardState = {
+          ...lastMsg.state,
+          status: 'error',
+          errorMessage: 'Task stopped by user',
+        };
+        updateMessageState(sessionId, lastMsg.id, stoppedState);
+      }
+    }
+  }, [sessionId, send, sessions, updateMessageState]);
+
+  const handleAnswer = useCallback(
+    (toolUseId: string, answer: string) => {
+      send({ type: 'answer', chatId: sessionId, toolUseId, answer });
+    },
+    [sessionId, send],
+  );
+
+  // Status badge
+  const statusColor = botStatus?.status === 'busy' ? '#ff9800' : botStatus?.status === 'error' ? '#f44336' : '#4caf50';
+  const statusText = botStatus?.status || 'idle';
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <div className={styles.headerInfo}>
+          <span className={styles.botIcon}>{botStatus?.icon || '\u{1F916}'}</span>
+          <div className={styles.botMeta}>
+            <span className={styles.botName}>{botName}</span>
+            <span className={styles.statusBadge} style={{ background: statusColor }}>
+              {statusText}
+            </span>
+          </div>
+        </div>
+        <button className={styles.closeBtn} onClick={onClose} title="Close">
+          &times;
+        </button>
+      </div>
+
+      {botStatus?.description && (
+        <div className={styles.description}>{botStatus.description}</div>
+      )}
+
+      <div className={styles.messages}>
+        <MessageList
+          messages={messages}
+          autoScrollRef={autoScrollRef}
+          isRunning={isRunning}
+          onAnswer={handleAnswer}
+        />
+      </div>
+
+      <div className={styles.inputArea}>
+        <InputBar
+          connected={connected}
+          isRunning={isRunning}
+          onSend={handleSend}
+          onStop={handleStop}
+          onStartCall={() => {}}
+          callActive={false}
+          send={send}
+          sendBinary={sendBinary}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace Team tab dashboard with an interactive 2D pixel art virtual office
- Each agent rendered as a pixel character at a desk with real-time status (idle/busy/error)
- Click-to-move player navigation with A* pathfinding
- Click any agent to open a chat side panel (reuses existing chat infrastructure)
- Auto-generated office layout based on bot count and specialties
- Pure Canvas rendering with CSS-drawn sprites — zero image assets, ~17KB added JS

## Architecture
```
office/
  types.ts, index.ts
  PixelOffice.tsx          — orchestrator + status bar + team poller
  canvas/
    OfficeCanvas.tsx        — Canvas + game loop + click/touch handlers
    renderer.ts             — frame rendering with static layer caching
    sprites.ts              — pixel art drawing (agents, player, tiles, furniture)
    camera.ts               — viewport following player
  engine/
    layout-generator.ts     — auto-generate rooms from bot list
    pathfinding.ts          — A* on tile grid
    movement.ts             — smooth walking animation
    interaction.ts          — click/hover detection
  ui/
    ChatSidePanel.tsx       — right-side chat (reuses MessageList + InputBar)
    AgentTooltip.tsx        — hover tooltip with agent details
```

## Test plan
- [ ] Open `/web/` → click Team tab → pixel office renders with all agents
- [ ] Click on floor tile → player walks to that position
- [ ] Click on agent → chat side panel opens, can send/receive messages
- [ ] Hover agent → tooltip shows name, status, specialties, cost
- [ ] Agent status updates in real-time (idle→busy→complete)
- [ ] Mobile: tap agent → full-screen chat overlay
- [ ] Build passes, 174 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)