### PR TITLE
feat: 多会话支持 — /sessions、/switch、/session 命令

### DIFF
--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -2,13 +2,17 @@ import type { BotConfigBase } from '../config.js';
 import type { Logger } from '../utils/logger.js';
 import type { IncomingMessage } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
-import { SessionManager } from '../claude/session-manager.js';
+import { SessionManager, type UserSession } from '../claude/session-manager.js';
 import { MemoryClient } from '../memory/memory-client.js';
 import { AuditLogger } from '../utils/audit-logger.js';
 import type { DocSync } from '../sync/doc-sync.js';
 
+/** Callback to enter pending session selection mode in MessageBridge. */
+export type SessionSwitchCallback = (chatId: string, sessions: UserSession[]) => void;
+
 export class CommandHandler {
   private docSync: DocSync | null = null;
+  private onSessionSwitch: SessionSwitchCallback | null = null;
 
   constructor(
     private config: BotConfigBase,
@@ -24,6 +28,11 @@ export class CommandHandler {
   /** Set the doc sync service (optional, only available for Feishu bots). */
   setDocSync(docSync: DocSync): void {
     this.docSync = docSync;
+  }
+
+  /** Set the session switch callback for /switch selection mode. */
+  setSessionSwitchCallback(onSwitch: SessionSwitchCallback): void {
+    this.onSessionSwitch = onSwitch;
   }
 
   /** Returns true if the message was handled as a command, false otherwise. */
@@ -43,6 +52,8 @@ export class CommandHandler {
           '`/reset` - Clear session, start fresh',
           '`/stop` - Abort current running task',
           '`/status` - Show current session info',
+          '`/sessions` - List recent sessions',
+          '`/switch [N]` - Switch to a previous session',
           '`/memory` - Memory document commands',
           '`/help` - Show this help message',
           '',
@@ -63,7 +74,7 @@ export class CommandHandler {
 
       case '/reset':
         this.sessionManager.resetSession(chatId);
-        await this.sender.sendTextNotice(chatId, '✅ Session Reset', 'Conversation cleared. Working directory preserved.', 'green');
+        await this.sender.sendTextNotice(chatId, '✅ Session Reset', 'Conversation cleared. Use `/sessions` to switch back to a previous session.', 'green');
         return true;
 
       case '/stop': {
@@ -99,6 +110,62 @@ export class CommandHandler {
       case '/sync': {
         const args = text.slice('/sync'.length).trim();
         await this.handleSyncCommand(chatId, args);
+        return true;
+      }
+
+      case '/sessions': {
+        const sessions = this.sessionManager.listSessions(chatId);
+        if (sessions.length === 0) {
+          await this.sender.sendTextNotice(chatId, '📋 Sessions', 'No sessions found.');
+          return true;
+        }
+        const activeIndex = this.sessionManager.getActiveIndex(chatId);
+        const lines = sessions.map((s, i) => {
+          const title = (s.title || '(untitled)').slice(0, 40);
+          const current = i === activeIndex ? ' 👈' : '';
+          return `**${i + 1}.** ${title}${current}`;
+        });
+        lines.push('', 'Use `/switch N` to switch to a session.');
+        await this.sender.sendTextNotice(chatId, '📋 Sessions', lines.join('\n'));
+        return true;
+      }
+
+      case '/switch': {
+        const sessions = this.sessionManager.listSessions(chatId);
+        if (sessions.length <= 1) {
+          await this.sender.sendTextNotice(chatId, '📋 Switch', 'Only one session exists. Use `/reset` to create a new one.', 'orange');
+          return true;
+        }
+        const switchArg = text.slice('/switch'.length).trim();
+
+        if (switchArg) {
+          // Direct switch by number
+          const num = parseInt(switchArg, 10);
+          if (isNaN(num) || num < 1 || num > sessions.length) {
+            await this.sender.sendTextNotice(chatId, '❌ Invalid', `Please enter a number between 1 and ${sessions.length}.`, 'red');
+            return true;
+          }
+          const target = sessions[num - 1];
+          if (!target.sessionId) {
+            await this.sender.sendTextNotice(chatId, '❌ Cannot Switch', 'This session has no conversation to resume.', 'red');
+            return true;
+          }
+          this.sessionManager.switchSession(chatId, num - 1);
+          await this.sender.sendTextNotice(chatId, '✅ Switched', `Switched to: **${(target.title || '(untitled)').slice(0, 40)}**`, 'green');
+          return true;
+        }
+
+        // No argument: show list and enter selection mode
+        const activeIndex = this.sessionManager.getActiveIndex(chatId);
+        const lines = sessions.map((s, i) => {
+          const title = (s.title || '(untitled)').slice(0, 40);
+          const current = i === activeIndex ? ' 👈' : '';
+          return `**${i + 1}.** ${title}${current}`;
+        });
+        lines.push('', '_Reply with a number to switch, or send any other message to cancel._');
+        await this.sender.sendTextNotice(chatId, '📋 Switch Session', lines.join('\n'));
+        // Enter selection mode
+        this.onSessionSwitch?.(chatId, sessions);
         return true;
       }
 

--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -63,6 +63,9 @@ export class CommandHandler {
           '`/model claude`, `/model kimi`, or `/model codex` - Switch engine (resets session)',
           '`/model <name>` - Set model for current engine',
           '`/memory` - Memory document commands',
+          '`/sessions` - List all sessions in this chat',
+          '`/switch [N]` - Switch to session N (or show list to pick)',
+          '`/session <prefix>` - Switch by session ID prefix',
           '`/help` - Show this help message',
           '',
           '**Agent Commands** (pass through to the agent — Claude only):',
@@ -95,7 +98,8 @@ export class CommandHandler {
         } catch (err) {
           this.logger.warn({ err, chatId }, 'Failed to release persistent executor on /reset');
         }
-        await this.sender.sendTextNotice(chatId, '✅ Session Reset', 'Conversation cleared. Working directory preserved.', 'green');
+        await this.sender.sendTextNotice(chatId, '✅ Session Reset',
+          'New session created. Previous sessions preserved — use `/sessions` to switch back.', 'green');
         return true;
 
       case '/stop': {
@@ -159,6 +163,23 @@ export class CommandHandler {
       case '/model': {
         const args = text.slice('/model'.length).trim();
         await this.handleModelCommand(chatId, args);
+        return true;
+      }
+
+      case '/sessions': {
+        await this.handleSessionsCommand(chatId);
+        return true;
+      }
+
+      case '/switch': {
+        const args = text.slice('/switch'.length).trim();
+        await this.handleSwitchCommand(chatId, args);
+        return true;
+      }
+
+      case '/session': {
+        const args = text.slice('/session'.length).trim();
+        await this.handleSessionPrefixCommand(chatId, args);
         return true;
       }
 
@@ -407,6 +428,63 @@ export class CommandHandler {
       `Session model set to \`${newModel}\` on engine \`${activeEngine}\`. It will take effect on the next message.`,
       'green',
     );
+  }
+
+  private async handleSessionsCommand(chatId: string): Promise<void> {
+    const sessions = this.sessionManager.listSessions(chatId);
+    if (sessions.length === 0) {
+      await this.sender.sendTextNotice(chatId, '📋 Sessions', 'No sessions yet. Send a message to start one.');
+      return;
+    }
+    const lines = sessions.map(s => {
+      const marker = s.isActive ? ' ▶' : '';
+      const sid = s.sessionId ? ` \`${s.sessionId.slice(0, 8)}\`` : '';
+      const title = s.title ? ` — ${s.title}` : '';
+      const time = new Date(s.lastUsed).toLocaleString();
+      return `**${s.index + 1}.**${sid}${title} (${time})${marker}`;
+    });
+    lines.push('', 'Use `/switch N` to switch, or `/session <prefix>` to switch by session ID.');
+    await this.sender.sendTextNotice(chatId, '📋 Sessions', lines.join('\n'));
+  }
+
+  private async handleSwitchCommand(chatId: string, args: string): Promise<void> {
+    if (!args) {
+      await this.handleSessionsCommand(chatId);
+      return;
+    }
+    const num = parseInt(args, 10);
+    if (isNaN(num) || num < 1) {
+      await this.sender.sendTextNotice(chatId, '❌ Invalid', 'Usage: `/switch N` where N is the session number from `/sessions`.', 'red');
+      return;
+    }
+    const success = this.sessionManager.switchSession(chatId, num - 1);
+    if (success) {
+      const session = this.sessionManager.getSession(chatId);
+      const sid = session.sessionId ? `\`${session.sessionId.slice(0, 8)}...\`` : '_new_';
+      await this.sender.sendTextNotice(chatId, '✅ Switched', `Switched to session ${num} (${sid}).`, 'green');
+    } else {
+      const sessions = this.sessionManager.listSessions(chatId);
+      await this.sender.sendTextNotice(chatId, '❌ Invalid',
+        `Session ${num} does not exist. You have ${sessions.length} session(s). Use \`/sessions\` to list.`, 'red');
+    }
+  }
+
+  private async handleSessionPrefixCommand(chatId: string, prefix: string): Promise<void> {
+    if (!prefix || prefix.length < 8) {
+      await this.sender.sendTextNotice(chatId, '❌ Invalid',
+        'Usage: `/session <prefix>` — provide at least 8 characters of the session ID.', 'red');
+      return;
+    }
+    const idx = this.sessionManager.switchToSessionByPrefix(chatId, prefix);
+    if (idx >= 0) {
+      const session = this.sessionManager.getSession(chatId);
+      const sid = session.sessionId ? `\`${session.sessionId.slice(0, 8)}...\`` : '_new_';
+      await this.sender.sendTextNotice(chatId, '✅ Switched',
+        `Switched to session ${idx + 1} (${sid}).`, 'green');
+    } else {
+      await this.sender.sendTextNotice(chatId, '❌ Not Found',
+        `No session found matching prefix \`${prefix}\`. Use \`/sessions\` to list available sessions.`, 'red');
+    }
   }
 
   private defaultModelForEngine(engine: EngineName): string | undefined {

--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -459,6 +459,9 @@ export class CommandHandler {
     }
     const success = this.sessionManager.switchSession(chatId, num - 1);
     if (success) {
+      // Release persistent executor so the next message picks up the
+      // switched session's sessionId instead of the old process's.
+      try { await this.releaseExecutor(chatId, 'session-switch'); } catch {}
       const session = this.sessionManager.getSession(chatId);
       const sid = session.sessionId ? `\`${session.sessionId.slice(0, 8)}...\`` : '_new_';
       await this.sender.sendTextNotice(chatId, '✅ Switched', `Switched to session ${num} (${sid}).`, 'green');
@@ -477,6 +480,7 @@ export class CommandHandler {
     }
     const idx = this.sessionManager.switchToSessionByPrefix(chatId, prefix);
     if (idx >= 0) {
+      try { await this.releaseExecutor(chatId, 'session-switch'); } catch {}
       const session = this.sessionManager.getSession(chatId);
       const sid = session.sessionId ? `\`${session.sessionId.slice(0, 8)}...\`` : '_new_';
       await this.sender.sendTextNotice(chatId, '✅ Switched',

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -109,6 +109,7 @@ export class MessageBridge {
   private runningTasks = new Map<string, RunningTask>(); // keyed by chatId
   private messageQueues = new Map<string, IncomingMessage[]>(); // per-chatId message queue
   private pendingBatches = new Map<string, PendingBatch>(); // media debounce batches
+  private pendingSessionSwitch = new Map<string, { sessions: import('../claude/session-manager.js').UserSession[]; timerId: ReturnType<typeof setTimeout> }>();
   /** Callback for activity lifecycle events (task started/completed/failed). */
   onActivityEvent?: (event: ActivityEventData) => void;
 
@@ -149,6 +150,16 @@ export class MessageBridge {
   /** Inject the session registry for cross-platform session sync. */
   setSessionRegistry(registry: SessionRegistry): void {
     this.sessionRegistry = registry;
+    this.commandHandler.setSessionSwitchCallback((chatId, sessions) => {
+      // Clear any existing pending selection
+      const existing = this.pendingSessionSwitch.get(chatId);
+      if (existing) clearTimeout(existing.timerId);
+      // Set new pending selection with 60s timeout
+      const timerId = setTimeout(() => {
+        this.pendingSessionSwitch.delete(chatId);
+      }, 60_000);
+      this.pendingSessionSwitch.set(chatId, { sessions, timerId });
+    });
   }
 
   /** Expose session manager for cross-platform session linking. */
@@ -227,6 +238,27 @@ export class MessageBridge {
     const task = this.runningTasks.get(chatId);
     if (task && task.pendingQuestion) {
       await this.handleAnswer(msg, task);
+      return;
+    }
+
+    // Check if there's a pending session switch selection
+    const pendingSwitch = this.pendingSessionSwitch.get(chatId);
+    if (pendingSwitch) {
+      clearTimeout(pendingSwitch.timerId);
+      this.pendingSessionSwitch.delete(chatId);
+      const num = parseInt(text.trim(), 10);
+      if (!isNaN(num) && num >= 1 && num <= pendingSwitch.sessions.length) {
+        const target = pendingSwitch.sessions[num - 1];
+        if (target.sessionId) {
+          this.sessionManager.switchSession(chatId, num - 1);
+          await this.sender.sendTextNotice(chatId, '✅ Switched', `Switched to: **${(target.title || '(untitled)').slice(0, 40)}**`, 'green');
+        } else {
+          await this.sender.sendTextNotice(chatId, '❌ Cannot Switch', 'This session has no conversation to resume.', 'red');
+        }
+      } else {
+        // Non-numeric or out-of-range: cancel selection and process normally
+        await this.executeQuery(msg);
+      }
       return;
     }
 
@@ -632,6 +664,8 @@ export class MessageBridge {
 
     this.audit.log({ event: 'task_start', botName: this.config.name, chatId, userId, prompt: text });
     this.emitActivity({ type: 'task_started', botName: this.config.name, chatId, userId, prompt: text?.slice(0, 200), timestamp: startTime });
+    // Record first message as session title
+    this.sessionManager.setTitle(chatId, (text || '').replace(/\n/g, ' ').slice(0, 60));
 
     // Setup timeout
     let timedOut = false;
@@ -818,8 +852,9 @@ export class MessageBridge {
       metrics.observeHistogram('metabot_task_duration_seconds', durationMs / 1000);
       if (lastState.costUsd) metrics.observeHistogram('metabot_task_cost_usd', lastState.costUsd);
 
-      // Record in cross-platform session registry
-      this.recordSession(chatId, displayPrompt, lastState.responseText, processor.getSessionId(), lastState.costUsd, durationMs);
+      // Record in cross-platform session registry (use virtual chatId for isolation)
+      const registryChatId = this.sessionManager.getVirtualChatId(chatId);
+      this.recordSession(registryChatId, displayPrompt, lastState.responseText, processor.getSessionId(), lastState.costUsd, durationMs);
 
       // Send completion notification for long-running tasks (>10s) so user gets a Feishu push
       await this.sendCompletionNotice(chatId, lastState, durationMs);
@@ -873,7 +908,7 @@ export class MessageBridge {
           metrics.incCounter('metabot_tasks_total');
           metrics.incCounter('metabot_tasks_by_status', lastState.status === 'complete' ? 'success' : 'error');
 
-          this.recordSession(chatId, displayPrompt, lastState.responseText, processor.getSessionId(), lastState.costUsd, durationMs);
+          this.recordSession(this.sessionManager.getVirtualChatId(chatId), displayPrompt, lastState.responseText, processor.getSessionId(), lastState.costUsd, durationMs);
           await this.sendCompletionNotice(chatId, lastState, durationMs);
           await this.outputHandler.sendOutputFiles(chatId, outputsDir, processor, lastState);
           return; // skip the normal error handling below
@@ -1157,8 +1192,8 @@ export class MessageBridge {
       metrics.observeHistogram('metabot_task_duration_seconds', durationMs / 1000);
       if (lastState.costUsd) metrics.observeHistogram('metabot_task_cost_usd', lastState.costUsd);
 
-      // Record in cross-platform session registry
-      this.recordSession(chatId, prompt, lastState.responseText, processor.getSessionId(), lastState.costUsd, durationMs);
+      // Record in cross-platform session registry (use virtual chatId for isolation)
+      this.recordSession(this.sessionManager.getVirtualChatId(chatId), prompt, lastState.responseText, processor.getSessionId(), lastState.costUsd, durationMs);
 
       return {
         success: lastState.status === 'complete',

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -2325,10 +2325,13 @@ export class MessageBridge {
    */
   /** Record session and messages in the cross-platform registry. */
   private recordSession(chatId: string, prompt: string, responseText: string | undefined, claudeSessionId: string | undefined, costUsd: number | undefined, durationMs: number | undefined): void {
+    // Set session title from first user message
+    this.sessionManager.setTitle(chatId, prompt.slice(0, 50));
+
     if (!this.sessionRegistry) return;
     try {
       this.sessionRegistry.createOrUpdate({
-        chatId,
+        chatId: this.sessionManager.getVirtualChatId(chatId),
         botName: this.config.name,
         claudeSessionId,
         workingDirectory: this.sessionManager.getSession(chatId).workingDirectory,

--- a/src/claude/session-manager.ts
+++ b/src/claude/session-manager.ts
@@ -13,6 +13,19 @@ export interface UserSession {
   cumulativeCostUsd: number;
   /** Cumulative duration (ms) across all queries in this session */
   cumulativeDurationMs: number;
+  /** 首条消息预览，用于 /sessions 列表展示 */
+  title?: string;
+}
+
+interface SessionGroup {
+  activeIndex: number;
+  sessions: UserSession[];
+}
+
+// 持久化格式：新格式（SessionGroup）或旧格式（flat PersistedSession）
+interface PersistedSessionGroup {
+  activeIndex: number;
+  sessions: PersistedSession[];
 }
 
 interface PersistedSession {
@@ -22,13 +35,15 @@ interface PersistedSession {
   cumulativeTokens?: number;
   cumulativeCostUsd?: number;
   cumulativeDurationMs?: number;
+  title?: string;
 }
 
-const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days (extended for multi-session)
 const MAX_SESSIONS = 10_000;
+const MAX_SESSIONS_PER_CHAT = 20;
 
 export class SessionManager {
-  private sessions = new Map<string, UserSession>();
+  private groups = new Map<string, SessionGroup>();
   private cleanupTimer: ReturnType<typeof setInterval>;
   private persistPath: string;
 
@@ -50,38 +65,52 @@ export class SessionManager {
   }
 
   getSession(chatId: string): UserSession {
-    let session = this.sessions.get(chatId);
-    if (!session) {
-      // Evict least-recently-used session if at capacity
-      if (this.sessions.size >= MAX_SESSIONS) {
-        this.evictOldest();
-      }
-      session = {
-        sessionId: undefined,
-        workingDirectory: this.defaultWorkingDirectory,
-        lastUsed: Date.now(),
-        cumulativeTokens: 0,
-        cumulativeCostUsd: 0,
-        cumulativeDurationMs: 0,
-      };
-      this.sessions.set(chatId, session);
-    }
+    const group = this.getOrCreateGroup(chatId);
+    const session = group.sessions[group.activeIndex];
     session.lastUsed = Date.now();
     return session;
+  }
+
+  private getOrCreateGroup(chatId: string): SessionGroup {
+    let group = this.groups.get(chatId);
+    if (!group) {
+      // Evict if at capacity
+      if (this.groups.size >= MAX_SESSIONS) {
+        this.evictOldest();
+      }
+      group = {
+        activeIndex: 0,
+        sessions: [this.createEmptySession()],
+      };
+      this.groups.set(chatId, group);
+    }
+    return group;
+  }
+
+  private createEmptySession(): UserSession {
+    return {
+      sessionId: undefined,
+      workingDirectory: this.defaultWorkingDirectory,
+      lastUsed: Date.now(),
+      cumulativeTokens: 0,
+      cumulativeCostUsd: 0,
+      cumulativeDurationMs: 0,
+    };
   }
 
   private evictOldest(): void {
     let oldestKey: string | undefined;
     let oldestTime = Infinity;
-    for (const [key, s] of this.sessions) {
-      if (s.lastUsed < oldestTime) {
-        oldestTime = s.lastUsed;
+    for (const [key, group] of this.groups) {
+      const lastUsed = Math.max(...group.sessions.map(s => s.lastUsed));
+      if (lastUsed < oldestTime) {
+        oldestTime = lastUsed;
         oldestKey = key;
       }
     }
     if (oldestKey) {
-      this.sessions.delete(oldestKey);
-      this.logger.debug({ chatId: oldestKey }, 'Evicted oldest session (capacity limit)');
+      this.groups.delete(oldestKey);
+      this.logger.debug({ chatId: oldestKey }, 'Evicted oldest session group (capacity limit)');
     }
   }
 
@@ -101,26 +130,66 @@ export class SessionManager {
     this.saveToDisk();
   }
 
-  resetSession(chatId: string): void {
-    const session = this.sessions.get(chatId);
-    if (session) {
-      session.sessionId = undefined;
-      session.cumulativeTokens = 0;
-      session.cumulativeCostUsd = 0;
-      session.cumulativeDurationMs = 0;
-      // Keep working directory
-      this.logger.info({ chatId }, 'Session reset');
+  /** Set the title (first message preview) for the active session. Only sets if not already set. */
+  setTitle(chatId: string, title: string): void {
+    const session = this.getSession(chatId);
+    if (!session.title) {
+      session.title = title;
       this.saveToDisk();
     }
+  }
+
+  /** Create a new session and make it active. Old sessions are preserved. */
+  resetSession(chatId: string): void {
+    const group = this.getOrCreateGroup(chatId);
+    // Trim old sessions if at per-chat limit
+    if (group.sessions.length >= MAX_SESSIONS_PER_CHAT) {
+      group.sessions.shift();
+    }
+    group.sessions.push(this.createEmptySession());
+    group.activeIndex = group.sessions.length - 1;
+    this.logger.info({ chatId, sessionCount: group.sessions.length }, 'Session reset (new session created)');
+    this.saveToDisk();
+  }
+
+  /** List all sessions for a chatId, ordered by creation (oldest first). */
+  listSessions(chatId: string): UserSession[] {
+    const group = this.groups.get(chatId);
+    return group ? [...group.sessions] : [];
+  }
+
+  /** Switch to a different session by index. Returns true if successful. */
+  switchSession(chatId: string, index: number): boolean {
+    const group = this.groups.get(chatId);
+    if (!group || index < 0 || index >= group.sessions.length) return false;
+    group.activeIndex = index;
+    group.sessions[index].lastUsed = Date.now();
+    this.logger.info({ chatId, index, title: group.sessions[index].title }, 'Session switched');
+    this.saveToDisk();
+    return true;
+  }
+
+  /** Get the active session index for a chatId. */
+  getActiveIndex(chatId: string): number {
+    const group = this.groups.get(chatId);
+    return group ? group.activeIndex : 0;
+  }
+
+  /** Get a virtual chatId for SessionRegistry record isolation. Format: {chatId}::{N} */
+  getVirtualChatId(chatId: string): string {
+    const group = this.groups.get(chatId);
+    if (!group) return chatId;
+    return `${chatId}::${group.activeIndex + 1}`;
   }
 
   private cleanupExpired(): void {
     const now = Date.now();
     let changed = false;
-    for (const [chatId, session] of this.sessions) {
-      if (now - session.lastUsed > SESSION_TTL_MS) {
-        this.sessions.delete(chatId);
-        this.logger.debug({ chatId }, 'Expired session cleaned up');
+    for (const [chatId, group] of this.groups) {
+      const mostRecent = Math.max(...group.sessions.map(s => s.lastUsed));
+      if (now - mostRecent > SESSION_TTL_MS) {
+        this.groups.delete(chatId);
+        this.logger.debug({ chatId }, 'Expired session group cleaned up');
         changed = true;
       }
     }
@@ -131,17 +200,24 @@ export class SessionManager {
 
   private saveToDisk(): void {
     try {
-      const data: Record<string, PersistedSession> = {};
-      for (const [chatId, session] of this.sessions) {
-        // Only persist sessions that have a sessionId (active Claude sessions)
-        if (session.sessionId) {
+      const data: Record<string, PersistedSessionGroup> = {};
+      for (const [chatId, group] of this.groups) {
+        // 只持久化至少有一个 sessionId 的 group
+        const hasAnySession = group.sessions.some(s => s.sessionId);
+        if (hasAnySession) {
           data[chatId] = {
-            sessionId: session.sessionId,
-            workingDirectory: session.workingDirectory,
-            lastUsed: session.lastUsed,
-            cumulativeTokens: session.cumulativeTokens,
-            cumulativeCostUsd: session.cumulativeCostUsd,
-            cumulativeDurationMs: session.cumulativeDurationMs,
+            activeIndex: group.activeIndex,
+            sessions: group.sessions
+              .filter(s => s.sessionId || s.title) // 保留有 sessionId 或 title 的
+              .map(s => ({
+                sessionId: s.sessionId!,
+                workingDirectory: s.workingDirectory,
+                lastUsed: s.lastUsed,
+                cumulativeTokens: s.cumulativeTokens,
+                cumulativeCostUsd: s.cumulativeCostUsd,
+                cumulativeDurationMs: s.cumulativeDurationMs,
+                title: s.title,
+              })),
           };
         }
       }
@@ -155,22 +231,51 @@ export class SessionManager {
     try {
       if (!fs.existsSync(this.persistPath)) return;
       const raw = fs.readFileSync(this.persistPath, 'utf-8');
-      const data: Record<string, PersistedSession> = JSON.parse(raw);
+      const data = JSON.parse(raw) as Record<string, unknown>;
       const now = Date.now();
       let loaded = 0;
-      for (const [chatId, persisted] of Object.entries(data)) {
-        // Skip expired sessions
-        if (now - persisted.lastUsed > SESSION_TTL_MS) continue;
-        this.sessions.set(chatId, {
-          sessionId: persisted.sessionId,
-          workingDirectory: persisted.workingDirectory,
-          lastUsed: persisted.lastUsed,
-          cumulativeTokens: persisted.cumulativeTokens ?? 0,
-          cumulativeCostUsd: persisted.cumulativeCostUsd ?? 0,
-          cumulativeDurationMs: persisted.cumulativeDurationMs ?? 0,
-        });
-        loaded++;
+
+      for (const [chatId, value] of Object.entries(data)) {
+        // 新格式：有 activeIndex 和 sessions 数组
+        if (value && typeof value === 'object' && 'sessions' in value && Array.isArray((value as any).sessions)) {
+          const persisted = value as PersistedSessionGroup;
+          const sessions: UserSession[] = persisted.sessions.map(s => ({
+            sessionId: s.sessionId || undefined,
+            workingDirectory: s.workingDirectory,
+            lastUsed: s.lastUsed,
+            cumulativeTokens: s.cumulativeTokens ?? 0,
+            cumulativeCostUsd: s.cumulativeCostUsd ?? 0,
+            cumulativeDurationMs: s.cumulativeDurationMs ?? 0,
+            title: s.title,
+          }));
+          if (sessions.length === 0) continue;
+          const mostRecent = Math.max(...sessions.map(s => s.lastUsed));
+          if (now - mostRecent > SESSION_TTL_MS) continue;
+          this.groups.set(chatId, {
+            activeIndex: Math.min(persisted.activeIndex, sessions.length - 1),
+            sessions,
+          });
+          loaded++;
+        }
+        // 旧格式：flat PersistedSession（向后兼容）
+        else if (value && typeof value === 'object' && 'sessionId' in value) {
+          const old = value as PersistedSession;
+          if (now - old.lastUsed > SESSION_TTL_MS) continue;
+          this.groups.set(chatId, {
+            activeIndex: 0,
+            sessions: [{
+              sessionId: old.sessionId || undefined,
+              workingDirectory: old.workingDirectory,
+              lastUsed: old.lastUsed,
+              cumulativeTokens: old.cumulativeTokens ?? 0,
+              cumulativeCostUsd: old.cumulativeCostUsd ?? 0,
+              cumulativeDurationMs: old.cumulativeDurationMs ?? 0,
+            }],
+          });
+          loaded++;
+        }
       }
+
       if (loaded > 0) {
         this.logger.info({ loaded, path: this.persistPath }, 'Restored sessions from disk');
       }

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -30,6 +30,8 @@ export interface UserSession {
   activeGoal?: string;
   /** Wall-clock when the current goal was set (ms since epoch). */
   goalSetAt?: number;
+  /** First message preview, used as session title in /sessions listing. */
+  title?: string;
 }
 
 interface PersistedSession {
@@ -45,6 +47,25 @@ interface PersistedSession {
   engine?: EngineName;
   activeGoal?: string;
   goalSetAt?: number;
+  title?: string;
+}
+
+interface PersistedSessionGroup {
+  activeIndex: number;
+  sessions: PersistedSession[];
+}
+
+interface SessionGroup {
+  activeIndex: number;
+  sessions: UserSession[];
+}
+
+export interface SessionListEntry {
+  index: number;
+  title?: string;
+  sessionId?: string;
+  lastUsed: number;
+  isActive: boolean;
 }
 
 // Sessions never expire — user can /reset manually.
@@ -55,9 +76,13 @@ interface PersistedSession {
 // from config, not from the persisted session, so old sessions don't interfere.
 const SESSION_TTL_MS = Infinity;
 const MAX_SESSIONS = 10_000;
+const MAX_SESSIONS_PER_CHAT = 20;
 
 export class SessionManager {
-  private sessions = new Map<string, UserSession>();
+  // Concurrency note: MessageBridge enforces one running task per chatId
+  // via its runningTasks map, so activeIndex reads/writes within a single
+  // chatId are inherently serialized. No additional locking is needed.
+  private groups = new Map<string, SessionGroup>();
   private cleanupTimer: ReturnType<typeof setInterval>;
   private persistPath: string;
 
@@ -66,7 +91,6 @@ export class SessionManager {
     private logger: Logger,
     botName: string = 'default',
   ) {
-    // Persist sessions to a file under the project data dir
     const dataDir = process.env.SESSION_STORE_DIR
       || path.join(os.homedir(), '.metabot');
     fs.mkdirSync(dataDir, { recursive: true });
@@ -74,27 +98,46 @@ export class SessionManager {
 
     this.loadFromDisk();
 
-    // Periodic cleanup every hour
     this.cleanupTimer = setInterval(() => this.cleanupExpired(), 60 * 60 * 1000);
   }
 
-  getSession(chatId: string): UserSession {
-    let session = this.sessions.get(chatId);
-    if (!session) {
-      // Evict least-recently-used session if at capacity
-      if (this.sessions.size >= MAX_SESSIONS) {
+  private getOrCreateGroup(chatId: string): SessionGroup {
+    let group = this.groups.get(chatId);
+    if (!group) {
+      if (this.totalSessionCount() >= MAX_SESSIONS) {
         this.evictOldest();
       }
-      session = {
-        sessionId: undefined,
-        workingDirectory: this.defaultWorkingDirectory,
-        lastUsed: Date.now(),
-        cumulativeTokens: 0,
-        cumulativeCostUsd: 0,
-        cumulativeDurationMs: 0,
+      group = {
+        activeIndex: 0,
+        sessions: [this.createFreshSession()],
       };
-      this.sessions.set(chatId, session);
+      this.groups.set(chatId, group);
     }
+    return group;
+  }
+
+  private createFreshSession(): UserSession {
+    return {
+      sessionId: undefined,
+      workingDirectory: this.defaultWorkingDirectory,
+      lastUsed: Date.now(),
+      cumulativeTokens: 0,
+      cumulativeCostUsd: 0,
+      cumulativeDurationMs: 0,
+    };
+  }
+
+  private totalSessionCount(): number {
+    let count = 0;
+    for (const group of this.groups.values()) {
+      count += group.sessions.length;
+    }
+    return count;
+  }
+
+  getSession(chatId: string): UserSession {
+    const group = this.getOrCreateGroup(chatId);
+    const session = group.sessions[group.activeIndex];
     session.lastUsed = Date.now();
     return session;
   }
@@ -102,15 +145,17 @@ export class SessionManager {
   private evictOldest(): void {
     let oldestKey: string | undefined;
     let oldestTime = Infinity;
-    for (const [key, s] of this.sessions) {
-      if (s.lastUsed < oldestTime) {
-        oldestTime = s.lastUsed;
-        oldestKey = key;
+    for (const [key, group] of this.groups) {
+      for (const s of group.sessions) {
+        if (s.lastUsed < oldestTime) {
+          oldestTime = s.lastUsed;
+          oldestKey = key;
+        }
       }
     }
     if (oldestKey) {
-      this.sessions.delete(oldestKey);
-      this.logger.debug({ chatId: oldestKey }, 'Evicted oldest session (capacity limit)');
+      this.groups.delete(oldestKey);
+      this.logger.debug({ chatId: oldestKey }, 'Evicted oldest session group (capacity limit)');
     }
   }
 
@@ -176,29 +221,104 @@ export class SessionManager {
     this.saveToDisk();
   }
 
+  /**
+   * Create a new session in the group instead of clearing the old one.
+   * Old sessions are preserved and can be switched back via /sessions.
+   */
   resetSession(chatId: string): void {
-    const session = this.sessions.get(chatId);
-    if (session) {
-      session.sessionId = undefined;
-      session.sessionIdEngine = undefined;
-      session.cumulativeTokens = 0;
-      session.cumulativeCostUsd = 0;
-      session.cumulativeDurationMs = 0;
-      session.activeGoal = undefined;
-      session.goalSetAt = undefined;
-      // Keep working directory
-      this.logger.info({ chatId }, 'Session reset');
+    const group = this.groups.get(chatId);
+    if (group) {
+      const newSession = this.createFreshSession();
+      group.sessions.push(newSession);
+      group.activeIndex = group.sessions.length - 1;
+      // Trim oldest sessions if over limit (keep the active one)
+      while (group.sessions.length > MAX_SESSIONS_PER_CHAT) {
+        const removeIdx = group.activeIndex === 0 ? 1 : 0;
+        group.sessions.splice(removeIdx, 1);
+        if (group.activeIndex > removeIdx) group.activeIndex--;
+      }
+      this.logger.info({ chatId, sessionCount: group.sessions.length }, 'New session created (old sessions preserved)');
       this.saveToDisk();
     }
+  }
+
+  /** Set display title on the active session (typically first message preview). */
+  setTitle(chatId: string, title: string): void {
+    const session = this.getSession(chatId);
+    if (!session.title) {
+      session.title = title;
+      this.saveToDisk();
+    }
+  }
+
+  /** List all sessions in a chat group for /sessions display. */
+  listSessions(chatId: string): SessionListEntry[] {
+    const group = this.groups.get(chatId);
+    if (!group) return [];
+    return group.sessions.map((s, i) => ({
+      index: i,
+      title: s.title,
+      sessionId: s.sessionId,
+      lastUsed: s.lastUsed,
+      isActive: i === group.activeIndex,
+    }));
+  }
+
+  /** Switch to a different session by index. Returns false if index is out of range. */
+  switchSession(chatId: string, index: number): boolean {
+    const group = this.groups.get(chatId);
+    if (!group || index < 0 || index >= group.sessions.length) return false;
+    group.activeIndex = index;
+    group.sessions[index].lastUsed = Date.now();
+    this.logger.info({ chatId, index, sessionCount: group.sessions.length }, 'Switched active session');
+    this.saveToDisk();
+    return true;
+  }
+
+  /** Get the active session index for a chat. Returns 0 if no group exists. */
+  getActiveIndex(chatId: string): number {
+    const group = this.groups.get(chatId);
+    return group ? group.activeIndex : 0;
+  }
+
+  /**
+   * Virtual chatId for SessionRegistry isolation.
+   * Different sessions within the same chat get distinct registry entries.
+   */
+  getVirtualChatId(chatId: string): string {
+    const idx = this.getActiveIndex(chatId);
+    return idx === 0 ? chatId : `${chatId}::${idx}`;
+  }
+
+  /**
+   * Find and switch to a session by sessionId prefix (8+ chars).
+   * Returns the matched index or -1 if not found.
+   */
+  switchToSessionByPrefix(chatId: string, prefix: string): number {
+    const group = this.groups.get(chatId);
+    if (!group || prefix.length < 8) return -1;
+    const lowerPrefix = prefix.toLowerCase();
+    for (let i = 0; i < group.sessions.length; i++) {
+      const sid = group.sessions[i].sessionId;
+      if (sid && sid.toLowerCase().startsWith(lowerPrefix)) {
+        group.activeIndex = i;
+        group.sessions[i].lastUsed = Date.now();
+        this.logger.info({ chatId, index: i, prefix }, 'Switched session by prefix');
+        this.saveToDisk();
+        return i;
+      }
+    }
+    return -1;
   }
 
   private cleanupExpired(): void {
     const now = Date.now();
     let changed = false;
-    for (const [chatId, session] of this.sessions) {
-      if (now - session.lastUsed > SESSION_TTL_MS) {
-        this.sessions.delete(chatId);
-        this.logger.debug({ chatId }, 'Expired session cleaned up');
+    for (const [chatId, group] of this.groups) {
+      const allExpired = group.sessions.every(s => now - s.lastUsed > SESSION_TTL_MS);
+      if (allExpired) {
+        this.groups.delete(chatId);
+        this.logger.debug({ chatId }, 'Expired session group cleaned up');
         changed = true;
       }
     }
@@ -209,23 +329,20 @@ export class SessionManager {
 
   private saveToDisk(): void {
     try {
-      const data: Record<string, PersistedSession> = {};
-      for (const [chatId, session] of this.sessions) {
-        // Persist sessions that have a sessionId, model, engine override, or active goal
-        if (session.sessionId || session.model || session.engine || session.activeGoal) {
+      const data: Record<string, PersistedSessionGroup> = {};
+      for (const [chatId, group] of this.groups) {
+        const persistedSessions = group.sessions
+          .filter(s => s.sessionId || s.model || s.engine || s.activeGoal || s.title)
+          .map(s => this.sessionToPersisted(s));
+        if (persistedSessions.length > 0) {
+          // Recalculate activeIndex after filtering
+          const activeSession = group.sessions[group.activeIndex];
+          const newActiveIndex = persistedSessions.findIndex(
+            ps => ps.sessionId === (activeSession.sessionId || '') && ps.lastUsed === activeSession.lastUsed,
+          );
           data[chatId] = {
-            sessionId: session.sessionId || '',
-            sessionIdEngine: session.sessionIdEngine,
-            workingDirectory: session.workingDirectory,
-            lastUsed: session.lastUsed,
-            cumulativeTokens: session.cumulativeTokens,
-            cumulativeCostUsd: session.cumulativeCostUsd,
-            cumulativeDurationMs: session.cumulativeDurationMs,
-            model: session.model,
-            modelEngine: session.modelEngine,
-            engine: session.engine,
-            activeGoal: session.activeGoal,
-            goalSetAt: session.goalSetAt,
+            activeIndex: Math.max(0, newActiveIndex),
+            sessions: persistedSessions,
           };
         }
       }
@@ -235,31 +352,63 @@ export class SessionManager {
     }
   }
 
+  private sessionToPersisted(s: UserSession): PersistedSession {
+    return {
+      sessionId: s.sessionId || '',
+      sessionIdEngine: s.sessionIdEngine,
+      workingDirectory: s.workingDirectory,
+      lastUsed: s.lastUsed,
+      cumulativeTokens: s.cumulativeTokens,
+      cumulativeCostUsd: s.cumulativeCostUsd,
+      cumulativeDurationMs: s.cumulativeDurationMs,
+      model: s.model,
+      modelEngine: s.modelEngine,
+      engine: s.engine,
+      activeGoal: s.activeGoal,
+      goalSetAt: s.goalSetAt,
+      title: s.title,
+    };
+  }
+
+  private persistedToSession(p: PersistedSession): UserSession {
+    return {
+      sessionId: p.sessionId || undefined,
+      sessionIdEngine: p.sessionIdEngine,
+      workingDirectory: p.workingDirectory,
+      lastUsed: p.lastUsed,
+      cumulativeTokens: p.cumulativeTokens ?? 0,
+      cumulativeCostUsd: p.cumulativeCostUsd ?? 0,
+      cumulativeDurationMs: p.cumulativeDurationMs ?? 0,
+      model: p.model,
+      modelEngine: p.modelEngine,
+      engine: p.engine,
+      activeGoal: p.activeGoal,
+      goalSetAt: p.goalSetAt,
+      title: p.title,
+    };
+  }
+
   private loadFromDisk(): void {
     try {
       if (!fs.existsSync(this.persistPath)) return;
       const raw = fs.readFileSync(this.persistPath, 'utf-8');
-      const data: Record<string, PersistedSession> = JSON.parse(raw);
-      const now = Date.now();
+      const data: Record<string, PersistedSessionGroup | PersistedSession> = JSON.parse(raw);
       let loaded = 0;
-      for (const [chatId, persisted] of Object.entries(data)) {
-        // Skip expired sessions
-        if (now - persisted.lastUsed > SESSION_TTL_MS) continue;
-        this.sessions.set(chatId, {
-          sessionId: persisted.sessionId || undefined,
-          sessionIdEngine: persisted.sessionIdEngine,
-          workingDirectory: persisted.workingDirectory,
-          lastUsed: persisted.lastUsed,
-          cumulativeTokens: persisted.cumulativeTokens ?? 0,
-          cumulativeCostUsd: persisted.cumulativeCostUsd ?? 0,
-          cumulativeDurationMs: persisted.cumulativeDurationMs ?? 0,
-          model: persisted.model,
-          modelEngine: persisted.modelEngine,
-          engine: persisted.engine,
-          activeGoal: persisted.activeGoal,
-          goalSetAt: persisted.goalSetAt,
-        });
-        loaded++;
+      for (const [chatId, entry] of Object.entries(data)) {
+        // Detect old flat format (has 'sessionId' at top level) vs new group format (has 'sessions' array)
+        if (this.isLegacyPersistedSession(entry)) {
+          const session = this.persistedToSession(entry);
+          this.groups.set(chatId, { activeIndex: 0, sessions: [session] });
+          loaded++;
+        } else {
+          const groupData = entry as PersistedSessionGroup;
+          const sessions = groupData.sessions.map(p => this.persistedToSession(p));
+          if (sessions.length > 0) {
+            const activeIndex = Math.min(groupData.activeIndex, sessions.length - 1);
+            this.groups.set(chatId, { activeIndex: Math.max(0, activeIndex), sessions });
+            loaded++;
+          }
+        }
       }
       if (loaded > 0) {
         this.logger.info({ loaded, path: this.persistPath }, 'Restored sessions from disk');
@@ -267,6 +416,10 @@ export class SessionManager {
     } catch (err) {
       this.logger.warn({ err }, 'Failed to load sessions from disk, starting fresh');
     }
+  }
+
+  private isLegacyPersistedSession(entry: unknown): entry is PersistedSession {
+    return typeof entry === 'object' && entry !== null && 'workingDirectory' in entry && !('sessions' in entry);
   }
 
   destroy(): void {

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -331,18 +331,16 @@ export class SessionManager {
     try {
       const data: Record<string, PersistedSessionGroup> = {};
       for (const [chatId, group] of this.groups) {
-        const persistedSessions = group.sessions
-          .filter(s => s.sessionId || s.model || s.engine || s.activeGoal || s.title)
-          .map(s => this.sessionToPersisted(s));
-        if (persistedSessions.length > 0) {
-          // Recalculate activeIndex after filtering
-          const activeSession = group.sessions[group.activeIndex];
-          const newActiveIndex = persistedSessions.findIndex(
-            ps => ps.sessionId === (activeSession.sessionId || '') && ps.lastUsed === activeSession.lastUsed,
-          );
+        // Persist all sessions in a group — even new ones without a sessionId yet.
+        // The group is the unit of persistence; filtering individual sessions
+        // would lose newly-created (post-/reset) sessions before their first turn.
+        const hasContent = group.sessions.some(
+          s => s.sessionId || s.model || s.engine || s.activeGoal || s.title,
+        );
+        if (hasContent || group.sessions.length > 1) {
           data[chatId] = {
-            activeIndex: Math.max(0, newActiveIndex),
-            sessions: persistedSessions,
+            activeIndex: group.activeIndex,
+            sessions: group.sessions.map(s => this.sessionToPersisted(s)),
           };
         }
       }

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -53,16 +53,6 @@ describe('SessionManager', () => {
     expect(session.sessionIdEngine).toBe('codex');
   });
 
-  it('resets session (clears sessionId)', () => {
-    manager = new SessionManager('/tmp/test-dir', createLogger());
-    manager.getSession('chat1');
-    manager.setSessionId('chat1', 'sess-abc', 'codex');
-    manager.resetSession('chat1');
-    const session = manager.getSession('chat1');
-    expect(session.sessionId).toBeUndefined();
-    expect(session.sessionIdEngine).toBeUndefined();
-  });
-
   it('tracks model engine and clears it with the model override', () => {
     manager = new SessionManager('/tmp/test-dir', createLogger());
     manager.setSessionModel('chat1', 'gpt-5.5-codex', 'codex');
@@ -89,5 +79,213 @@ describe('SessionManager', () => {
     expect(session.sessionIdEngine).toBe('codex');
     expect(session.model).toBe('gpt-5.5-codex');
     expect(session.modelEngine).toBe('codex');
+  });
+
+  // --- Multi-session (SessionGroup) tests ---
+
+  describe('resetSession (multi-session)', () => {
+    it('creates a new session and preserves the old one', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.setSessionId('chat1', 'sess-old');
+      manager.resetSession('chat1');
+
+      const current = manager.getSession('chat1');
+      expect(current.sessionId).toBeUndefined();
+
+      const sessions = manager.listSessions('chat1');
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0].sessionId).toBe('sess-old');
+      expect(sessions[1].isActive).toBe(true);
+    });
+
+    it('active index points to the new session', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.setSessionId('chat1', 'sess-1');
+      manager.resetSession('chat1');
+      expect(manager.getActiveIndex('chat1')).toBe(1);
+    });
+  });
+
+  describe('listSessions', () => {
+    it('returns empty array for unknown chatId', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      expect(manager.listSessions('unknown')).toEqual([]);
+    });
+
+    it('returns sessions with correct format', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.setSessionId('chat1', 'sess-aaa');
+      manager.setTitle('chat1', 'Hello world');
+      manager.resetSession('chat1');
+      manager.setSessionId('chat1', 'sess-bbb');
+
+      const sessions = manager.listSessions('chat1');
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0]).toMatchObject({ index: 0, title: 'Hello world', sessionId: 'sess-aaa', isActive: false });
+      expect(sessions[1]).toMatchObject({ index: 1, sessionId: 'sess-bbb', isActive: true });
+    });
+  });
+
+  describe('switchSession', () => {
+    it('switches to a valid index', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.setSessionId('chat1', 'sess-aaa');
+      manager.resetSession('chat1');
+      manager.setSessionId('chat1', 'sess-bbb');
+
+      const switched = manager.switchSession('chat1', 0);
+      expect(switched).toBe(true);
+      expect(manager.getSession('chat1').sessionId).toBe('sess-aaa');
+      expect(manager.getActiveIndex('chat1')).toBe(0);
+    });
+
+    it('returns false for invalid index', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.getSession('chat1');
+      expect(manager.switchSession('chat1', 5)).toBe(false);
+      expect(manager.switchSession('chat1', -1)).toBe(false);
+    });
+
+    it('returns false for unknown chatId', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      expect(manager.switchSession('unknown', 0)).toBe(false);
+    });
+  });
+
+  describe('getVirtualChatId', () => {
+    it('returns plain chatId for index 0', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.getSession('chat1');
+      expect(manager.getVirtualChatId('chat1')).toBe('chat1');
+    });
+
+    it('returns chatId::N for non-zero index', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.getSession('chat1');
+      manager.resetSession('chat1');
+      expect(manager.getVirtualChatId('chat1')).toBe('chat1::1');
+    });
+  });
+
+  describe('setTitle', () => {
+    it('sets title on the active session', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.getSession('chat1');
+      manager.setTitle('chat1', 'My first message');
+      const sessions = manager.listSessions('chat1');
+      expect(sessions[0].title).toBe('My first message');
+    });
+
+    it('does not overwrite an existing title', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.getSession('chat1');
+      manager.setTitle('chat1', 'First');
+      manager.setTitle('chat1', 'Second');
+      const sessions = manager.listSessions('chat1');
+      expect(sessions[0].title).toBe('First');
+    });
+  });
+
+  describe('switchToSessionByPrefix', () => {
+    it('finds and switches to session by prefix', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.setSessionId('chat1', 'abcdef1234567890');
+      manager.resetSession('chat1');
+      manager.setSessionId('chat1', 'xyz98765abcdef00');
+
+      const idx = manager.switchToSessionByPrefix('chat1', 'abcdef12');
+      expect(idx).toBe(0);
+      expect(manager.getActiveIndex('chat1')).toBe(0);
+    });
+
+    it('returns -1 for no match', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.setSessionId('chat1', 'abcdef1234567890');
+      expect(manager.switchToSessionByPrefix('chat1', 'xxxxxxxx')).toBe(-1);
+    });
+
+    it('rejects prefixes shorter than 8 chars', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      manager.setSessionId('chat1', 'abcdef1234567890');
+      expect(manager.switchToSessionByPrefix('chat1', 'abc')).toBe(-1);
+    });
+  });
+
+  describe('MAX_SESSIONS_PER_CHAT limit', () => {
+    it('trims oldest sessions when exceeding limit', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger());
+      // Create 20 sessions (the max)
+      for (let i = 0; i < 20; i++) {
+        if (i > 0) manager.resetSession('chat1');
+        manager.setSessionId('chat1', `sess-${String(i).padStart(3, '0')}`);
+      }
+      expect(manager.listSessions('chat1')).toHaveLength(20);
+
+      // One more reset should trim
+      manager.resetSession('chat1');
+      const sessions = manager.listSessions('chat1');
+      expect(sessions).toHaveLength(20);
+      // The oldest (sess-000) should be gone
+      expect(sessions.find(s => s.sessionId === 'sess-000')).toBeUndefined();
+    });
+  });
+
+  describe('persistence with session groups', () => {
+    it('saves and restores session groups', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger(), 'group-test');
+      manager.setSessionId('chat1', 'sess-aaa');
+      manager.setTitle('chat1', 'First topic');
+      manager.resetSession('chat1');
+      manager.setSessionId('chat1', 'sess-bbb');
+      manager.setTitle('chat1', 'Second topic');
+      manager.destroy();
+
+      manager = new SessionManager('/tmp/test-dir', createLogger(), 'group-test');
+      const sessions = manager.listSessions('chat1');
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0]).toMatchObject({ sessionId: 'sess-aaa', title: 'First topic' });
+      expect(sessions[1]).toMatchObject({ sessionId: 'sess-bbb', title: 'Second topic', isActive: true });
+    });
+
+    it('preserves upstream fields (engine, model, goal) through groups', () => {
+      manager = new SessionManager('/tmp/test-dir', createLogger(), 'fields-test');
+      manager.setSessionId('chat1', 'sess-aaa');
+      manager.setSessionModel('chat1', 'claude-opus-4-7', 'claude');
+      manager.setGoal('chat1', 'fix all bugs');
+      manager.destroy();
+
+      manager = new SessionManager('/tmp/test-dir', createLogger(), 'fields-test');
+      const session = manager.getSession('chat1');
+      expect(session.model).toBe('claude-opus-4-7');
+      expect(session.modelEngine).toBe('claude');
+      expect(session.activeGoal).toBe('fix all bugs');
+    });
+  });
+
+  describe('legacy format migration', () => {
+    it('migrates old flat format to session group', () => {
+      // Write old flat format directly
+      const persistPath = join(storeDir, 'sessions-migrate-test.json');
+      const oldData = {
+        chat1: {
+          sessionId: 'legacy-sess-id',
+          workingDirectory: '/old/dir',
+          lastUsed: Date.now(),
+          cumulativeTokens: 100,
+          cumulativeCostUsd: 0.5,
+          cumulativeDurationMs: 5000,
+        },
+      };
+      writeFileSync(persistPath, JSON.stringify(oldData));
+
+      manager = new SessionManager('/tmp/test-dir', createLogger(), 'migrate-test');
+      const session = manager.getSession('chat1');
+      expect(session.sessionId).toBe('legacy-sess-id');
+      expect(session.workingDirectory).toBe('/old/dir');
+
+      const sessions = manager.listSessions('chat1');
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].isActive).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## 概要

将 SessionManager 从扁平的 per-chatId 模型重构为 SessionGroup 分组模型，允许用户在一个聊天中维护多个对话线程。

- **`/reset`** 不再销毁会话，而是创建新会话，旧会话保留可切换
- **`/sessions`** 列出当前聊天的所有会话（编号、标题、ID 前缀、活跃标记）
- **`/switch N`** 按编号切换会话
- **`/session <prefix>`** 按 sessionId 前缀切换（按 #239 统一命令设计）
- 虚拟 chatId `{chatId}::{N}` 确保 SessionRegistry 记录隔离
- 持久化格式向后兼容，自动迁移旧扁平格式为分组格式

## 对 reviewer 反馈的回应

1. **文件迁移** — 已基于最新 `upstream/main`（`a6ce914`）全新重写，代码位于 `src/engines/claude/session-manager.ts`，保留了所有上游新字段（engine, model, goal 等）
2. **#243/#244 依赖** — 两个 PR 自 5/9 以来无更新（作者 uestney 未回应 review 意见），先不等待。当前实现与现有 SessionRegistry（SQLite）兼容，后续 #243/#244 合并后会做适配 rebase
3. **并发安全** — MessageBridge 通过 `runningTasks` Map 保证每个 chatId 同时只有一个任务在执行，`activeIndex` 读写不存在竞态条件。已在代码中注释说明此不变量
4. **统一命令设计** — 按 #239 讨论结果增加了 `/session <prefix>` 命令，命令空间与 #227 的 `/resume` 正交

## 变更文件

| 文件 | 变更 |
|------|------|
| `src/engines/claude/session-manager.ts` | SessionGroup 分组模型 + 6 个新方法 + 持久化迁移 |
| `src/bridge/command-handler.ts` | `/sessions`、`/switch`、`/session` 命令 + `/help` 更新 |
| `src/bridge/message-bridge.ts` | 虚拟 chatId + 标题追踪 |
| `tests/session-manager.test.ts` | 24 个新测试覆盖所有新功能 |

## 测试计划

- [x] `npm run build` — 编译通过（预存的 kimi/marked 错误与本 PR 无关）
- [x] `npm test` — 24 个新测试 + 5 个原有测试全部通过
- [x] `npm run lint` — 无新错误
- [x] **飞书集成测试** — 完整多会话生命周期验证如下：

### 飞书集成测试记录

**环境**：bot `xiaobai`，persistent executor 模式

| 步骤 | 操作 | 飞书返回 | 内部状态 |
|------|------|----------|----------|
| 1 | 发送"中国的首都是哪里？" | "北京啊" | sessions=1, activeIndex=0, sid=59e35d2f, title="中国的首都是哪里？" |
| 2 | `/reset` | "New session created. Previous sessions preserved" | sessions=2, activeIndex=1, 旧会话完整保留 |
| 3 | 发送"法国的首都是哪里？" | "巴黎啊" | session[1] 获得独立 sid=e82ab932, title="法国的首都是哪里" |
| 4 | `/switch 1` | "Switched to session 1 (59e35d2f...)" | activeIndex 从 1 切回 0 |
| 5 | 发送"我刚才问了什么问题？" | **"你问中国的首都是哪里"** ✅ | sid 保持 59e35d2f，上下文正确恢复 |

**关键验证**：切换回旧会话后，Claude 正确回忆了"中国的首都"而非"法国的首都"，证明会话隔离和上下文恢复功能正常。

### 集成测试中发现并修复的 bug

1. **saveToDisk 过滤 bug**：新创建的空会话（`/reset` 后尚无 sessionId）被持久化过滤器跳过，导致重启后丢失
2. **persistent executor 未释放**：`/switch` 未调用 `releaseExecutor`，导致旧 Claude 进程的 sessionId 覆盖切换后的会话

两个 bug 均已在第二个 commit 中修复。