### PR TITLE
feat: default to claude-opus-4-6 1M context model

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -241,7 +241,7 @@ function buildClaudeConfig(entry: {
     defaultWorkingDirectory: entry.defaultWorkingDirectory,
     maxTurns: entry.maxTurns ?? (process.env.CLAUDE_MAX_TURNS ? parseInt(process.env.CLAUDE_MAX_TURNS, 10) : undefined),
     maxBudgetUsd: entry.maxBudgetUsd ?? (process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined),
-    model: entry.model || process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || 'claude-opus-4-6',
+    model: entry.model || process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || 'claude-opus-4-6[1m]',
     apiKey: entry.apiKey || undefined,
     outputsBaseDir: entry.outputsBaseDir || process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), `metabot-outputs-${os.userInfo().username}`),
     downloadsDir: entry.downloadsDir || process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),


### PR DESCRIPTION
## Summary
- Update default model from `claude-opus-4-6` to `claude-opus-4-6[1m]` for 1M context window support

## Test plan
- [x] Verify service starts with new default model
- [ ] Confirm Claude responses work correctly with 1M context model

🤖 Generated with [Claude Code](https://claude.com/claude-code)