### PR TITLE
feat: auto-split long responses into multiple Feishu cards (#161)

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -18,6 +18,7 @@ import { OutputHandler } from './output-handler.js';
 import { CostTracker } from '../utils/cost-tracker.js';
 import { metrics } from '../utils/metrics.js';
 import type { SessionRegistry } from '../session/session-registry.js';
+import { splitResponseText } from '../feishu/card-builder.js';
 
 const TASK_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
 const QUESTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes for user to answer
@@ -1276,29 +1277,61 @@ export class MessageBridge {
    * sends a plain text fallback so the user at least sees the result.
    */
   private async sendFinalCard(messageId: string, state: CardState, chatId?: string): Promise<void> {
+    // Split long responses into multiple cards
+    const chunks = state.responseText ? splitResponseText(state.responseText) : null;
+    const needsSplit = chunks !== null && chunks.length > 1;
+
+    const cardState = needsSplit
+      ? { ...state, responseText: chunks[0] + `\n\n---\n_📄 (1/${chunks.length})_` }
+      : state;
+
+    let updateSucceeded = false;
     for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
       try {
-        await this.sender.updateCard(messageId, state);
+        await this.sender.updateCard(messageId, cardState);
         if (attempt > 0) {
           await new Promise((r) => setTimeout(r, FINAL_CARD_BASE_DELAY_MS));
-          await this.sender.updateCard(messageId, state);
+          await this.sender.updateCard(messageId, cardState);
         }
-        return;
+        updateSucceeded = true;
+        break;
       } catch {
         const delay = FINAL_CARD_BASE_DELAY_MS * Math.pow(2, attempt);
         this.logger.warn({ attempt, delay, messageId }, 'Final card update failed, retrying');
         await new Promise((r) => setTimeout(r, delay));
       }
     }
-    if (chatId) {
-      this.logger.error({ messageId, chatId }, 'All final card retries failed, sending text fallback');
-      const statusEmoji = state.status === 'complete' ? '✅' : '❌';
-      const summary = state.responseText
-        ? state.responseText.slice(0, 2000)
-        : state.errorMessage || 'Task finished';
-      try {
-        await this.sender.sendText(chatId, `${statusEmoji} ${summary}`);
-      } catch { /* last resort failed */ }
+
+    if (!updateSucceeded) {
+      if (chatId) {
+        this.logger.error({ messageId, chatId }, 'All final card retries failed, sending text fallback');
+        const statusEmoji = state.status === 'complete' ? '✅' : '❌';
+        const summary = state.responseText
+          ? state.responseText.slice(0, 2000)
+          : state.errorMessage || 'Task finished';
+        try {
+          await this.sender.sendText(chatId, `${statusEmoji} ${summary}`);
+        } catch { /* last resort failed */ }
+      }
+      return;
+    }
+
+    // Send continuation cards for remaining chunks
+    if (needsSplit && chatId) {
+      this.logger.info({ chatId, totalChunks: chunks.length }, 'Sending continuation cards for long response');
+      for (let i = 1; i < chunks.length; i++) {
+        try {
+          await new Promise((r) => setTimeout(r, 1500));
+          await this.sender.sendTextNotice(
+            chatId,
+            `📄 Continued (${i + 1}/${chunks.length})`,
+            chunks[i] + `\n\n---\n_📄 (${i + 1}/${chunks.length})_`,
+            'green',
+          );
+        } catch {
+          this.logger.warn({ chatId, chunk: i + 1, total: chunks.length }, 'Failed to send continuation card');
+        }
+      }
     }
   }
 

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -10,7 +10,64 @@ const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: st
   waiting_for_input: { color: 'yellow', title: 'Waiting for Input', icon: '🟡' },
 };
 
-const MAX_CONTENT_LENGTH = 28000;
+export const MAX_CONTENT_LENGTH = 28000;
+
+/**
+ * Split long text into chunks that each fit within MAX_CONTENT_LENGTH.
+ * Splits at paragraph (\n\n) boundaries first, then line (\n) boundaries.
+ */
+export function splitResponseText(text: string): string[] {
+  if (text.length <= MAX_CONTENT_LENGTH) return [text];
+
+  const blocks = text.split('\n\n');
+  const chunks: string[] = [];
+  let current = '';
+
+  for (const block of blocks) {
+    const candidate = current ? current + '\n\n' + block : block;
+    if (candidate.length <= MAX_CONTENT_LENGTH) {
+      current = candidate;
+    } else if (current) {
+      chunks.push(current);
+      if (block.length > MAX_CONTENT_LENGTH) {
+        const sub = splitAtNewlines(block);
+        for (let i = 0; i < sub.length - 1; i++) chunks.push(sub[i]);
+        current = sub[sub.length - 1];
+      } else {
+        current = block;
+      }
+    } else {
+      const sub = splitAtNewlines(block);
+      for (let i = 0; i < sub.length - 1; i++) chunks.push(sub[i]);
+      current = sub[sub.length - 1];
+    }
+  }
+
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+function splitAtNewlines(text: string): string[] {
+  const lines = text.split('\n');
+  const chunks: string[] = [];
+  let current = '';
+
+  for (const line of lines) {
+    const candidate = current ? current + '\n' + line : line;
+    if (candidate.length <= MAX_CONTENT_LENGTH) {
+      current = candidate;
+    } else if (current) {
+      chunks.push(current);
+      current = line.length > MAX_CONTENT_LENGTH ? line.slice(0, MAX_CONTENT_LENGTH) : line;
+    } else {
+      chunks.push(line.slice(0, MAX_CONTENT_LENGTH));
+      current = '';
+    }
+  }
+
+  if (current) chunks.push(current);
+  return chunks;
+}
 
 function truncateContent(text: string): string {
   if (text.length <= MAX_CONTENT_LENGTH) return text;


### PR DESCRIPTION
## What

Auto-split long Claude responses into multiple sequential Feishu card messages instead of truncating the middle content.

## Why

Fixes #161

When Claude's response exceeds 28,000 chars, `truncateContent()` drops the middle portion — users lose information with no way to recover it. This is especially problematic for long analysis, code reviews, or document generation tasks.

## How

**card-builder.ts:**
- Export `splitResponseText(text)` — splits text into chunks ≤ `MAX_CONTENT_LENGTH` at paragraph (`\n\n`) boundaries first, then line (`\n`) boundaries as fallback
- Never hard-cuts mid-line unless a single line exceeds the limit

**message-bridge.ts:**
- `sendFinalCard()` now calls `splitResponseText()` on `responseText`
- First chunk updates the original card with a `(1/N)` page indicator
- Remaining chunks are sent as new cards via `sendTextNotice()` with `📄 Continued (i/N)` headers
- 1.5s delay between continuation sends to respect Feishu rate limits
- Failures on individual continuation cards are logged but don't block others

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] `tsc` reports no new errors (pre-existing errors in unrelated files)
- [x] `npm test` — all 145 tests pass (4 pre-existing file load failures unchanged)
- [x] PR targets the correct branch (`dev`)