### PR TITLE
feat: upgrade Feishu card to schema 2.0 with markdown styling

### DIFF
--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -1,6 +1,7 @@
 // Re-export shared types so existing imports from this module continue to work
 export type { CardStatus, ToolCall, PendingQuestion, CardState } from '../types.js';
 import type { CardState, CardStatus } from '../types.js';
+import { optimizeMarkdownStyle, sanitizeTextForCard } from './markdown-style.js';
 
 const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: string }> = {
   thinking: { color: 'blue', title: 'Thinking...', icon: '🔵' },
@@ -41,9 +42,11 @@ export function buildCard(state: CardState): string {
 
   // Response content
   if (state.responseText) {
+    // Apply: sanitizeTextForCard → optimizeMarkdownStyle → truncateContent
+    const processed = truncateContent(optimizeMarkdownStyle(sanitizeTextForCard(state.responseText)));
     elements.push({
       tag: 'markdown',
-      content: truncateContent(state.responseText),
+      content: processed,
     });
   } else if (state.status === 'thinking') {
     elements.push({
@@ -101,18 +104,15 @@ export function buildCard(state: CardState): string {
     }
     if (parts.length > 0) {
       elements.push({
-        tag: 'note',
-        elements: [
-          {
-            tag: 'plain_text',
-            content: parts.join(' | '),
-          },
-        ],
+        tag: 'markdown',
+        content: `<font color="grey">${parts.join(' · ')}</font>`,
+        text_size: 'notation_small_v2',
       });
     }
   }
 
   const card = {
+    schema: '2.0',
     config: { wide_screen_mode: true },
     header: {
       template: config.color,
@@ -121,7 +121,7 @@ export function buildCard(state: CardState): string {
         tag: 'plain_text',
       },
     },
-    elements,
+    body: { elements },
   };
 
   return JSON.stringify(card);
@@ -129,6 +129,7 @@ export function buildCard(state: CardState): string {
 
 export function buildHelpCard(): string {
   const card = {
+    schema: '2.0',
     config: { wide_screen_mode: true },
     header: {
       template: 'blue',
@@ -137,28 +138,30 @@ export function buildHelpCard(): string {
         tag: 'plain_text',
       },
     },
-    elements: [
-      {
-        tag: 'markdown',
-        content: [
-          '**Available Commands:**',
-          '`/reset` - Clear session, start fresh',
-          '`/stop` - Abort current running task',
-          '`/status` - Show current session info',
-          '`/memory` - Memory document commands',
-          '`/help` - Show this help message',
-          '',
-          '**Usage:**',
-          'Send any text message to start a conversation with Claude Code.',
-          'Each chat has an independent session with a fixed working directory.',
-          '',
-          '**Memory Commands:**',
-          '`/memory list` - Show folder tree',
-          '`/memory search <query>` - Search documents',
-          '`/memory status` - Server health check',
-        ].join('\n'),
-      },
-    ],
+    body: {
+      elements: [
+        {
+          tag: 'markdown',
+          content: [
+            '**Available Commands:**',
+            '`/reset` - Clear session, start fresh',
+            '`/stop` - Abort current running task',
+            '`/status` - Show current session info',
+            '`/memory` - Memory document commands',
+            '`/help` - Show this help message',
+            '',
+            '**Usage:**',
+            'Send any text message to start a conversation with Claude Code.',
+            'Each chat has an independent session with a fixed working directory.',
+            '',
+            '**Memory Commands:**',
+            '`/memory list` - Show folder tree',
+            '`/memory search <query>` - Search documents',
+            '`/memory status` - Server health check',
+          ].join('\n'),
+        },
+      ],
+    },
   };
   return JSON.stringify(card);
 }
@@ -170,6 +173,7 @@ export function buildStatusCard(
   isRunning: boolean,
 ): string {
   const card = {
+    schema: '2.0',
     config: { wide_screen_mode: true },
     header: {
       template: 'blue',
@@ -178,23 +182,26 @@ export function buildStatusCard(
         tag: 'plain_text',
       },
     },
-    elements: [
-      {
-        tag: 'markdown',
-        content: [
-          `**User:** \`${userId}\``,
-          `**Working Directory:** \`${workingDirectory}\``,
-          `**Session:** ${sessionId ? `\`${sessionId.slice(0, 8)}...\`` : '_None_'}`,
-          `**Running:** ${isRunning ? 'Yes ⏳' : 'No'}`,
-        ].join('\n'),
-      },
-    ],
+    body: {
+      elements: [
+        {
+          tag: 'markdown',
+          content: [
+            `**User:** \`${userId}\``,
+            `**Working Directory:** \`${workingDirectory}\``,
+            `**Session:** ${sessionId ? `\`${sessionId.slice(0, 8)}...\`` : '_None_'}`,
+            `**Running:** ${isRunning ? 'Yes ⏳' : 'No'}`,
+          ].join('\n'),
+        },
+      ],
+    },
   };
   return JSON.stringify(card);
 }
 
 export function buildTextCard(title: string, content: string, color: string = 'blue'): string {
   const card = {
+    schema: '2.0',
     config: { wide_screen_mode: true },
     header: {
       template: color,
@@ -203,12 +210,14 @@ export function buildTextCard(title: string, content: string, color: string = 'b
         tag: 'plain_text',
       },
     },
-    elements: [
-      {
-        tag: 'markdown',
-        content,
-      },
-    ],
+    body: {
+      elements: [
+        {
+          tag: 'markdown',
+          content: optimizeMarkdownStyle(content),
+        },
+      ],
+    },
   };
   return JSON.stringify(card);
 }

--- a/src/feishu/markdown-style.ts
+++ b/src/feishu/markdown-style.ts
@@ -1,0 +1,180 @@
+/**
+ * Markdown style optimization for Feishu card rendering.
+ *
+ * Ported from OpenClaw Lark (https://github.com/larksuite/openclaw-lark/)
+ * src/card/markdown-style.ts and src/card/card-error.ts (MIT License).
+ */
+
+// ---------------------------------------------------------------------------
+// optimizeMarkdownStyle
+// ---------------------------------------------------------------------------
+
+/**
+ * Optimize markdown for Feishu card display:
+ * - Heading demotion: H1 → H4, H2~H6 → H5 (only when H1-H3 exist)
+ * - Add <br> spacing before/after tables and code blocks (cardVersion >= 2)
+ * - Compress excessive blank lines (3+ → 2)
+ * - Protect code block content from transformation
+ * - Strip invalid image keys (non img_ prefixed)
+ */
+export function optimizeMarkdownStyle(text: string, cardVersion = 2): string {
+  try {
+    let r = _optimizeMarkdownStyle(text, cardVersion);
+    r = stripInvalidImageKeys(r);
+    return r;
+  } catch {
+    return text;
+  }
+}
+
+function _optimizeMarkdownStyle(text: string, cardVersion = 2): string {
+  // 1. Extract code blocks, protect with placeholders, restore after processing
+  const MARK = '___CB_';
+  const codeBlocks: string[] = [];
+  let r = text.replace(/(^|\n)(`{3,})([^\n]*)\n[\s\S]*?\n\2(?=\n|$)/g, (m, prefix = '') => {
+    const block = m.slice(String(prefix).length);
+    return `${prefix}${MARK}${codeBlocks.push(block) - 1}___`;
+  });
+
+  // 2. Heading demotion — only when original text contains h1~h3 headings.
+  //    Process H2~H6 → H5 first, then H1 → H4 (order matters to avoid
+  //    double-matching H1→H4 as H2~H6).
+  const hasH1toH3 = /^#{1,3} /m.test(text);
+  if (hasH1toH3) {
+    r = r.replace(/^#{2,6} (.+)$/gm, '##### $1'); // H2~H6 → H5
+    r = r.replace(/^# (.+)$/gm, '#### $1');       // H1 → H4
+  }
+
+  if (cardVersion >= 2) {
+    // 3. Add <br> between consecutive headings
+    r = r.replace(/^(#{4,5} .+)\n{1,2}(#{4,5} )/gm, '$1\n<br>\n$2');
+
+    // 4. Table spacing
+    // 4a. Non-table line directly followed by table line — insert blank line
+    r = r.replace(/^([^|\n].*)\n(\|.+\|)/gm, '$1\n\n$2');
+    // 4b. Insert <br> before table blocks
+    r = r.replace(/\n\n((?:\|.+\|[^\S\n]*\n?)+)/g, '\n\n<br>\n\n$1');
+    // 4c. Append <br> after table blocks (skip if followed by hr/heading/bold/EOF)
+    r = r.replace(/((?:^\|.+\|[^\S\n]*\n?)+)/gm, (m, _table, offset) => {
+      const after = r.slice(offset + m.length).replace(/^\n+/, '');
+      if (!after || /^(---|#{4,5} |\*\*)/.test(after)) return m;
+      return m + '\n<br>\n';
+    });
+    // 4d. Clean up extra blank lines around <br> for plain text before tables
+    r = r.replace(/^((?!#{4,5} )(?!\*\*).+)\n\n(<br>)\n\n(\|)/gm, '$1\n$2\n$3');
+    // 4d2. Bold line before table
+    r = r.replace(/^(\*\*.+)\n\n(<br>)\n\n(\|)/gm, '$1\n$2\n\n$3');
+    // 4e. Clean up extra blank lines around <br> for plain text after tables
+    r = r.replace(/(\|[^\n]*\n)\n(<br>\n)((?!#{4,5} )(?!\*\*))/gm, '$1$2$3');
+
+    // 5. Restore code blocks with <br> spacing
+    codeBlocks.forEach((block, i) => {
+      r = r.replace(`${MARK}${i}___`, `\n<br>\n${block}\n<br>\n`);
+    });
+  } else {
+    // 5. Restore code blocks without <br>
+    codeBlocks.forEach((block, i) => {
+      r = r.replace(`${MARK}${i}___`, block);
+    });
+  }
+
+  // 6. Compress excessive blank lines (3+ newlines → 2)
+  r = r.replace(/\n{3,}/g, '\n\n');
+
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// stripInvalidImageKeys
+// ---------------------------------------------------------------------------
+
+/** Matches complete markdown image syntax: `![alt](value)` */
+const IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+
+/**
+ * Strip `![alt](value)` where value is not a valid Feishu image key
+ * (`img_xxx`). Prevents CardKit error 200570.
+ */
+function stripInvalidImageKeys(text: string): string {
+  if (!text.includes('![')) return text;
+  return text.replace(IMAGE_RE, (fullMatch, _alt, value) => {
+    if (value.startsWith('img_')) return fullMatch;
+    return ''; // strip all non-img_ image references
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Table limit protection
+// ---------------------------------------------------------------------------
+
+/** Empirical Feishu card table limit — 4+ triggers 230099/11310 */
+export const FEISHU_CARD_TABLE_LIMIT = 3;
+
+export interface MarkdownTableMatch {
+  index: number;
+  length: number;
+  raw: string;
+}
+
+/**
+ * Find markdown tables that are outside code blocks (only those are
+ * rendered as card table elements by Feishu).
+ */
+export function findMarkdownTablesOutsideCodeBlocks(text: string): MarkdownTableMatch[] {
+  const codeBlockRanges: Array<{ start: number; end: number }> = [];
+  const codeBlockRegex = /```[\s\S]*?```/g;
+  let codeBlockMatch = codeBlockRegex.exec(text);
+  while (codeBlockMatch != null) {
+    codeBlockRanges.push({
+      start: codeBlockMatch.index,
+      end: codeBlockMatch.index + codeBlockMatch[0].length,
+    });
+    codeBlockMatch = codeBlockRegex.exec(text);
+  }
+
+  const isInsideCodeBlock = (idx: number): boolean =>
+    codeBlockRanges.some((range) => idx >= range.start && idx < range.end);
+
+  const tableRegex = /\|.+\|[\r\n]+\|[-:| ]+\|[\s\S]*?(?=\n\n|\n(?!\|)|$)/g;
+  const matches: MarkdownTableMatch[] = [];
+  let tableMatch = tableRegex.exec(text);
+  while (tableMatch != null) {
+    if (!isInsideCodeBlock(tableMatch.index)) {
+      matches.push({
+        index: tableMatch.index,
+        length: tableMatch[0].length,
+        raw: tableMatch[0],
+      });
+    }
+    tableMatch = tableRegex.exec(text);
+  }
+
+  return matches;
+}
+
+/**
+ * Wrap markdown tables beyond the limit in code blocks to prevent
+ * Feishu card error 230099/11310 (table element count exceeded).
+ *
+ * The first `tableLimit` tables are kept as-is for card rendering;
+ * excess tables are wrapped in backtick fences.
+ */
+export function sanitizeTextForCard(text: string, tableLimit: number = FEISHU_CARD_TABLE_LIMIT): string {
+  const matches = findMarkdownTablesOutsideCodeBlocks(text);
+  if (matches.length <= tableLimit) return text;
+  return wrapTablesBeyondLimit(text, matches, tableLimit);
+}
+
+function wrapTablesBeyondLimit(text: string, matches: readonly MarkdownTableMatch[], keepCount: number): string {
+  if (matches.length <= keepCount) return text;
+
+  // Back-to-front replacement keeps the original indices stable.
+  let result = text;
+  for (let i = matches.length - 1; i >= keepCount; i--) {
+    const { index, length, raw } = matches[i];
+    const replacement = `\`\`\`\n${raw}\n\`\`\``;
+    result = result.slice(0, index) + replacement + result.slice(index + length);
+  }
+
+  return result;
+}

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -1,8 +1,28 @@
 import { describe, it, expect } from 'vitest';
 import { buildCard, buildHelpCard, buildStatusCard, buildTextCard } from '../src/feishu/card-builder.js';
+import { optimizeMarkdownStyle, sanitizeTextForCard, findMarkdownTablesOutsideCodeBlocks } from '../src/feishu/markdown-style.js';
 import type { CardState } from '../src/types.js';
 
+// ---------------------------------------------------------------------------
+// buildCard — CardKit v2 structure
+// ---------------------------------------------------------------------------
+
 describe('buildCard', () => {
+  it('outputs CardKit v2 structure with schema and body.elements', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'hello',
+      responseText: 'Done.',
+      toolCalls: [],
+    };
+    const json = JSON.parse(buildCard(state));
+    expect(json.schema).toBe('2.0');
+    expect(json.body).toBeDefined();
+    expect(json.body.elements).toBeInstanceOf(Array);
+    // v1 top-level `elements` should NOT exist
+    expect(json.elements).toBeUndefined();
+  });
+
   it('builds thinking card', () => {
     const state: CardState = {
       status: 'thinking',
@@ -13,7 +33,7 @@ describe('buildCard', () => {
     const json = JSON.parse(buildCard(state));
     expect(json.header.template).toBe('blue');
     expect(json.header.title.content).toContain('Thinking');
-    expect(json.elements.some((e: any) => e.tag === 'markdown' && e.content.includes('thinking'))).toBe(true);
+    expect(json.body.elements.some((e: any) => e.tag === 'markdown' && e.content.includes('thinking'))).toBe(true);
   });
 
   it('builds running card with tool calls', () => {
@@ -28,7 +48,7 @@ describe('buildCard', () => {
     };
     const json = JSON.parse(buildCard(state));
     expect(json.header.template).toBe('blue');
-    const md = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('Read'));
+    const md = json.body.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('Read'));
     expect(md).toBeDefined();
     expect(md.content).toContain('✅');
     expect(md.content).toContain('⏳');
@@ -45,9 +65,11 @@ describe('buildCard', () => {
     };
     const json = JSON.parse(buildCard(state));
     expect(json.header.template).toBe('green');
-    const note = json.elements.find((e: any) => e.tag === 'note');
-    expect(note).toBeDefined();
-    expect(note.elements[0].content).toContain('5.0s');
+    const footer = json.body.elements.find(
+      (e: any) => e.tag === 'markdown' && e.text_size === 'notation_small_v2'
+    );
+    expect(footer).toBeDefined();
+    expect(footer.content).toContain('5.0s');
   });
 
   it('builds error card with error message', () => {
@@ -60,7 +82,7 @@ describe('buildCard', () => {
     };
     const json = JSON.parse(buildCard(state));
     expect(json.header.template).toBe('red');
-    const errEl = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('Process crashed'));
+    const errEl = json.body.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('Process crashed'));
     expect(errEl).toBeDefined();
   });
 
@@ -85,7 +107,7 @@ describe('buildCard', () => {
     };
     const json = JSON.parse(buildCard(state));
     expect(json.header.template).toBe('yellow');
-    const qEl = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('Which env?'));
+    const qEl = json.body.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('Which env?'));
     expect(qEl).toBeDefined();
     expect(qEl.content).toContain('Production');
     expect(qEl.content).toContain('Staging');
@@ -99,23 +121,25 @@ describe('buildCard', () => {
       toolCalls: [],
     };
     const json = JSON.parse(buildCard(state));
-    const md = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('truncated'));
+    const md = json.body.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('truncated'));
     expect(md).toBeDefined();
   });
 });
 
 describe('buildHelpCard', () => {
-  it('returns valid card JSON', () => {
+  it('returns valid v2 card JSON', () => {
     const json = JSON.parse(buildHelpCard());
+    expect(json.schema).toBe('2.0');
     expect(json.header.title.content).toContain('Help');
-    expect(json.elements.length).toBeGreaterThan(0);
+    expect(json.body.elements.length).toBeGreaterThan(0);
   });
 });
 
 describe('buildStatusCard', () => {
   it('shows session info', () => {
     const json = JSON.parse(buildStatusCard('user123', '/home/user/project', 'sess-abc-12345678', true));
-    const md = json.elements[0].content;
+    expect(json.schema).toBe('2.0');
+    const md = json.body.elements[0].content;
     expect(md).toContain('user123');
     expect(md).toContain('/home/user/project');
     expect(md).toContain('sess-abc');
@@ -124,17 +148,111 @@ describe('buildStatusCard', () => {
 
   it('shows no session', () => {
     const json = JSON.parse(buildStatusCard('user', '/home', undefined, false));
-    const md = json.elements[0].content;
+    const md = json.body.elements[0].content;
     expect(md).toContain('None');
     expect(md).toContain('No');
   });
 });
 
 describe('buildTextCard', () => {
-  it('builds simple text card', () => {
+  it('builds simple text card with v2 structure', () => {
     const json = JSON.parse(buildTextCard('Title', 'Some content', 'green'));
+    expect(json.schema).toBe('2.0');
     expect(json.header.template).toBe('green');
     expect(json.header.title.content).toBe('Title');
-    expect(json.elements[0].content).toBe('Some content');
+    expect(json.body.elements[0].content).toBe('Some content');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// optimizeMarkdownStyle
+// ---------------------------------------------------------------------------
+
+describe('optimizeMarkdownStyle', () => {
+  it('demotes headings when H1-H3 are present', () => {
+    const input = '# Title\n## Section\n### Sub\ntext';
+    const result = optimizeMarkdownStyle(input);
+    expect(result).toContain('#### Title');
+    expect(result).toContain('##### Section');
+    expect(result).toContain('##### Sub');
+  });
+
+  it('does not demote headings when only H4+ are present', () => {
+    const input = '#### Already small\n##### Tiny';
+    const result = optimizeMarkdownStyle(input);
+    expect(result).toContain('#### Already small');
+    expect(result).toContain('##### Tiny');
+  });
+
+  it('adds <br> spacing around tables for cardVersion >= 2', () => {
+    const input = 'Some text\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nMore text';
+    const result = optimizeMarkdownStyle(input, 2);
+    expect(result).toContain('<br>');
+  });
+
+  it('does not add <br> for cardVersion 1', () => {
+    const input = 'Some text\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nMore text';
+    const result = optimizeMarkdownStyle(input, 1);
+    expect(result).not.toContain('<br>');
+  });
+
+  it('protects code block content from heading demotion', () => {
+    const input = '# Title\n\n```\n# Not a heading\n## Also not\n```\n\nEnd';
+    const result = optimizeMarkdownStyle(input);
+    expect(result).toContain('#### Title');
+    // Code block content should be preserved
+    expect(result).toContain('# Not a heading');
+    expect(result).toContain('## Also not');
+  });
+
+  it('compresses excessive blank lines', () => {
+    const input = 'A\n\n\n\n\nB';
+    const result = optimizeMarkdownStyle(input);
+    expect(result).toBe('A\n\nB');
+  });
+
+  it('strips invalid image keys', () => {
+    const input = '![alt](https://example.com/img.png)\n![ok](img_abc123)';
+    const result = optimizeMarkdownStyle(input);
+    expect(result).not.toContain('https://example.com');
+    expect(result).toContain('![ok](img_abc123)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeTextForCard
+// ---------------------------------------------------------------------------
+
+describe('sanitizeTextForCard', () => {
+  const makeTable = (label: string) =>
+    `| ${label} | Value |\n|---|---|\n| a | 1 |`;
+
+  it('passes through text with tables within limit', () => {
+    const text = `${makeTable('T1')}\n\n${makeTable('T2')}\n\n${makeTable('T3')}`;
+    expect(sanitizeTextForCard(text)).toBe(text);
+  });
+
+  it('wraps excess tables in code blocks', () => {
+    const tables = Array.from({ length: 5 }, (_, i) => makeTable(`T${i + 1}`));
+    const text = tables.join('\n\n');
+    const result = sanitizeTextForCard(text);
+
+    // First 3 tables should remain as markdown tables
+    const remainingTables = findMarkdownTablesOutsideCodeBlocks(result);
+    expect(remainingTables.length).toBe(3);
+
+    // Tables 4 and 5 should be wrapped in code blocks
+    expect(result).toContain('```\n| T4');
+    expect(result).toContain('```\n| T5');
+  });
+
+  it('ignores tables inside code blocks', () => {
+    const text = '```\n| A | B |\n|---|---|\n| 1 | 2 |\n```';
+    expect(sanitizeTextForCard(text)).toBe(text);
+  });
+
+  it('returns text unchanged when no tables exist', () => {
+    const text = 'Just some plain text without tables.';
+    expect(sanitizeTextForCard(text)).toBe(text);
   });
 });


### PR DESCRIPTION
## Summary
- Upgrade Feishu interactive card to schema `2.0`
- Replace the unsupported `tag: note` footer element with a `markdown` element using `text_size: notation_small_v2` — fixes 400 `Failed to create card content … unsupported tag note` when sending cards
- Extract shared markdown rendering helpers into `src/feishu/markdown-style.ts` (sanitize + style optimization)
- Update `tests/card-builder.test.ts` to assert the new footer shape

## Test plan
- [x] `npm run build`
- [x] `npm test` (187 passing)
- [x] `npm run lint` (no new errors)
- [x] Live-tested against Feishu: card renders, no 400 responses