### PR TITLE
feat(web): add session rename and search in sidebar

### DIFF
--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -288,6 +288,13 @@ export class SessionRegistry {
     return session.claudeSessionId;
   }
 
+  /** Rename a session. */
+  renameSession(id: string, newTitle: string): boolean {
+    const result = this.db.prepare('UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?')
+      .run(newTitle, Date.now(), id);
+    return result.changes > 0;
+  }
+
   /** Delete a session and all its messages/links. */
   deleteSession(id: string): void {
     this.db.prepare('DELETE FROM session_messages WHERE session_id = ?').run(id);

--- a/src/web/ws-server.ts
+++ b/src/web/ws-server.ts
@@ -27,6 +27,8 @@ type ClientMessage =
   | { type: 'list_sessions'; botName: string }
   | { type: 'adopt_session'; chatId: string; sessionId: string }
   | { type: 'get_session_history'; sessionId: string; since?: number }
+  | { type: 'rename_session'; chatId: string; title: string }
+  | { type: 'delete_session'; chatId: string }
   | { type: 'start_asr' }
   | { type: 'stop_asr' }
   | { type: 'ping' };
@@ -47,6 +49,8 @@ type ServerMessage =
   | { type: 'sessions_list'; botName: string; sessions: SessionRecord[] }
   | { type: 'session_adopted'; chatId: string; sessionId: string; claudeSessionId?: string; history: SessionMessage[] }
   | { type: 'session_history'; sessionId: string; messages: SessionMessage[] }
+  | { type: 'session_renamed'; chatId: string; title: string }
+  | { type: 'session_deleted'; chatId: string }
   | { type: 'asr_started' }
   | { type: 'asr_transcript'; text: string; isFinal: boolean }
   | { type: 'asr_error'; error: string }
@@ -334,6 +338,32 @@ export function setupWebSocketServer(
           }
           const messages = sessionRegistry.getMessages(msg.sessionId, msg.since);
           sendMessage(ws, { type: 'session_history', sessionId: msg.sessionId, messages });
+          break;
+        }
+
+        case 'rename_session': {
+          if (!sessionRegistry) {
+            sendMessage(ws, { type: 'error', chatId: msg.chatId, error: 'Session sync not available' });
+            break;
+          }
+          const session = sessionRegistry.findByChatId(msg.chatId);
+          if (session) {
+            sessionRegistry.renameSession(session.id, msg.title);
+            sendMessage(ws, { type: 'session_renamed', chatId: msg.chatId, title: msg.title });
+          }
+          break;
+        }
+
+        case 'delete_session': {
+          if (!sessionRegistry) {
+            sendMessage(ws, { type: 'error', chatId: msg.chatId, error: 'Session sync not available' });
+            break;
+          }
+          const delSession = sessionRegistry.findByChatId(msg.chatId);
+          if (delSession) {
+            sessionRegistry.deleteSession(delSession.id);
+            sendMessage(ws, { type: 'session_deleted', chatId: msg.chatId });
+          }
           break;
         }
 

--- a/web/src/components/Layout.module.css
+++ b/web/src/components/Layout.module.css
@@ -149,6 +149,61 @@
   font-family: var(--font-mono);
 }
 
