### PR TITLE
feat(web): add bot management panel with create/edit/delete

### DIFF
--- a/src/api/bots-config-writer.ts
+++ b/src/api/bots-config-writer.ts
@@ -113,6 +113,37 @@ export function removeBot(configPath: string, name: string): boolean {
   return false;
 }
 
+export function updateBot(configPath: string, name: string, updates: Record<string, unknown>): boolean {
+  const config = readBotsConfig(configPath);
+
+  // Search each platform array and update the matching entry
+  const platforms = [
+    config.feishuBots,
+    config.telegramBots,
+    config.webBots,
+    config.wechatBots,
+  ];
+  for (const bots of platforms) {
+    if (!bots) continue;
+    const idx = bots.findIndex((b: any) => b.name === name);
+    if (idx !== -1) {
+      // Merge updates into existing entry (name and platform credentials are immutable)
+      const entry = bots[idx] as unknown as Record<string, unknown>;
+      for (const [key, value] of Object.entries(updates)) {
+        if (key === 'name' || key === 'platform') continue; // immutable
+        if (value === undefined || value === null || value === '') {
+          delete entry[key];
+        } else {
+          entry[key] = value;
+        }
+      }
+      writeBotsConfig(configPath, config);
+      return true;
+    }
+  }
+  return false;
+}
+
 export function getBotEntry(
   configPath: string,
   name: string,

--- a/src/api/routes/bot-routes.ts
+++ b/src/api/routes/bot-routes.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import type * as http from 'node:http';
-import { addBot, removeBot, getBotEntry } from '../bots-config-writer.js';
+import { addBot, removeBot, updateBot, getBotEntry } from '../bots-config-writer.js';
 import { installSkillsToWorkDir } from '../skills-installer.js';
 import { webBotFromJson } from '../../config.js';
 import { NullSender } from '../../web/null-sender.js';
@@ -149,6 +149,29 @@ export async function handleBotRoutes(
         throw err;
       }
     }
+    return true;
+  }
+
+  // PUT /api/bots/:name — update an existing bot
+  if (method === 'PUT' && url.startsWith('/api/bots/')) {
+    const name = decodeURIComponent(url.slice('/api/bots/'.length));
+    if (!name) {
+      jsonResponse(res, 400, { error: 'Missing bot name' });
+      return true;
+    }
+    if (!botsConfigPath) {
+      jsonResponse(res, 400, { error: 'Bot CRUD requires BOTS_CONFIG to be set' });
+      return true;
+    }
+    const body = await parseJsonBody(req);
+    const updated = updateBot(botsConfigPath, name, body);
+    if (!updated) {
+      jsonResponse(res, 404, { error: `Bot not found: ${name}` });
+      return true;
+    }
+    logger.info({ name, updates: Object.keys(body) }, 'Bot config updated');
+    ws.handle?.broadcastBotList();
+    jsonResponse(res, 200, { name, updated: true });
     return true;
   }
 

