### PR TITLE
fix: isolate downloads directory per OS user

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -252,7 +252,7 @@ function buildClaudeConfig(entry: {
     model: entry.model || process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || 'claude-opus-4-6',
     apiKey: entry.apiKey || undefined,
     outputsBaseDir: entry.outputsBaseDir || process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), `metabot-outputs-${os.userInfo().username}`),
-    downloadsDir: entry.downloadsDir || process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
+    downloadsDir: entry.downloadsDir || process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), `metabot-downloads-${os.userInfo().username}`),
   };
 }
 
@@ -272,7 +272,7 @@ function feishuBotFromEnv(): BotConfig {
       model: process.env.CLAUDE_MODEL || 'claude-opus-4-6',
       apiKey: undefined,
       outputsBaseDir: process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), `metabot-outputs-${os.userInfo().username}`),
-      downloadsDir: process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
+      downloadsDir: process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), `metabot-downloads-${os.userInfo().username}`),
     },
   };
 }
@@ -290,7 +290,7 @@ function telegramBotFromEnv(): TelegramBotConfig {
       model: process.env.CLAUDE_MODEL || 'claude-opus-4-6',
       apiKey: undefined,
       outputsBaseDir: process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), `metabot-outputs-${os.userInfo().username}`),
-      downloadsDir: process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads'),
+      downloadsDir: process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), `metabot-downloads-${os.userInfo().username}`),
     },
   };
 }
@@ -307,8 +307,8 @@ function wechatBotFromEnv(): WechatBotConfig {
       maxBudgetUsd: process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined,
       model: process.env.CLAUDE_MODEL || 'claude-opus-4-6',
       apiKey: undefined,
-      outputsBaseDir: expandUserPath(process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), 'metabot-outputs')),
-      downloadsDir: expandUserPath(process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), 'metabot-downloads')),
+      outputsBaseDir: expandUserPath(process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), `metabot-outputs-${os.userInfo().username}`)),
+      downloadsDir: expandUserPath(process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), `metabot-downloads-${os.userInfo().username}`)),
     },
   };
 }


### PR DESCRIPTION
## Summary
- Default downloads dir was `/tmp/metabot-downloads` (shared by all OS users)
- When multiple users run MetaBot on the same machine, the first user's directory permissions block others → `EACCES: permission denied`
- Now uses `metabot-downloads-<username>` suffix, matching the existing outputs directory pattern

## Root cause
```
EACCES: permission denied, open '/tmp/metabot-downloads/img_xxx.png'
```
Directory owned by `shizhanxu`, process running as `floodsung`.

## Test plan
- [x] `npm run build` succeeds
- [x] All 175 tests pass
- [x] Verified all 4 config paths updated (multi-bot, feishu, telegram, wechat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)