### PR TITLE
fix: add vitest config to externalize undici module (#163)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        external: ['undici'],
+      },
+    },
+  },
+});


### PR DESCRIPTION
## What

Add `vitest.config.ts` with `server.deps.external: ['undici']` to fix 4 test files failing at import time.

## Why

Fixes #163

Vitest uses Vite's module resolver, which cannot resolve the native `undici` module when loading test files that depend on `src/utils/http.ts`. Externalizing it lets Node.js handle the resolution natively.

## How

Single new file `vitest.config.ts`:
```ts
export default defineConfig({
  test: {
    server: {
      deps: {
        external: ['undici'],
      },
    },
  },
});
```

**Before:** 14/18 test files pass, 145/145 tests
**After:** 17/17 committed test files pass, 174/174 tests

(The 18th file `tests/403-retry.test.ts` is untracked/local — it references functions that don't exist on dev.)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] `tsc` reports no new errors
- [x] `npm test` — 17/17 test files, 174/174 tests pass
- [x] PR targets the correct branch (`dev`)