### PR TITLE
feat(web): show sub-agents in pixel office with per-bot team rooms

### DIFF
--- a/src/api/agent-scanner.ts
+++ b/src/api/agent-scanner.ts
@@ -1,0 +1,85 @@
+/**
+ * Agent Scanner — reads .claude/agents/*.md from bot working directories
+ * and extracts YAML frontmatter metadata for each sub-agent.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface AgentMetadata {
+  name: string;
+  description?: string;
+  model?: string;
+  tools?: string;
+}
+
+/**
+ * Scan a directory's .claude/agents/ folder and parse agent metadata.
+ * Returns empty array if no agents found or directory doesn't exist.
+ */
+export async function scanAgents(workingDirectory: string): Promise<AgentMetadata[]> {
+  const agentsDir = join(workingDirectory, '.claude', 'agents');
+  const agents: AgentMetadata[] = [];
+
+  let files: string[];
+  try {
+    files = await readdir(agentsDir);
+  } catch {
+    return agents;
+  }
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    try {
+      const content = await readFile(join(agentsDir, file), 'utf-8');
+      const meta = parseFrontmatter(content);
+      if (meta.name) {
+        agents.push(meta);
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  return agents;
+}
+
+/** Parse YAML frontmatter from a markdown file. Simple key: value parser. */
+function parseFrontmatter(content: string): AgentMetadata {
+  const meta: AgentMetadata = { name: '' };
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return meta;
+
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const key = line.slice(0, idx).trim();
+    let value = line.slice(idx + 1).trim();
+    // Strip surrounding quotes
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key === 'name') meta.name = value;
+    else if (key === 'description') meta.description = value;
+    else if (key === 'model') meta.model = value;
+    else if (key === 'tools') meta.tools = value;
+  }
+
+  return meta;
+}
+
+/**
+ * Cache for agent metadata. Scanned once at startup, refreshed on demand.
+ */
+const agentCache = new Map<string, { agents: AgentMetadata[]; timestamp: number }>();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+export async function getAgents(workingDirectory: string): Promise<AgentMetadata[]> {
+  const cached = agentCache.get(workingDirectory);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    return cached.agents;
+  }
+  const agents = await scanAgents(workingDirectory);
+  agentCache.set(workingDirectory, { agents, timestamp: Date.now() });
+  return agents;
+}