+/* ═══ Search Box ═══ */
+
+.searchBox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  border-radius: var(--r-md);
+  background: var(--surface-1);
+  border: 1px solid var(--glass-border);
+  transition: border-color var(--duration-fast);
+}
+
+.searchBox:focus-within {
+  border-color: var(--accent);
+}
+
+.searchBox svg {
+  color: var(--text-3);
+  flex-shrink: 0;
+}
+
+.searchInput {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text-1);
+  font-size: 12px;
+  font-family: inherit;
+}
+
+.searchInput::placeholder {
+  color: var(--text-3);
+}
+
+.searchClear {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-xs);
+  color: var(--text-3);
+  flex-shrink: 0;
+  transition: color var(--duration-fast), background var(--duration-fast);
+}
+
+.searchClear:hover {
+  color: var(--text-1);
+  background: var(--surface-hover);
+}
+
 /* ═══ Agents List ═══ */
 
 .agentsList {
@@ -393,6 +448,19 @@
 .sessionItem[data-active] .sessionTitle {
   color: var(--text-0);
   font-weight: 500;
+}
+
+.sessionRenameInput {
+  flex: 1;
+  min-width: 0;
+  background: var(--surface-1);
+  border: 1px solid var(--accent);
+  border-radius: var(--r-xs);
+  outline: none;
+  color: var(--text-0);
+  font-size: 12px;
+  font-family: inherit;
+  padding: 1px 4px;
 }
 
 .sessionTime {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useStore } from '../store';
 import { useWebSocket } from '../hooks/useWebSocket';
@@ -78,6 +78,14 @@ function IconPanelLeft() {
     <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
       <rect x="3" y="3" width="18" height="18" rx="2" />
       <path d="M9 3v18" />
+    </svg>
+  );
+}
+function IconSearch() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="11" cy="11" r="8" />
+      <path d="M21 21l-4.35-4.35" />
     </svg>
   );
 }