--- a/web/src/components/BotManageDialog.module.css
+++ b/web/src/components/BotManageDialog.module.css
@@ -1,0 +1,137 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  backdrop-filter: blur(4px);
+}
+
+.dialog {
+  background: var(--surface-1);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--r-lg);
+  padding: 28px;
+  width: 480px;
+  max-width: 90vw;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-0);
+  letter-spacing: -0.3px;
+  margin-bottom: 24px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  flex: 1;
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-2);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-family: var(--font-mono);
+}
+
+.input {
+  padding: 10px 14px;
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  border: 1px solid var(--glass-border);
+  color: var(--text-0);
+  font-size: 13px;
+  font-family: inherit;
+  transition: border-color var(--duration-fast);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+}
+
+.error {
+  margin-top: 12px;
+  padding: 10px 14px;
+  border-radius: var(--r-md);
+  background: var(--red-soft);
+  color: var(--red);
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.cancelBtn {
+  padding: 9px 20px;
+  border-radius: var(--r-md);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-1);
+  background: transparent;
+  border: 1px solid var(--glass-border);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+
+.cancelBtn:hover {
+  background: var(--surface-hover);
+  color: var(--text-0);
+}
+
+.submitBtn {
+  padding: 9px 24px;
+  border-radius: var(--r-md);
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+
+.submitBtn:hover {
+  box-shadow: 0 0 12px rgba(0, 214, 143, 0.3);
+}
+
+.submitBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .dialog { padding: 20px; }
+  .row { flex-direction: column; }
+}

--- a/web/src/components/BotManageDialog.tsx
+++ b/web/src/components/BotManageDialog.tsx
@@ -1,0 +1,172 @@
+import { useState, useCallback } from 'react';
+import { useStore } from '../store';
+import type { BotInfo } from '../types';
+import styles from './BotManageDialog.module.css';
+
+interface BotManageDialogProps {
+  mode: 'create' | 'edit';
+  bot?: BotInfo;
+  onClose: () => void;
+}
+
+export function BotManageDialog({ mode, bot, onClose }: BotManageDialogProps) {
+  const token = useStore((s) => s.token);
+
+  const [name, setName] = useState(bot?.name || '');
+  const [platform, setPlatform] = useState(bot?.platform || 'web');
+  const [workDir, setWorkDir] = useState(bot?.workingDirectory || '');
+  const [description, setDescription] = useState(bot?.description || '');
+  const [model, setModel] = useState('');
+  const [maxTurns, setMaxTurns] = useState('');
+  const [maxBudget, setMaxBudget] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = useCallback(async () => {
+    if (!name.trim() || !workDir.trim()) {
+      setError('Name and working directory are required');
+      return;
+    }
+    setLoading(true);
+    setError('');
+
+    const body: Record<string, unknown> = {
+      name: name.trim(),
+      platform,
+      defaultWorkingDirectory: workDir.trim(),
+    };
+    if (description.trim()) body.description = description.trim();
+    if (model.trim()) body.model = model.trim();
+    if (maxTurns.trim()) body.maxTurns = parseInt(maxTurns, 10);
+    if (maxBudget.trim()) body.maxBudgetUsd = parseFloat(maxBudget);
+
+    try {
+      const url = mode === 'create'
+        ? '/api/bots'
+        : `/api/bots/${encodeURIComponent(bot!.name)}`;
+      const method = mode === 'create' ? 'POST' : 'PUT';
+      const res = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `HTTP ${res.status}`);
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [name, platform, workDir, description, model, maxTurns, maxBudget, mode, bot, token, onClose]);
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+        <h2 className={styles.title}>
+          {mode === 'create' ? 'Add Bot' : `Edit ${bot?.name}`}
+        </h2>
+
+        <div className={styles.form}>
+          <label className={styles.field}>
+            <span className={styles.label}>Name</span>
+            <input
+              className={styles.input}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-bot"
+              disabled={mode === 'edit'}
+            />
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.label}>Platform</span>
+            <select
+              className={styles.input}
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value)}
+              disabled={mode === 'edit'}
+            >
+              <option value="web">Web</option>
+              <option value="feishu">Feishu</option>
+              <option value="telegram">Telegram</option>
+            </select>
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.label}>Working Directory</span>
+            <input
+              className={styles.input}
+              value={workDir}
+              onChange={(e) => setWorkDir(e.target.value)}
+              placeholder="/home/user/project"
+            />
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.label}>Description (optional)</span>
+            <input
+              className={styles.input}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What this bot does"
+            />
+          </label>
+
+          <div className={styles.row}>
+            <label className={styles.field}>
+              <span className={styles.label}>Model (optional)</span>
+              <input
+                className={styles.input}
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="claude-sonnet-4-6"
+              />
+            </label>
+            <label className={styles.field}>
+              <span className={styles.label}>Max Turns</span>
+              <input
+                className={styles.input}
+                type="number"
+                value={maxTurns}
+                onChange={(e) => setMaxTurns(e.target.value)}
+                placeholder="30"
+              />
+            </label>
+            <label className={styles.field}>
+              <span className={styles.label}>Budget ($)</span>
+              <input
+                className={styles.input}
+                type="number"
+                step="0.1"
+                value={maxBudget}
+                onChange={(e) => setMaxBudget(e.target.value)}
+                placeholder="5.00"
+              />
+            </label>
+          </div>
+        </div>
+
+        {error && <div className={styles.error}>{error}</div>}
+
+        <div className={styles.actions}>
+          <button className={styles.cancelBtn} onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className={styles.submitBtn}
+            onClick={handleSubmit}
+            disabled={loading}
+          >
+            {loading ? 'Saving...' : mode === 'create' ? 'Create' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SettingsView.module.css
+++ b/web/src/components/SettingsView.module.css
@@ -39,6 +39,17 @@
   font-family: var(--font-mono);
 }
 
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.sectionHeader .sectionTitle {
+  margin-bottom: 0;
+}
+
 /* Cards */
 .card {
   background: var(--surface-1);
@@ -133,6 +144,21 @@
   border-color: var(--glass-border-hover);
 }
 