--- a/src/api/routes/team-routes.ts
+++ b/src/api/routes/team-routes.ts
@@ -14,7 +14,7 @@ export async function handleTeamRoutes(
 
   // GET /api/team/status
   if (method === 'GET' && url === '/api/team/status') {
-    const status = getTeamStatus(registry);
+    const status = await getTeamStatus(registry);
     jsonResponse(res, 200, status);
     return true;
   }

--- a/src/api/team-status.ts
+++ b/src/api/team-status.ts
@@ -1,4 +1,5 @@
 import type { BotRegistry, BotInfo } from './bot-registry.js';
+import { getAgents, type AgentMetadata } from './agent-scanner.js';
 
 export interface BotStatus extends BotInfo {
   status: 'idle' | 'busy' | 'error';
@@ -13,6 +14,7 @@ export interface BotStatus extends BotInfo {
     failedTasks: number;
     totalCostUsd: number;
   };
+  agents?: AgentMetadata[];
 }
 
 export interface TeamStatus {
@@ -29,7 +31,7 @@ export interface TeamStatus {
 /**
  * Aggregate bot status from the registry, running tasks, and cost tracker.
  */
-export function getTeamStatus(registry: BotRegistry): TeamStatus {
+export async function getTeamStatus(registry: BotRegistry): Promise<TeamStatus> {
   const bots: BotStatus[] = [];
   const registeredBots = registry.list();
 
@@ -57,6 +59,9 @@ export function getTeamStatus(registry: BotRegistry): TeamStatus {
     const costStats = bridge?.costTracker?.getStats();
     const botStats = costStats?.byBot?.[botInfo.name];
 
+    // Scan sub-agents from the bot's working directory
+    const agents = await getAgents(botInfo.workingDirectory);
+
     bots.push({
       ...botInfo,
       status,
@@ -67,6 +72,7 @@ export function getTeamStatus(registry: BotRegistry): TeamStatus {
         failedTasks: botStats?.failedTasks ?? 0,
         totalCostUsd: botStats?.totalCostUsd ?? 0,
       },
+      ...(agents.length > 0 ? { agents } : {}),
     });
   }
 

--- a/web/src/components/office/PixelOffice.tsx
+++ b/web/src/components/office/PixelOffice.tsx
@@ -1,19 +1,17 @@
 /* ============================================================
    PixelOffice — 2D Pixel art virtual office for the Team tab.
-   Replaces TeamDashboard with an interactive pixel office where
-   each agent sits at a desk and the user can walk around and chat.
+   Each bot gets its own room with sub-agents at desks inside.
+   Click any agent (lead or sub-agent) to open a chat session.
    ============================================================ */
 
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useStore, type BotStatus, type TeamStatus } from '../../store';
 import { OfficeCanvas } from './canvas/OfficeCanvas';
 import { generateLayout } from './engine/layout-generator';
 import { agentColor } from './canvas/sprites';
-import { worldToScreen } from './engine/interaction';
 import { ChatSidePanel } from './ui/ChatSidePanel';
 import { AgentTooltip } from './ui/AgentTooltip';
-import type { AgentSprite, Position } from './types';
-import { TILE_SIZE } from './types';
+import type { AgentSprite } from './types';
 import styles from './PixelOffice.module.css';
 
 /* ── Team status polling hook ── */
@@ -62,50 +60,84 @@ export function PixelOffice() {
   const [hoveredAgent, setHoveredAgent] = useState<string | null>(null);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
 
-  // Generate layout from bot names
+  // Count total sub-agents for summary
+  const totalSubAgents = useMemo(() => {
+    if (!teamStatus) return 0;
+    return teamStatus.bots.reduce((sum, b) => sum + (b.agents?.length || 0), 0);
+  }, [teamStatus]);
+
+  // Generate layout: each bot gets a room with its sub-agents
   const layout = useMemo(() => {
     if (!teamStatus) return null;
     const bots = teamStatus.bots.map((b) => ({
       name: b.name,
       specialties: b.specialties,
       platform: b.platform,
+      agents: b.agents?.map((a) => ({
+        name: a.name,
+        description: a.description,
+        model: a.model,
+      })),
     }));
     return generateLayout(bots);
-  }, [teamStatus?.bots.length]); // only regenerate when bot count changes
+  }, [teamStatus?.bots.map((b) => `${b.name}:${b.agents?.length || 0}`).join(',')]);
 
-  // Build agent sprites from team status + layout positions
+  // Build agent sprites for leads AND sub-agents
   const agents = useMemo(() => {
     const map = new Map<string, AgentSprite>();
     if (!teamStatus || !layout) return map;
 
     for (const bot of teamStatus.bots) {
-      const pos = layout.agentPositions.get(bot.name);
-      if (!pos) continue;
-      map.set(bot.name, {
-        botName: bot.name,
-        position: pos.seat,
-        deskPosition: pos.desk,
-        status: bot.status,
-        color: agentColor(bot.name),
-        description: bot.description,
-        specialties: bot.specialties,
-        platform: bot.platform,
-        currentTask: bot.currentTask
-          ? { durationMs: bot.currentTask.durationMs }
-          : undefined,
-        stats: bot.stats
-          ? {
-              totalTasks: bot.stats.totalTasks,
-              completedTasks: bot.stats.completedTasks,
-              totalCostUsd: bot.stats.totalCostUsd,
-            }
-          : undefined,
-      });
+      // Lead bot sprite
+      const leadPos = layout.agentPositions.get(bot.name);
+      if (leadPos) {
+        map.set(bot.name, {
+          botName: bot.name,
+          position: leadPos.seat,
+          deskPosition: leadPos.desk,
+          status: bot.status,
+          color: agentColor(bot.name),
+          description: bot.description,
+          specialties: bot.specialties,
+          platform: bot.platform,
+          currentTask: bot.currentTask
+            ? { durationMs: bot.currentTask.durationMs }
+            : undefined,
+          stats: bot.stats
+            ? {
+                totalTasks: bot.stats.totalTasks,
+                completedTasks: bot.stats.completedTasks,
+                totalCostUsd: bot.stats.totalCostUsd,
+              }
+            : undefined,
+          isLead: true,
+        });
+      }
+
+      // Sub-agent sprites
+      if (bot.agents) {
+        for (const sub of bot.agents) {
+          const key = `${bot.name}/${sub.name}`;
+          const subPos = layout.agentPositions.get(key);
+          if (!subPos) continue;
+          map.set(key, {
+            botName: sub.name,
+            position: subPos.seat,
+            deskPosition: subPos.desk,
+            status: 'idle', // sub-agents don't have independent status
+            color: agentColor(sub.name),
+            description: sub.description,
+            platform: sub.model || 'sub-agent',
+            isLead: false,
+            parentBot: bot.name,
+          });
+        }
+      }
     }
     return map;
   }, [teamStatus, layout]);
 
-  // Track mouse for tooltip positioning
+  // Track mouse for tooltip
   useEffect(() => {
     const handler = (e: MouseEvent) => setMousePos({ x: e.clientX, y: e.clientY });
     window.addEventListener('mousemove', handler);
@@ -124,8 +156,15 @@ export function PixelOffice() {
     setSelectedAgent(null);
   }, []);
 
-  // Find bot status for selected/hovered agent
-  const selectedBotStatus = teamStatus?.bots.find((b) => b.name === selectedAgent);
+  // For chat panel: resolve the actual bot name to chat with
+  // Sub-agents chat through their parent bot
+  const chatBotName = useMemo(() => {
+    if (!selectedAgent) return null;
+    const sprite = agents.get(selectedAgent);
+    return sprite?.parentBot || selectedAgent;
+  }, [selectedAgent, agents]);
+
+  const selectedBotStatus = teamStatus?.bots.find((b) => b.name === chatBotName);
   const hoveredAgentSprite = hoveredAgent ? agents.get(hoveredAgent) : null;
 
   if (loading && !teamStatus) {
@@ -153,7 +192,10 @@ export function PixelOffice() {
       {/* Status bar */}
       <div className={styles.statusBar}>
         <span className={styles.stat}>
-          <span className={styles.statValue}>{summary.totalBots}</span> Agents
+          <span className={styles.statValue}>{summary.totalBots}</span> Bots
+        </span>
+        <span className={styles.stat}>
+          <span className={styles.statValue}>{totalSubAgents}</span> Sub-agents
         </span>
         <span className={styles.stat}>
           <span className={styles.statBusy}>{summary.busyBots}</span> Busy
@@ -167,7 +209,7 @@ export function PixelOffice() {
         <span className={styles.hint}>Click agent to chat | Click floor to move</span>
       </div>
 
-      {/* Main content: canvas + optional side panel */}
+      {/* Main content */}
       <div className={styles.main}>
         <div className={styles.canvasArea}>
           <OfficeCanvas
@@ -182,10 +224,10 @@ export function PixelOffice() {
           />
         </div>
 
-        {/* Chat side panel */}
-        {selectedAgent && (
+        {/* Chat side panel — always talks to the parent bot */}
+        {chatBotName && (
           <ChatSidePanel
-            botName={selectedAgent}
+            botName={chatBotName}
             botStatus={selectedBotStatus}
             onClose={handleCloseChat}
           />

--- a/web/src/components/office/canvas/renderer.ts
+++ b/web/src/components/office/canvas/renderer.ts
@@ -106,6 +106,7 @@ export function renderFrame(
           d.name,
           frame,
           d.name === selectedAgent,
+          a.isLead,
         );
         // Hover highlight
         if (d.name === hoveredAgent && d.name !== selectedAgent) {

--- a/web/src/components/office/canvas/sprites.ts
+++ b/web/src/components/office/canvas/sprites.ts
@@ -153,6 +153,7 @@ export function drawAgent(
   name: string,
   frame: number,
   isSelected: boolean,
+  isLead?: boolean,
 ): void {
   const px = x * TILE_SIZE;
   const py = y * TILE_SIZE;
@@ -164,6 +165,14 @@ export function drawAgent(
     ctx.lineWidth = 2;
     ctx.strokeRect(px - 2, py - 18, TILE_SIZE + 4, TILE_SIZE + 22);
     ctx.lineWidth = 1;
+  }
+
+  // Lead badge glow
+  if (isLead) {
+    ctx.fillStyle = 'rgba(255, 215, 0, 0.15)';
+    ctx.beginPath();
+    ctx.arc(cx, py + 12, 18, 0, Math.PI * 2);
+    ctx.fill();
   }
 
   // Body

--- a/web/src/components/office/engine/layout-generator.ts
+++ b/web/src/components/office/engine/layout-generator.ts
@@ -1,74 +1,72 @@
 /* ============================================================
    Office Layout Generator
-   Auto-generates a tile map from a list of bot names.
+   Creates a large office where each bot has its own room
+   containing its sub-agents at individual desks.
    ============================================================ */
 
 import { TileType, type TileMap, type Room, type Position } from '../types';
 
-interface LayoutInput {
+export interface SubAgent {
+  name: string;
+  description?: string;
+  model?: string;
+}
+
+export interface LayoutInput {
   name: string;
   specialties?: string[];
   platform?: string;
+  agents?: SubAgent[];
 }
 
-interface LayoutResult {
+export interface LayoutResult {
   tileMap: TileMap;
   rooms: Room[];
+  /** Key: "botName" for the lead, "botName/subAgentName" for sub-agents */
   agentPositions: Map<string, { seat: Position; desk: Position }>;
   playerSpawn: Position;
 }
 
-/** Group bots into rooms by first specialty or platform */
-function groupBots(bots: LayoutInput[]): Map<string, LayoutInput[]> {
-  const groups = new Map<string, LayoutInput[]>();
-  for (const bot of bots) {
-    const key = bot.specialties?.[0] || bot.platform || 'general';
-    const arr = groups.get(key) || [];
-    arr.push(bot);
-    groups.set(key, arr);
-  }
-  return groups;
+interface RoomLayout {
+  room: Room;
+  desks: Position[];
+  seats: Position[];
+  width: number;
+  height: number;
 }
 
-/** Create a single room with desks for n agents */
-function createRoom(
+/**
+ * Create a room for a bot and its sub-agents.
+ * The bot lead sits at a prominent desk; sub-agents fill rows behind.
+ */
+function createTeamRoom(
   id: string,
   name: string,
-  agentCount: number,
+  memberCount: number, // lead + sub-agents
   offsetX: number,
   offsetY: number,
-): { room: Room; desks: Position[]; seats: Position[]; width: number; height: number } {
-  // Layout: 2 columns of desks, each desk takes 2x2 area (desk + seat)
-  const cols = 2;
-  const rows = Math.ceil(agentCount / cols);
-  // Room inner size: cols * 3 wide (desk spacing) + 1 padding, rows * 2 + 1 padding
-  const innerW = cols * 4;
-  const innerH = rows * 3 + 1;
-  const width = innerW + 2; // +2 for walls
+): RoomLayout {
+  const cols = Math.min(memberCount, 3);
+  const rows = Math.ceil(memberCount / cols);
+  const innerW = cols * 4 + 1;
+  const innerH = rows * 3 + 2; // extra row for room label
+  const width = innerW + 2;
   const height = innerH + 2;
 
   const desks: Position[] = [];
   const seats: Position[] = [];
 
-  for (let i = 0; i < agentCount; i++) {
+  for (let i = 0; i < memberCount; i++) {
     const col = i % cols;
     const row = Math.floor(i / cols);
     const dx = offsetX + 1 + col * 4 + 1;
-    const dy = offsetY + 1 + row * 3 + 1;
+    const dy = offsetY + 2 + row * 3 + 1; // +2 for label space
     desks.push({ x: dx, y: dy });
-    seats.push({ x: dx, y: dy + 1 }); // agent sits south of desk
+    seats.push({ x: dx, y: dy + 1 });
   }
 
   return {
-    room: {
-      id,
-      name,
-      x: offsetX,
-      y: offsetY,
-      width,
-      height,
-      agents: [],
-    },
+    room: { id, name, x: offsetX, y: offsetY, width, height, agents: [] },
     desks,
     seats,
     width,
@@ -86,34 +84,73 @@ export function generateLayout(bots: LayoutInput[]): LayoutResult {
     };
   }
 
-  const groups = groupBots(bots);
-  const roomDefs: { id: string; name: string; bots: LayoutInput[] }[] = [];
-  let i = 0;
-  for (const [name, members] of groups) {
-    roomDefs.push({ id: `room-${i}`, name, bots: members });
-    i++;
+  // Each bot gets its own room. Members = lead (the bot) + its sub-agents.
+  const teamRooms: { bot: LayoutInput; members: string[]; memberCount: number }[] = [];
+  for (const bot of bots) {
+    const subNames = (bot.agents || []).map((a) => a.name);
+    teamRooms.push({
+      bot,
+      members: [bot.name, ...subNames],
+      memberCount: 1 + subNames.length,
+    });
   }
 
-  // Corridor height
+  // Arrange rooms in a grid layout (multiple rows of rooms)
+  const maxRoomsPerRow = Math.min(teamRooms.length, 4);
+  const rowCount = Math.ceil(teamRooms.length / maxRoomsPerRow);
   const corridorH = 3;
 
-  // Calculate room sizes and total width
-  const roomResults: ReturnType<typeof createRoom>[] = [];
-  let totalWidth = 1; // left margin
-  const roomY = 1; // top margin
-
-  for (const def of roomDefs) {
-    const result = createRoom(def.id, def.name, def.bots.length, totalWidth, roomY);
-    roomResults.push(result);
-    totalWidth += result.width + 1; // gap between rooms
+  // First pass: compute room sizes
+  const roomLayouts: RoomLayout[] = [];
+  for (let i = 0; i < teamRooms.length; i++) {
+    const t = teamRooms[i];
+    // Placeholder position, will recompute
+    roomLayouts.push(createTeamRoom(`room-${i}`, t.bot.name, t.memberCount, 0, 0));
   }
-  totalWidth = Math.max(totalWidth, 12);
 
-  const maxRoomHeight = Math.max(...roomResults.map((r) => r.height), 6);
-  const corridorY = roomY + maxRoomHeight;
-  const totalHeight = corridorY + corridorH + 2;
+  // Compute row widths and heights
+  const rowInfos: { roomIndices: number[]; maxHeight: number; totalWidth: number }[] = [];
+  for (let r = 0; r < rowCount; r++) {
+    const startIdx = r * maxRoomsPerRow;
+    const endIdx = Math.min(startIdx + maxRoomsPerRow, teamRooms.length);
+    const indices = [];
+    let maxH = 0;
+    let totalW = 1; // left margin
+    for (let i = startIdx; i < endIdx; i++) {
+      indices.push(i);
+      maxH = Math.max(maxH, roomLayouts[i].height);
+      totalW += roomLayouts[i].width + 1;
+    }
+    rowInfos.push({ roomIndices: indices, maxHeight: maxH, totalWidth: totalW });
+  }
 
-  // Initialize tile map with VOID
+  const maxTotalWidth = Math.max(...rowInfos.map((r) => r.totalWidth), 16);
+
+  // Second pass: place rooms with correct offsets
+  let currentY = 1;
+  const finalRooms: RoomLayout[] = [];
+
+  for (let r = 0; r < rowInfos.length; r++) {
+    const info = rowInfos[r];
+    let currentX = 1;
+
+    for (const idx of info.roomIndices) {
+      const t = teamRooms[idx];
+      const layout = createTeamRoom(`room-${idx}`, t.bot.name, t.memberCount, currentX, currentY);
+      finalRooms[idx] = layout;
+      currentX += layout.width + 1;
+    }
+
+    currentY += info.maxHeight;
+
+    // Add corridor after each row of rooms
+    currentY += corridorH;
+  }
+
+  const totalHeight = currentY + 1;
+  const totalWidth = maxTotalWidth;
+
+  // Initialize tile map
   const tiles: TileType[][] = Array.from({ length: totalHeight }, () =>
     Array(totalWidth).fill(TileType.VOID),
   );
@@ -121,92 +158,132 @@ export function generateLayout(bots: LayoutInput[]): LayoutResult {
   const rooms: Room[] = [];
   const agentPositions = new Map<string, { seat: Position; desk: Position }>();
 
-  // Draw each room
-  for (let ri = 0; ri < roomDefs.length; ri++) {
-    const def = roomDefs[ri];
-    const result = roomResults[ri];
-    const { room } = result;
+  // Draw rooms
+  for (let idx = 0; idx < teamRooms.length; idx++) {
+    const t = teamRooms[idx];
+    const layout = finalRooms[idx];
+    if (!layout) continue;
+    const { room } = layout;
 
-    // Draw room floor and walls
-    for (let ry = room.y; ry < room.y + result.height; ry++) {
-      for (let rx = room.x; rx < room.x + result.width; rx++) {
+    // Draw floor and walls
+    for (let ry = room.y; ry < room.y + layout.height; ry++) {
+      for (let rx = room.x; rx < room.x + layout.width; rx++) {
         if (ry < 0 || ry >= totalHeight || rx < 0 || rx >= totalWidth) continue;
-        if (
+        const isWall =
           ry === room.y ||
-          ry === room.y + result.height - 1 ||
+          ry === room.y + layout.height - 1 ||
           rx === room.x ||
-          rx === room.x + result.width - 1
-        ) {
-          tiles[ry][rx] = TileType.WALL;
-        } else {
-          tiles[ry][rx] = TileType.FLOOR;
-        }
+          rx === room.x + layout.width - 1;
+        tiles[ry][rx] = isWall ? TileType.WALL : TileType.FLOOR;
       }
     }
 
-    // Place door at bottom center of room
-    const doorX = room.x + Math.floor(result.width / 2);
-    const doorY = room.y + result.height - 1;
-    if (doorY < totalHeight && doorX < totalWidth) {
-      tiles[doorY][doorX] = TileType.DOOR;
-    }
+    // Door at bottom center
+    const doorX = room.x + Math.floor(layout.width / 2);
+    const doorY = room.y + layout.height - 1;
+    if (doorY < totalHeight && doorX < totalWidth) tiles[doorY][doorX] = TileType.DOOR;
 
-    // Place desks and chairs
-    for (let di = 0; di < result.desks.length; di++) {
-      const desk = result.desks[di];
-      const seat = result.seats[di];
+    // Place desks and chairs, assign positions
+    const agentNames: string[] = [];
+    for (let mi = 0; mi < t.members.length; mi++) {
+      const desk = layout.desks[mi];
+      const seat = layout.seats[mi];
+      if (!desk || !seat) continue;
       if (desk.y < totalHeight && desk.x < totalWidth) tiles[desk.y][desk.x] = TileType.DESK;
       if (seat.y < totalHeight && seat.x < totalWidth) tiles[seat.y][seat.x] = TileType.CHAIR;
-    }
 
-    // Assign agents to positions
-    const agentNames: string[] = [];
-    for (let ai = 0; ai < def.bots.length; ai++) {
-      agentPositions.set(def.bots[ai].name, {
-        seat: result.seats[ai],
-        desk: result.desks[ai],
-      });
-      agentNames.push(def.bots[ai].name);
+      const memberName = t.members[mi];
+      // Key: "botName" for lead, "botName/subAgentName" for sub-agents
+      const key = mi === 0 ? memberName : `${t.bot.name}/${memberName}`;
+      agentPositions.set(key, { seat, desk });
+      agentNames.push(key);
     }
 
     rooms.push({ ...room, agents: agentNames });
   }
 
-  // Draw corridor
-  for (let cy = corridorY; cy < corridorY + corridorH && cy < totalHeight; cy++) {
-    for (let cx = 0; cx < totalWidth; cx++) {
-      if (tiles[cy][cx] === TileType.VOID) {
-        tiles[cy][cx] = TileType.CARPET;
+  // Draw corridors (fill VOID rows between room rows)
+  for (let y = 0; y < totalHeight; y++) {
+    // Check if this row is entirely VOID across the width — it's a corridor row
+    let isCorridorRow = true;
+    for (let x = 0; x < totalWidth; x++) {
+      if (tiles[y][x] !== TileType.VOID) { isCorridorRow = false; break; }
+    }
+    if (isCorridorRow) {
+      // Check if adjacent to a room (wall or door above or below)
+      let nearRoom = false;
+      for (let x = 0; x < totalWidth; x++) {
+        if (y > 0 && (tiles[y - 1][x] === TileType.WALL || tiles[y - 1][x] === TileType.DOOR)) nearRoom = true;
+        if (y < totalHeight - 1 && (tiles[y + 1][x] === TileType.WALL || tiles[y + 1][x] === TileType.DOOR)) nearRoom = true;
+      }
+      if (nearRoom) {
+        for (let x = 0; x < totalWidth; x++) {
+          if (tiles[y][x] === TileType.VOID) tiles[y][x] = TileType.CARPET;
+        }
       }
     }
   }
 
-  // Add some plants for decoration
-  const plantPositions = [
-    { x: 0, y: corridorY },
-    { x: totalWidth - 1, y: corridorY },
-    { x: 0, y: corridorY + corridorH - 1 },
-    { x: totalWidth - 1, y: corridorY + corridorH - 1 },
-  ];
-  for (const p of plantPositions) {
-    if (p.y < totalHeight && p.x < totalWidth && tiles[p.y][p.x] !== TileType.WALL) {
-      tiles[p.y][p.x] = TileType.PLANT;
+  // Fill remaining VOID gaps between rooms in the same row with carpet
+  for (let y = 0; y < totalHeight; y++) {
+    let hasFloor = false;
+    for (let x = 0; x < totalWidth; x++) {
+      if (tiles[y][x] === TileType.FLOOR || tiles[y][x] === TileType.CARPET) hasFloor = true;
+    }
+    if (!hasFloor) continue;
+    // Fill VOID gaps in rows that have floor tiles
+    let first = -1;
+    let last = -1;
+    for (let x = 0; x < totalWidth; x++) {
+      if (tiles[y][x] !== TileType.VOID) {
+        if (first < 0) first = x;
+        last = x;
+      }
+    }
+    // Don't fill — the walls themselves form the boundary
+  }
+
+  // Add a main corridor at the bottom spanning full width
+  const mainCorridorY = totalHeight - corridorH - 1;
+  for (let cy = mainCorridorY; cy < mainCorridorY + corridorH && cy < totalHeight; cy++) {
+    for (let cx = 0; cx < totalWidth; cx++) {
+      if (tiles[cy][cx] === TileType.VOID) tiles[cy][cx] = TileType.CARPET;
     }
   }
 
+  // Connect rooms to corridors: ensure carpet path from each door downward
+  for (const layout of finalRooms) {
+    if (!layout) continue;
+    const doorX = layout.room.x + Math.floor(layout.width / 2);
+    const doorY = layout.room.y + layout.height - 1;
+    for (let y = doorY + 1; y < totalHeight; y++) {
+      if (tiles[y][doorX] === TileType.VOID) tiles[y][doorX] = TileType.CARPET;
+      if (tiles[y][doorX] === TileType.CARPET) break; // reached corridor
+      if (tiles[y][doorX] === TileType.WALL) break;
+    }
+  }
+
+  // Plants at corridor corners
+  const plantCandidates = [
+    { x: 0, y: mainCorridorY },
+    { x: totalWidth - 1, y: mainCorridorY },
+  ];
+  for (const p of plantCandidates) {
+    if (p.y >= 0 && p.y < totalHeight && p.x >= 0 && p.x < totalWidth) {
+      if (tiles[p.y][p.x] === TileType.CARPET || tiles[p.y][p.x] === TileType.VOID) {
+        tiles[p.y][p.x] = TileType.PLANT;
+      }
+    }
+  }
+
+  // Player spawns at bottom center corridor
   const playerSpawn: Position = {
     x: Math.floor(totalWidth / 2),
-    y: corridorY + 1,
+    y: Math.min(mainCorridorY + 1, totalHeight - 2),
   };
-  // Ensure spawn tile is walkable
-  if (playerSpawn.y < totalHeight && playerSpawn.x < totalWidth) {
+  if (playerSpawn.y >= 0 && playerSpawn.y < totalHeight && playerSpawn.x >= 0 && playerSpawn.x < totalWidth) {
     tiles[playerSpawn.y][playerSpawn.x] = TileType.CARPET;
   }
 
-  return {
-    tileMap: { width: totalWidth, height: totalHeight, tiles },
-    rooms,
-    agentPositions,
-    playerSpawn,
-  };
+  return { tileMap: { width: totalWidth, height: totalHeight, tiles }, rooms, agentPositions, playerSpawn };
 }

--- a/web/src/components/office/types.ts
+++ b/web/src/components/office/types.ts
@@ -37,6 +37,10 @@ export interface AgentSprite {
   platform?: string;
   currentTask?: { durationMs: number };
   stats?: { totalTasks: number; completedTasks: number; totalCostUsd: number };
+  /** True if this is the lead bot (not a sub-agent) */
+  isLead?: boolean;
+  /** Parent bot name (set for sub-agents) */
+  parentBot?: string;
 }
 
 export interface Room {

--- a/web/src/components/office/ui/AgentTooltip.module.css
+++ b/web/src/components/office/ui/AgentTooltip.module.css
@@ -30,6 +30,12 @@
   color: var(--text-secondary, #999);
 }
 
+.parent {
+  font-size: 10px;
+  color: var(--text-tertiary, #777);
+  margin-bottom: 4px;
+}
+
 .desc {
   font-size: 11px;
   color: var(--text-secondary, #999);

--- a/web/src/components/office/ui/AgentTooltip.tsx
+++ b/web/src/components/office/ui/AgentTooltip.tsx
@@ -33,9 +33,17 @@ export function AgentTooltip({ agent, screenX, screenY }: AgentTooltipProps) {
       }}
     >
       <div className={styles.header}>
-        <span className={styles.name}>{agent.botName}</span>
+        <span className={styles.name}>
+          {agent.isLead ? '\u{2B50} ' : ''}{agent.botName}
+        </span>
         <span className={styles.status}>{statusEmoji} {agent.status}</span>
       </div>
+      {agent.parentBot && (
+        <div className={styles.parent}>Team: {agent.parentBot}</div>
+      )}
+      {agent.platform && !agent.parentBot && (
+        <div className={styles.parent}>{agent.platform}</div>
+      )}
       {agent.description && <div className={styles.desc}>{agent.description}</div>}
       {agent.specialties && agent.specialties.length > 0 && (
         <div className={styles.tags}>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -15,6 +15,13 @@ import type {
 
 /* ---- team status types ---- */
 
+export interface AgentMetadata {
+  name: string;
+  description?: string;
+  model?: string;
+  tools?: string;
+}
+
 export interface BotStatus {
   name: string;
   description?: string;
@@ -34,6 +41,7 @@ export interface BotStatus {
     failedTasks: number;
     totalCostUsd: number;
   };
+  agents?: AgentMetadata[];
 }
 
 export interface TeamStatus {


### PR DESCRIPTION
## Summary
- Add backend agent scanner (`agent-scanner.ts`) that reads `.claude/agents/*.md` YAML frontmatter to discover sub-agents per bot
- Extend `/api/team/status` to include each bot's sub-agents in the response
- Rewrite office layout generator to create per-bot team rooms (lead + sub-agents at desks) arranged in a grid with corridors
- Sub-agents render in the pixel office with their parent bot; clicking a sub-agent opens chat through the parent bot
- Lead bots get a golden glow badge; tooltips show team membership

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 174 tests pass
- [x] `npm run lint` — 0 errors
- [ ] Open `/web/` → Team tab shows pixel office with per-bot rooms
- [ ] Each room contains the lead bot + sub-agents at individual desks
- [ ] Clicking a sub-agent opens chat via parent bot
- [ ] Hover tooltip shows parent team info for sub-agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)