@@ -180,6 +188,7 @@ function BotCard({
   onSessionClick,
   onNewSession,
   onDeleteSession,
+  onRenameSession,
 }: {
   bot: BotInfo;
   sessions: ChatSession[];
@@ -189,13 +198,30 @@ function BotCard({
   onSessionClick: (id: string, botName: string) => void;
   onNewSession: (botName: string) => void;
   onDeleteSession: (id: string) => void;
+  onRenameSession: (id: string, title: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const editRef = useRef<HTMLInputElement>(null);
   const isActive = activeBotName === bot.name && activeView === 'chat';
   const sorted = [...botSessions].sort((a, b) => b.updatedAt - a.updatedAt);
   const latest = sorted[0] || null;
   const preview = latest ? sessionPreview(latest) : null;
   const hasMultiple = sorted.length > 1;
+
+  const startRename = useCallback((session: ChatSession) => {
+    setEditingId(session.id);
+    setEditValue(session.title);
+    setTimeout(() => editRef.current?.select(), 0);
+  }, []);
+
+  const commitRename = useCallback(() => {
+    if (editingId && editValue.trim()) {
+      onRenameSession(editingId, editValue.trim());
+    }
+    setEditingId(null);
+  }, [editingId, editValue, onRenameSession]);
 
   return (
     <div className={s.botCard} data-active={isActive || undefined}>
@@ -274,9 +300,26 @@ function BotCard({
               className={s.sessionItem}
               data-active={activeSessionId === session.id || undefined}
               onClick={() => onSessionClick(session.id, bot.name)}
+              onDoubleClick={(e) => { e.stopPropagation(); startRename(session); }}
             >
               <span className={s.sessionDash} />
-              <span className={s.sessionTitle}>{session.title}</span>
+              {editingId === session.id ? (
+                <input
+                  ref={editRef}
+                  className={s.sessionRenameInput}
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename();
+                    if (e.key === 'Escape') setEditingId(null);
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                  autoFocus
+                />
+              ) : (
+                <span className={s.sessionTitle}>{session.title}</span>
+              )}
               <span className={s.sessionTime}>{relTime(session.updatedAt)}</span>
               <button
                 className={s.sessionDel}
@@ -391,9 +434,12 @@ export function Layout({ children }: LayoutProps) {
   const groups = useStore((s) => s.groups);
   const createGroupSession = useStore((s) => s.createGroupSession);
 
+  const renameSessionStore = useStore((s) => s.renameSession);
+
   const { send } = useWebSocket();
 
   const [showGroupDialog, setShowGroupDialog] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
 
   /* ── Mobile detection ── */
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
@@ -431,7 +477,39 @@ export function Layout({ children }: LayoutProps) {
     setMobileShowChat(true);
   }, [createSession, setView, navigate]);
 
-  const handleDeleteSession = useCallback((id: string) => { deleteSession(id); }, [deleteSession]);
+  const handleDeleteSession = useCallback((id: string) => {
+    deleteSession(id);
+    send({ type: 'delete_session', chatId: id });
+  }, [deleteSession, send]);
+
+  const handleRenameSession = useCallback((id: string, title: string) => {
+    renameSessionStore(id, title);
+    send({ type: 'rename_session', chatId: id, title });
+  }, [renameSessionStore, send]);
+
+  // Filter sessions by search query
+  const filteredSessionsByBot = useMemo(() => {
+    if (!searchQuery.trim()) return sessionsByBot;
+    const q = searchQuery.toLowerCase();
+    const map = new Map<string, ChatSession[]>();
+    for (const [botName, sessions] of sessionsByBot) {
+      if (botName.toLowerCase().includes(q)) {
+        map.set(botName, sessions);
+      } else {
+        const filtered = sessions.filter((s) => s.title.toLowerCase().includes(q));
+        if (filtered.length > 0) map.set(botName, filtered);
+      }
+    }
+    return map;
+  }, [sessionsByBot, searchQuery]);
+
+  const filteredBots = useMemo(() => {
+    if (!searchQuery.trim()) return bots;
+    const q = searchQuery.toLowerCase();
+    return bots.filter((b) =>
+      b.name.toLowerCase().includes(q) || filteredSessionsByBot.has(b.name),
+    );
+  }, [bots, searchQuery, filteredSessionsByBot]);
 
   const handleMobileBack = useCallback(() => { setMobileShowChat(false); }, []);
 
@@ -477,22 +555,41 @@ export function Layout({ children }: LayoutProps) {
   /* ── Shared bot list ── */
   const botList = (
     <>
-      {bots.length === 0 ? (
+      {/* Search box */}
+      <div className={s.searchBox}>
+        <IconSearch />
+        <input
+          className={s.searchInput}
+          type="text"
+          placeholder="Search chats..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          spellCheck={false}
+        />
+        {searchQuery && (
+          <button className={s.searchClear} onClick={() => setSearchQuery('')}>
+            <IconX size={10} />
+          </button>
+        )}
+      </div>
+
+      {filteredBots.length === 0 ? (
         <div className={s.emptyAgents}>
-          {connected ? 'No agents configured' : 'Connecting...'}
+          {searchQuery ? 'No matches' : connected ? 'No agents configured' : 'Connecting...'}
         </div>
       ) : (
-        bots.map((bot) => (
+        filteredBots.map((bot) => (
           <BotCard
             key={bot.name}
             bot={bot}
-            sessions={sessionsByBot.get(bot.name) || []}
+            sessions={filteredSessionsByBot.get(bot.name) || []}
             activeSessionId={activeSessionId}
             activeBotName={activeBotName}
             activeView={activeView}
             onSessionClick={handleSessionClick}
             onNewSession={handleNewSession}
             onDeleteSession={handleDeleteSession}
+            onRenameSession={handleRenameSession}
           />
         ))
       )}

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -27,6 +27,8 @@ export function useWebSocket() {
   const setGroups = useStore((s) => s.setGroups);
   const setIncomingVoiceCall = useStore((s) => s.setIncomingVoiceCall);
   const addActivityEvent = useStore((s) => s.addActivityEvent);
+  const renameSession = useStore((s) => s.renameSession);
+  const deleteSession = useStore((s) => s.deleteSession);
   const mergeServerSessions = useStore((s) => s.mergeServerSessions);
   const loadServerHistory = useStore((s) => s.loadServerHistory);
   const setAsrState = useStore((s) => s.setAsrState);
@@ -231,6 +233,14 @@ export function useWebSocket() {
             break;
           }
 
+          case 'session_renamed':
+            renameSession(msg.chatId, msg.title);
+            break;
+
+          case 'session_deleted':
+            deleteSession(msg.chatId);
+            break;
+
           case 'voice_call':
             setIncomingVoiceCall({
               sessionId: msg.sessionId,
@@ -296,7 +306,7 @@ export function useWebSocket() {
         if (mountedRef.current) connect();
       }, delay);
     };
-  }, [token, cleanup, setConnected, setBots, updateMessageState, addMessage, addMessageAttachment, markRunningMessagesDisconnected, addGroup, removeGroup, setGroups, setIncomingVoiceCall, addActivityEvent, mergeServerSessions, loadServerHistory, setAsrState, setAsrPartialText]);
+  }, [token, cleanup, setConnected, setBots, updateMessageState, addMessage, addMessageAttachment, markRunningMessagesDisconnected, addGroup, removeGroup, setGroups, setIncomingVoiceCall, addActivityEvent, renameSession, deleteSession, mergeServerSessions, loadServerHistory, setAsrState, setAsrPartialText]);
 
   const send = useCallback(
     (msg: WSOutgoingMessage) => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -135,6 +135,8 @@ export interface AppStore {
   markRunningMessagesDisconnected: () => void;
   clearSessions: () => void;
   getOrCreateBotSession: (botName: string) => string;
+  /** Rename a session locally. */
+  renameSession: (id: string, title: string) => void;
   /** Merge server-side sessions into local store (session persistence). */
   mergeServerSessions: (serverSessions: ServerSession[]) => void;
   /** Load server message history into a local session. */
@@ -376,6 +378,15 @@ export const useStore = create<AppStore>((set, get) => ({
     persistSessions(sessions);
     set({ sessions, activeSessionId: id, activeBotName: botName });
     return id;
+  },
+
+  renameSession(id: string, title: string) {
+    const sessions = new Map(get().sessions);
+    const session = sessions.get(id);
+    if (!session) return;
+    sessions.set(id, { ...session, title });
+    persistSessions(sessions);
+    set({ sessions });
   },
 
   mergeServerSessions(serverSessions: ServerSession[]) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -156,6 +156,8 @@ export type WSIncomingMessage =
   | { type: 'voice_call'; sessionId: string; roomId: string; token: string; appId: string; userId: string; aiUserId: string; chatId: string; botName: string; prompt?: string }
   | { type: 'sessions_list'; botName: string; sessions: ServerSession[] }
   | { type: 'session_history'; sessionId: string; messages: ServerSessionMessage[] }
+  | { type: 'session_renamed'; chatId: string; title: string }
+  | { type: 'session_deleted'; chatId: string }
   | { type: 'activity_event'; event: ActivityEvent }
   | { type: 'asr_started' }
   | { type: 'asr_transcript'; text: string; isFinal: boolean }
@@ -174,6 +176,8 @@ export type WSOutgoingMessage =
   | { type: 'subscribe_group'; groupId: string; chatId: string }
   | { type: 'list_sessions'; botName: string }
   | { type: 'get_session_history'; sessionId: string; since?: number }
+  | { type: 'rename_session'; chatId: string; title: string }
+  | { type: 'delete_session'; chatId: string }
   | { type: 'start_asr' }
   | { type: 'stop_asr' }
   | { type: 'ping' };


### PR DESCRIPTION
## Summary
- **Inline rename**: Double-click a session title in the sidebar to rename it. Changes sync to server via WebSocket.
- **Search filter**: Search box at top of sidebar filters bots and sessions by name/title.
- **Server sync**: rename_session and delete_session WS messages keep server SessionRegistry in sync.

## Changes
- `src/session/session-registry.ts`: Add `renameSession(id, newTitle)` method
- `src/web/ws-server.ts`: Add `rename_session` and `delete_session` client message handlers
- `web/src/types.ts`: New WS message types for rename/delete
- `web/src/store.ts`: Add `renameSession()` store method
- `web/src/hooks/useWebSocket.ts`: Handle `session_renamed` and `session_deleted` messages
- `web/src/components/Layout.tsx`: Search input + inline rename on double-click
- `web/src/components/Layout.module.css`: Styles for search box and rename input

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] 174 tests pass (`npm test`)
- [ ] 0 lint errors (`npm run lint`)
- [ ] Double-click session title → inline edit → Enter to save
- [ ] Search box filters bots and sessions by name
- [ ] Rename persists across browser refresh (server sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)