+.btnAccent {
+  background: var(--accent);
+  color: #fff;
+  font-size: 12px;
+  padding: 6px 14px;
+}
+.btnAccent:hover {
+  box-shadow: 0 0 12px rgba(0, 214, 143, 0.3);
+}
+
+.btnSmall {
+  padding: 5px 12px;
+  font-size: 11px;
+}
+
 .btnDanger {
   background: var(--red-soft);
   color: var(--red);
@@ -189,6 +215,12 @@
 .botInfo { flex: 1; min-width: 0; }
 .botName { font-size: 14px; font-weight: 500; color: var(--text-0); letter-spacing: -0.1px; }
 .botMeta { font-size: 12px; color: var(--text-2); font-family: var(--font-mono); }
+
+.botActions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
 
 /* Font size segmented control */
 .fontSizeGroup {

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -1,4 +1,7 @@
+import { useState, useCallback } from 'react';
 import { useStore } from '../store';
+import type { BotInfo } from '../types';
+import { BotManageDialog } from './BotManageDialog';
 import styles from './SettingsView.module.css';
 
 export function SettingsView() {
@@ -12,6 +15,31 @@ export function SettingsView() {
   const bots = useStore((s) => s.bots);
   const sessions = useStore((s) => s.sessions);
   const clearSessions = useStore((s) => s.clearSessions);
+
+  const [dialogMode, setDialogMode] = useState<'create' | 'edit' | null>(null);
+  const [editBot, setEditBot] = useState<BotInfo | undefined>();
+
+  const handleCreateBot = useCallback(() => {
+    setEditBot(undefined);
+    setDialogMode('create');
+  }, []);
+
+  const handleEditBot = useCallback((bot: BotInfo) => {
+    setEditBot(bot);
+    setDialogMode('edit');
+  }, []);
+
+  const handleDeleteBot = useCallback(async (botName: string) => {
+    if (!window.confirm(`Delete bot "${botName}"? This cannot be undone.`)) return;
+    try {
+      await fetch(`/api/bots/${encodeURIComponent(botName)}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch {
+      // ignore — bot list will update via WS
+    }
+  }, [token]);
 
   const maskedToken = token
     ? `${token.slice(0, 6)}${'*'.repeat(Math.min(token.length - 6, 20))}`
@@ -112,9 +140,17 @@ export function SettingsView() {
 
       {/* Bots */}
       <div className={styles.section}>
-        <h2 className={styles.sectionTitle}>
-          Bots ({bots.length})
-        </h2>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>
+            Bots ({bots.length})
+          </h2>
+          <button
+            className={`${styles.btn} ${styles.btnAccent}`}
+            onClick={handleCreateBot}
+          >
+            + Add Bot
+          </button>
+        </div>
         <div className={styles.card}>
           {bots.length === 0 ? (
             <div className={styles.cardItem}>
@@ -149,6 +185,20 @@ export function SettingsView() {
                         {bot.description}
                       </div>
                     )}
+                  </div>
+                  <div className={styles.botActions}>
+                    <button
+                      className={`${styles.btn} ${styles.btnSmall} ${styles.btnOutline}`}
+                      onClick={() => handleEditBot(bot)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className={`${styles.btn} ${styles.btnSmall} ${styles.btnDanger}`}
+                      onClick={() => handleDeleteBot(bot.name)}
+                    >
+                      Delete
+                    </button>
                   </div>
                 </div>
               ))}
@@ -198,6 +248,15 @@ export function SettingsView() {
           Claude Code
         </a>
       </div>
+
+      {/* Bot manage dialog */}
+      {dialogMode && (
+        <BotManageDialog
+          mode={dialogMode}
+          bot={editBot}
+          onClose={() => setDialogMode(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Add Bot**: "Add Bot" button in Settings page opens dialog to create web/feishu/telegram bots
- **Edit Bot**: Per-bot "Edit" button opens dialog with pre-filled config for updates
- **Delete Bot**: Per-bot "Delete" button with confirmation removes bot from config
- **PUT /api/bots/:name**: New backend endpoint for updating bot configuration

## Changes
- `src/api/bots-config-writer.ts`: Add `updateBot()` function for config persistence
- `src/api/routes/bot-routes.ts`: Add `PUT /api/bots/:name` route + import `updateBot`
- `web/src/components/BotManageDialog.tsx`: Modal dialog for create/edit (was untracked)
- `web/src/components/BotManageDialog.module.css`: Dialog styling (was untracked)
- `web/src/components/SettingsView.tsx`: Wire dialog with Add/Edit/Delete buttons
- `web/src/components/SettingsView.module.css`: New styles for section header, accent button, bot actions

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] 174 tests pass (`npm test`)
- [ ] 0 lint errors (`npm run lint`)
- [ ] Settings → Add Bot → fill form → Create → bot appears in sidebar
- [ ] Settings → Edit → change description → Save → description updated
- [ ] Settings → Delete → confirm → bot removed from sidebar
- [ ] Bot list updates in real-time across all connected clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)