### PR TITLE
feat: add Skill Hub for cross-bot skill sharing

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -257,6 +257,62 @@ print(json.dumps(body))
         ;;
     esac
     ;;
+  # --- Skill Hub ---
+  skills|sk)
+    subcmd="${1:-list}"; shift 2>/dev/null || true
+    case "$subcmd" in
+      list|ls)
+        curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/skills" | _json
+        ;;
+      search|s)
+        query="$*"
+        if [[ -z "${query:-}" ]]; then echo "Usage: mb skills search <query>"; exit 1; fi
+        curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/skills/search?q=$(python3 -c 'import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))' "$query")" | _json
+        ;;
+      get|g)
+        if [[ -z "${1:-}" ]]; then echo "Usage: mb skills get <name>"; exit 1; fi
+        curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/skills/$1" | _json
+        ;;
+      publish|pub)
+        bot="${1:-}" skill="${2:-}"
+        if [[ -z "$bot" || -z "$skill" ]]; then
+          echo "Usage: mb skills publish <botName> <skillName>"
+          exit 1
+        fi
+        curl -s -X POST "$METABOT_URL/api/skills/$skill/publish-from-bot" \
+          -H "$METABOT_AUTH" -H "Content-Type: application/json" \
+          -d "{\"botName\":\"$bot\"}" | _json
+        ;;
+      install|i)
+        skill="${1:-}" bot="${2:-}"
+        if [[ -z "$skill" || -z "$bot" ]]; then
+          echo "Usage: mb skills install <skillName> <botName>"
+          exit 1
+        fi
+        source="${3:-local}"
+        python3 -c "
+import json, sys
+print(json.dumps({'botName': sys.argv[1], 'source': sys.argv[2]}))
+" "$bot" "$source" | \
+        curl -s -X POST "$METABOT_URL/api/skills/$skill/install" \
+          -H "$METABOT_AUTH" -H "Content-Type: application/json" \
+          -d @- | _json
+        ;;
+      remove|rm)
+        if [[ -z "${1:-}" ]]; then echo "Usage: mb skills remove <name>"; exit 1; fi
+        curl -s -X DELETE "$METABOT_URL/api/skills/$1" -H "$METABOT_AUTH" | _json
+        ;;
+      *)
+        echo "mb skills - Skill Hub (shared skill registry)"
+        echo "  mb skills list                               - List all skills (local + peer)"
+        echo "  mb skills search <query>                     - Search skills by keyword"
+        echo "  mb skills get <name>                         - Get skill details"
+        echo "  mb skills publish <botName> <skillName>      - Publish a bot's skill to the hub"
+        echo "  mb skills install <skillName> <botName>      - Install a skill to a bot"
+        echo "  mb skills remove <name>                      - Unpublish a skill"
+        ;;
+    esac
+    ;;
   # --- Health ---
   health|h)
     curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/health" | _json
@@ -296,13 +352,14 @@ print(json.dumps(body))
     echo "==> Updating skills..."
     SKILLS_DIR="$HOME/.claude/skills"
     mkdir -p "$SKILLS_DIR"
-    for skill in metaskill metamemory metabot voice phone-call; do
+    for skill in metaskill metamemory metabot voice phone-call skill-hub; do
       case "$skill" in
         metaskill)   src="$METABOT_SRC/src/skills/metaskill" ;;
         metamemory)  src="$METABOT_SRC/src/memory/skill" ;;
         metabot)     src="$METABOT_SRC/src/skills/metabot" ;;
         voice)       src="$METABOT_SRC/src/skills/voice" ;;
         phone-call)  src="$METABOT_SRC/src/skills/phone-call" ;;
+        skill-hub)   src="$METABOT_SRC/src/skills/skill-hub" ;;
         *)           src="" ;;
       esac
       if [[ -n "$src" && -d "$src" ]]; then
@@ -333,7 +390,7 @@ print(json.dumps(body))
       if [[ -n "${work_dir:-}" ]]; then
         ws_skills_dir="$work_dir/.claude/skills"
         mkdir -p "$ws_skills_dir"
-        for skill in metaskill metamemory metabot voice phone-call; do
+        for skill in metaskill metamemory metabot voice phone-call skill-hub; do
           if [[ -d "$SKILLS_DIR/$skill" ]]; then
             mkdir -p "$ws_skills_dir/$skill"
             cp -r "$SKILLS_DIR/$skill/." "$ws_skills_dir/$skill/"
@@ -481,6 +538,12 @@ print(json.dumps(body))
     echo "    mb voice config                  - Check RTC configuration"
     echo "    mb voice tts \"text\" [--play] [-o f] - Text-to-speech (saves MP3)"
     echo ""
+    echo ""
+    echo "  Skill Hub:"
+    echo "    mb skills                        - List all shared skills"
+    echo "    mb skills search <query>         - Search skills"
+    echo "    mb skills publish <bot> <skill>  - Publish a skill"
+    echo "    mb skills install <skill> <bot>  - Install a skill to a bot"
     echo ""
     echo "  Monitoring:"
     echo "    mb stats                         - Cost & usage stats (per-bot, per-user)"

--- a/src/api/http-server.ts
+++ b/src/api/http-server.ts
@@ -1,4 +1,5 @@
 import * as http from 'node:http';
+import * as path from 'node:path';
 import type * as lark from '@larksuiteoapi/node-sdk';
 import type { Logger } from '../utils/logger.js';
 import type { BotRegistry } from './bot-registry.js';
@@ -16,6 +17,7 @@ import { VoiceMeetingService } from './voice-meeting.js';
 import { VoiceIdentityStore } from './voice-identity.js';
 import { RtcVoiceChatService } from './rtc-voice-chat.js';
 import { ActivityStore } from './activity-store.js';
+import { SkillHubStore } from './skill-hub-store.js';
 import { metrics as _metrics } from '../utils/metrics.js';
 import type { SessionRegistry } from '../session/session-registry.js';
 import {
@@ -28,6 +30,7 @@ import {
   handleSyncRoutes,
   handleRtcRoutes,
   handleSessionRoutes,
+  handleSkillHubRoutes,
 } from './routes/index.js';
 import type { RouteContext } from './routes/index.js';
 
@@ -66,6 +69,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
   const meetingService = new VoiceMeetingService(registry, logger);
   const voiceIdentityStore = new VoiceIdentityStore(logger);
   const activityStore = new ActivityStore(logger);
+  const skillHubStore = new SkillHubStore(path.join(process.cwd(), 'data'), logger);
   const rtcService = new RtcVoiceChatService(logger);
   if (rtcService.isConfigured()) {
     logger.info('RTC voice chat service enabled');
@@ -83,6 +87,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
     ws,
     sessionRegistry: options.sessionRegistry,
     activityStore,
+    skillHubStore,
   };
 
   // Route handlers in priority order
@@ -95,6 +100,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
     handleSyncRoutes,
     handleRtcRoutes,
     handleSessionRoutes,
+    handleSkillHubRoutes,
   ];
 
   const server = http.createServer(async (req, res) => {

--- a/src/api/peer-manager.ts
+++ b/src/api/peer-manager.ts
@@ -8,6 +8,16 @@ export interface PeerBotInfo extends BotInfo {
   peerName: string;
 }
 
+export interface PeerSkillInfo {
+  name: string;
+  description: string;
+  version: number;
+  author: string;
+  tags: string[];
+  peerUrl: string;
+  peerName: string;
+}
+
 export interface PeerStatus {
   name: string;
   url: string;
@@ -24,6 +34,7 @@ interface PeerState {
   lastChecked: number;
   lastHealthy: number;
   bots: PeerBotInfo[];
+  skills: PeerSkillInfo[];
   error?: string;
 }
 
@@ -47,6 +58,7 @@ export class PeerManager {
         lastChecked: 0,
         lastHealthy: 0,
         bots: [],
+        skills: [],
       });
     }
 
@@ -73,23 +85,31 @@ export class PeerManager {
 
   private async refreshPeer(state: PeerState): Promise<void> {
     const { config } = state;
-    const url = `${config.url}/api/bots`;
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = {
+      'X-MetaBot-Origin': 'peer',
+    };
     if (config.secret) {
       headers['Authorization'] = `Bearer ${config.secret}`;
     }
 
     try {
-      const response = await proxyFetch(url, {
-        headers,
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      });
+      // Fetch bots and skills in parallel
+      const [botsResp, skillsResp] = await Promise.all([
+        proxyFetch(`${config.url}/api/bots`, {
+          headers,
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        }),
+        proxyFetch(`${config.url}/api/skills`, {
+          headers,
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        }).catch(() => null), // Skills endpoint may not exist on older peers
+      ]);
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      if (!botsResp.ok) {
+        throw new Error(`HTTP ${botsResp.status}: ${botsResp.statusText}`);
       }
 
-      const data = (await response.json()) as {
+      const botsData = (await botsResp.json()) as {
         bots: Array<{
           name: string;
           description?: string;
@@ -100,7 +120,7 @@ export class PeerManager {
       };
 
       // Filter out transitive bots (bots that already have a peerUrl — they came from another peer)
-      const directBots: PeerBotInfo[] = (data.bots || [])
+      const directBots: PeerBotInfo[] = (botsData.bots || [])
         .filter((b) => !b.peerUrl)
         .map((b) => ({
           name: b.name,
@@ -111,14 +131,42 @@ export class PeerManager {
           peerName: config.name,
         }));
 
+      // Parse peer skills
+      let peerSkills: PeerSkillInfo[] = [];
+      if (skillsResp?.ok) {
+        const skillsData = (await skillsResp.json()) as {
+          skills: Array<{
+            name: string;
+            description: string;
+            version: number;
+            author: string;
+            tags: string[];
+            peerUrl?: string;
+          }>;
+        };
+        // Filter out transitive skills
+        peerSkills = (skillsData.skills || [])
+          .filter((s) => !s.peerUrl)
+          .map((s) => ({
+            name: s.name,
+            description: s.description || '',
+            version: s.version || 1,
+            author: s.author || '',
+            tags: s.tags || [],
+            peerUrl: config.url,
+            peerName: config.name,
+          }));
+      }
+
       state.bots = directBots;
+      state.skills = peerSkills;
       state.healthy = true;
       state.lastChecked = Date.now();
       state.lastHealthy = Date.now();
       state.error = undefined;
 
       this.logger.debug(
-        { peerName: config.name, peerUrl: config.url, botCount: directBots.length },
+        { peerName: config.name, peerUrl: config.url, botCount: directBots.length, skillCount: peerSkills.length },
         'Peer refreshed',
       );
     } catch (err: any) {
@@ -126,6 +174,7 @@ export class PeerManager {
       state.lastChecked = Date.now();
       state.error = err.message || 'Unknown error';
       state.bots = [];
+      state.skills = [];
 
       this.logger.warn(
         { peerName: config.name, peerUrl: config.url, err: err.message },
@@ -187,6 +236,46 @@ export class PeerManager {
     });
 
     return (await response.json()) as object;
+  }
+
+  /** Return all cached skills from healthy peers. */
+  getPeerSkills(): PeerSkillInfo[] {
+    const allSkills: PeerSkillInfo[] = [];
+    for (const state of this.peers.values()) {
+      if (state.healthy) {
+        allSkills.push(...state.skills);
+      }
+    }
+    return allSkills;
+  }
+
+  /** Fetch a full skill record from a peer by peer name. */
+  async fetchPeerSkill(peerName: string, skillName: string): Promise<{ skillMd: string; referencesTar?: Buffer } | null> {
+    const state = this.peers.get(peerName);
+    if (!state || !state.healthy) return null;
+
+    const { config } = state;
+    const headers: Record<string, string> = {
+      'X-MetaBot-Origin': 'peer',
+    };
+    if (config.secret) {
+      headers['Authorization'] = `Bearer ${config.secret}`;
+    }
+
+    try {
+      const response = await proxyFetch(`${config.url}/api/skills/${encodeURIComponent(skillName)}`, {
+        headers,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) return null;
+      const data = (await response.json()) as any;
+      return {
+        skillMd: data.skillMd || '',
+        referencesTar: data.referencesTar ? Buffer.from(data.referencesTar, 'base64') : undefined,
+      };
+    } catch {
+      return null;
+    }
   }
 
   /** Return health status of all configured peers. */

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -6,5 +6,6 @@ export { handleBotRoutes } from './bot-routes.js';
 export { handleSyncRoutes } from './sync-routes.js';
 export { handleRtcRoutes } from './rtc-routes.js';
 export { handleSessionRoutes } from './session-routes.js';
+export { handleSkillHubRoutes } from './skill-hub-routes.js';
 export { jsonResponse, readBody, parseJsonBody } from './helpers.js';
 export type { RouteContext, RouteHandler } from './types.js';

--- a/src/api/routes/skill-hub-routes.ts
+++ b/src/api/routes/skill-hub-routes.ts
@@ -1,0 +1,214 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type * as http from 'node:http';
+import { jsonResponse, parseJsonBody } from './helpers.js';
+import type { RouteContext } from './types.js';
+import { installSkillFromHub } from '../skills-installer.js';
+
+export async function handleSkillHubRoutes(
+  ctx: RouteContext,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  method: string,
+  url: string,
+): Promise<boolean> {
+  const { logger, registry, peerManager } = ctx;
+  const store = ctx.skillHubStore;
+
+  if (!url.startsWith('/api/skills')) return false;
+
+  // GET /api/skills/search?q=...
+  if (method === 'GET' && url.startsWith('/api/skills/search')) {
+    if (!store) { jsonResponse(res, 503, { error: 'Skill Hub not available' }); return true; }
+    const params = new URL(url, 'http://localhost').searchParams;
+    const query = params.get('q') || '';
+    const localResults = store.search(query);
+    // Include peer skills if not a peer request
+    const isPeer = req.headers['x-metabot-origin'] === 'peer';
+    if (!isPeer && peerManager) {
+      const peerSkills = peerManager.getPeerSkills?.() ?? [];
+      const filtered = query
+        ? peerSkills.filter((s) => {
+            const q = query.toLowerCase();
+            return s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q) || s.tags.some((t) => t.toLowerCase().includes(q));
+          })
+        : peerSkills;
+      jsonResponse(res, 200, { skills: [...localResults, ...filtered.map((s) => ({ ...s, snippet: '' }))] });
+    } else {
+      jsonResponse(res, 200, { skills: localResults });
+    }
+    return true;
+  }
+
+  // POST /api/skills/:name/publish-from-bot — publish from a bot's working directory
+  if (method === 'POST' && /^\/api\/skills\/[^/]+\/publish-from-bot$/.test(url)) {
+    if (!store) { jsonResponse(res, 503, { error: 'Skill Hub not available' }); return true; }
+    const skillName = decodeURIComponent(url.split('/')[3]);
+    const body = await parseJsonBody(req);
+    const botName = body.botName as string;
+    if (!botName) {
+      jsonResponse(res, 400, { error: 'Missing botName' });
+      return true;
+    }
+    const bot = registry.get(botName);
+    if (!bot) {
+      jsonResponse(res, 404, { error: `Bot not found: ${botName}` });
+      return true;
+    }
+
+    const skillDir = path.join(bot.config.claude.defaultWorkingDirectory, '.claude', 'skills', skillName);
+    const skillMdPath = path.join(skillDir, 'SKILL.md');
+    if (!fs.existsSync(skillMdPath)) {
+      jsonResponse(res, 404, { error: `Skill not found at ${skillMdPath}` });
+      return true;
+    }
+
+    const skillMd = fs.readFileSync(skillMdPath, 'utf-8');
+
+    // Pack references/ directory if it exists
+    let referencesTar: Buffer | undefined;
+    const refsDir = path.join(skillDir, 'references');
+    if (fs.existsSync(refsDir)) {
+      try {
+        const { execSync } = await import('node:child_process');
+        referencesTar = execSync(`tar cf - -C "${skillDir}" references`, { maxBuffer: 50 * 1024 * 1024 });
+      } catch (err: any) {
+        logger.warn({ err: err.message, skillName }, 'Failed to pack references directory');
+      }
+    }
+
+    const record = store.publish({ name: skillName, skillMd, referencesTar, author: botName });
+    jsonResponse(res, 201, { name: record.name, version: record.version, published: true });
+    return true;
+  }
+
+  // POST /api/skills/:name/install — install a skill to a bot
+  if (method === 'POST' && /^\/api\/skills\/[^/]+\/install$/.test(url)) {
+    if (!store) { jsonResponse(res, 503, { error: 'Skill Hub not available' }); return true; }
+    const skillName = decodeURIComponent(url.split('/')[3]);
+    const body = await parseJsonBody(req);
+    const botName = body.botName as string;
+    if (!botName) {
+      jsonResponse(res, 400, { error: 'Missing botName' });
+      return true;
+    }
+    const bot = registry.get(botName);
+    if (!bot) {
+      jsonResponse(res, 404, { error: `Bot not found: ${botName}` });
+      return true;
+    }
+
+    const source = (body.source as string) || 'local';
+
+    let skillMd: string;
+    let referencesTar: Buffer | undefined;
+
+    if (source.startsWith('peer:')) {
+      // Fetch from peer
+      const peerName = source.slice(5);
+      if (!peerManager?.fetchPeerSkill) {
+        jsonResponse(res, 400, { error: 'Peer manager not available' });
+        return true;
+      }
+      const peerSkill = await peerManager.fetchPeerSkill(peerName, skillName);
+      if (!peerSkill) {
+        jsonResponse(res, 404, { error: `Skill "${skillName}" not found on peer "${peerName}"` });
+        return true;
+      }
+      skillMd = peerSkill.skillMd;
+      referencesTar = peerSkill.referencesTar;
+    } else {
+      // Fetch from local store
+      const content = store.getContent(skillName);
+      if (!content) {
+        jsonResponse(res, 404, { error: `Skill not found: ${skillName}` });
+        return true;
+      }
+      skillMd = content.skillMd;
+      referencesTar = content.referencesTar;
+    }
+
+    const workDir = bot.config.claude.defaultWorkingDirectory;
+    installSkillFromHub(workDir, skillName, skillMd, referencesTar, logger);
+    jsonResponse(res, 200, { installed: true, botName, skillName });
+    return true;
+  }
+
+  // GET /api/skills/:name — get skill details
+  if (method === 'GET' && /^\/api\/skills\/[^/]+$/.test(url)) {
+    if (!store) { jsonResponse(res, 503, { error: 'Skill Hub not available' }); return true; }
+    const skillName = decodeURIComponent(url.split('/')[3]);
+    const record = store.get(skillName);
+    if (record) {
+      jsonResponse(res, 200, record);
+      return true;
+    }
+    // Try peers
+    if (peerManager?.fetchPeerSkill) {
+      // Search through peer skills to find which peer has it
+      const peerSkills = peerManager.getPeerSkills?.() ?? [];
+      const match = peerSkills.find((s) => s.name === skillName);
+      if (match) {
+        const full = await peerManager.fetchPeerSkill(match.peerName, skillName);
+        if (full) {
+          jsonResponse(res, 200, { ...full, peerName: match.peerName, peerUrl: match.peerUrl });
+          return true;
+        }
+      }
+    }
+    jsonResponse(res, 404, { error: `Skill not found: ${skillName}` });
+    return true;
+  }
+
+  // GET /api/skills — list all skills
+  if (method === 'GET' && (url === '/api/skills' || url.startsWith('/api/skills?'))) {
+    if (!store) { jsonResponse(res, 503, { error: 'Skill Hub not available' }); return true; }
+    const localSkills = store.list();
+    const isPeer = req.headers['x-metabot-origin'] === 'peer';
+    if (!isPeer && peerManager?.getPeerSkills) {
+      const peerSkills = peerManager.getPeerSkills();
+      jsonResponse(res, 200, { skills: [...localSkills, ...peerSkills] });
+    } else {
+      jsonResponse(res, 200, { skills: localSkills });
+    }
+    return true;
+  }
+
+  // POST /api/skills — publish a skill directly
+  if (method === 'POST' && url === '/api/skills') {
+    if (!store) { jsonResponse(res, 503, { error: 'Skill Hub not available' }); return true; }
+    const body = await parseJsonBody(req);
+    const skillMd = body.skillMd as string;
+    if (!skillMd) {
+      jsonResponse(res, 400, { error: 'Missing skillMd' });
+      return true;
+    }
+    const referencesTar = body.referencesTar
+      ? Buffer.from(body.referencesTar as string, 'base64')
+      : undefined;
+
+    const record = store.publish({
+      name: body.name as string || '',
+      skillMd,
+      referencesTar,
+      author: body.author as string,
+    });
+    jsonResponse(res, 201, { name: record.name, version: record.version, published: true });
+    return true;
+  }
+
+  // DELETE /api/skills/:name
+  if (method === 'DELETE' && /^\/api\/skills\/[^/]+$/.test(url)) {
+    if (!store) { jsonResponse(res, 503, { error: 'Skill Hub not available' }); return true; }
+    const skillName = decodeURIComponent(url.split('/')[3]);
+    const removed = store.remove(skillName);
+    if (removed) {
+      jsonResponse(res, 200, { name: skillName, removed: true });
+    } else {
+      jsonResponse(res, 404, { error: `Skill not found: ${skillName}` });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/src/api/routes/types.ts
+++ b/src/api/routes/types.ts
@@ -17,6 +17,7 @@ import type { RtcVoiceChatService } from '../rtc-voice-chat.js';
 import type { WebSocketHandle } from '../../web/ws-server.js';
 import type { SessionRegistry } from '../../session/session-registry.js';
 import type { ActivityStore } from '../activity-store.js';
+import type { SkillHubStore } from '../skill-hub-store.js';
 
 export interface RouteContext {
   registry: BotRegistry;
@@ -39,6 +40,7 @@ export interface RouteContext {
   ws: { handle?: WebSocketHandle };
   sessionRegistry?: SessionRegistry;
   activityStore?: ActivityStore;
+  skillHubStore?: SkillHubStore;
 }
 
 /**

--- a/src/api/skill-hub-store.ts
+++ b/src/api/skill-hub-store.ts
@@ -1,0 +1,286 @@
+/**
+ * Skill Hub Store: SQLite-backed registry for shared skills.
+ * Skills can be published, discovered, and installed across bot instances.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import Database from 'better-sqlite3';
+import type { Logger } from '../utils/logger.js';
+
+export interface SkillRecord {
+  id: string;
+  name: string;
+  description: string;
+  version: number;
+  author: string;
+  tags: string[];
+  userInvocable: boolean;
+  context?: string;
+  allowedTools?: string;
+  skillMd: string;
+  hasReferences: boolean;
+  publishedAt: string;
+  updatedAt: string;
+}
+
+export interface SkillSummary {
+  id: string;
+  name: string;
+  description: string;
+  version: number;
+  author: string;
+  tags: string[];
+  publishedAt: string;
+  updatedAt: string;
+}
+
+export interface SkillSearchResult extends SkillSummary {
+  snippet: string;
+}
+
+export interface SkillPublishInput {
+  name: string;
+  skillMd: string;
+  referencesTar?: Buffer;
+  author?: string;
+}
+
+/**
+ * Parse YAML-like frontmatter from SKILL.md content.
+ * Extracts key: value pairs between --- delimiters.
+ */
+function parseFrontmatter(content: string): Record<string, string> {
+  const meta: Record<string, string> = {};
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return meta;
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx > 0) {
+      const key = line.slice(0, idx).trim();
+      let value = line.slice(idx + 1).trim();
+      // Strip surrounding quotes
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      meta[key] = value;
+    }
+  }
+  return meta;
+}
+
+export class SkillHubStore {
+  private db: Database.Database;
+  private logger: Logger;
+
+  constructor(databaseDir: string, logger: Logger) {
+    this.logger = logger.child({ module: 'skill-hub' });
+    fs.mkdirSync(databaseDir, { recursive: true });
+    const dbPath = path.join(databaseDir, 'skill-hub.db');
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initSchema();
+    this.logger.info({ dbPath }, 'Skill Hub store initialized');
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS skills (
+        id              TEXT PRIMARY KEY,
+        name            TEXT NOT NULL UNIQUE,
+        description     TEXT NOT NULL DEFAULT '',
+        version         INTEGER NOT NULL DEFAULT 1,
+        author          TEXT NOT NULL DEFAULT '',
+        tags            TEXT NOT NULL DEFAULT '[]',
+        user_invocable  INTEGER NOT NULL DEFAULT 1,
+        context         TEXT,
+        allowed_tools   TEXT,
+        skill_md        TEXT NOT NULL,
+        references_tar  BLOB,
+        published_at    TEXT NOT NULL,
+        updated_at      TEXT NOT NULL
+      );
+    `);
+
+    // Create FTS5 virtual table if not exists
+    // Check if table already exists to avoid errors on restart
+    const ftsExists = this.db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='skills_fts'",
+    ).get();
+
+    if (!ftsExists) {
+      this.db.exec(`
+        CREATE VIRTUAL TABLE skills_fts USING fts5(
+          name, description, tags, skill_md,
+          content='skills',
+          content_rowid='rowid'
+        );
+
+        CREATE TRIGGER skills_ai AFTER INSERT ON skills BEGIN
+          INSERT INTO skills_fts(rowid, name, description, tags, skill_md)
+          VALUES (new.rowid, new.name, new.description, new.tags, new.skill_md);
+        END;
+
+        CREATE TRIGGER skills_au AFTER UPDATE ON skills BEGIN
+          INSERT INTO skills_fts(skills_fts, rowid, name, description, tags, skill_md)
+          VALUES ('delete', old.rowid, old.name, old.description, old.tags, old.skill_md);
+          INSERT INTO skills_fts(rowid, name, description, tags, skill_md)
+          VALUES (new.rowid, new.name, new.description, new.tags, new.skill_md);
+        END;
+
+        CREATE TRIGGER skills_ad AFTER DELETE ON skills BEGIN
+          INSERT INTO skills_fts(skills_fts, rowid, name, description, tags, skill_md)
+          VALUES ('delete', old.rowid, old.name, old.description, old.tags, old.skill_md);
+        END;
+      `);
+    }
+  }
+
+  /** Publish or update a skill. Returns the skill record. */
+  publish(input: SkillPublishInput): SkillRecord {
+    const meta = parseFrontmatter(input.skillMd);
+    const name = input.name || meta['name'] || 'unnamed-skill';
+    const description = meta['description'] || '';
+    const tags = meta['tags'] ? meta['tags'].split(',').map((t) => t.trim()) : [];
+    const userInvocable = meta['user-invocable'] !== 'false';
+    const context = meta['context'] || undefined;
+    const allowedTools = meta['allowed-tools'] || undefined;
+    const now = new Date().toISOString();
+
+    // Check if skill already exists (upsert)
+    const existing = this.db.prepare('SELECT id, version FROM skills WHERE name = ?').get(name) as
+      | { id: string; version: number }
+      | undefined;
+
+    if (existing) {
+      this.db.prepare(`
+        UPDATE skills SET
+          description = ?, version = ?, author = ?, tags = ?,
+          user_invocable = ?, context = ?, allowed_tools = ?,
+          skill_md = ?, references_tar = ?, updated_at = ?
+        WHERE name = ?
+      `).run(
+        description, existing.version + 1, input.author || '', JSON.stringify(tags),
+        userInvocable ? 1 : 0, context || null, allowedTools || null,
+        input.skillMd, input.referencesTar || null, now, name,
+      );
+
+      this.logger.info({ name, version: existing.version + 1 }, 'Skill updated');
+      return this.get(name)!;
+    }
+
+    const id = crypto.randomUUID();
+    this.db.prepare(`
+      INSERT INTO skills (id, name, description, version, author, tags,
+        user_invocable, context, allowed_tools, skill_md, references_tar,
+        published_at, updated_at)
+      VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id, name, description, input.author || '', JSON.stringify(tags),
+      userInvocable ? 1 : 0, context || null, allowedTools || null,
+      input.skillMd, input.referencesTar || null, now, now,
+    );
+
+    this.logger.info({ name, id }, 'Skill published');
+    return this.get(name)!;
+  }
+
+  /** Get a skill by name (full record including SKILL.md content). */
+  get(name: string): SkillRecord | undefined {
+    const row = this.db.prepare('SELECT * FROM skills WHERE name = ?').get(name) as any;
+    if (!row) return undefined;
+    return this.rowToRecord(row);
+  }
+
+  /** Get skill content for installation (SKILL.md + optional references tar). */
+  getContent(name: string): { skillMd: string; referencesTar?: Buffer } | undefined {
+    const row = this.db.prepare('SELECT skill_md, references_tar FROM skills WHERE name = ?').get(name) as any;
+    if (!row) return undefined;
+    return {
+      skillMd: row.skill_md,
+      referencesTar: row.references_tar || undefined,
+    };
+  }
+
+  /** List all skills (summary only, no SKILL.md content). */
+  list(): SkillSummary[] {
+    const rows = this.db.prepare(
+      'SELECT id, name, description, version, author, tags, published_at, updated_at FROM skills ORDER BY updated_at DESC',
+    ).all() as any[];
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      version: row.version,
+      author: row.author,
+      tags: JSON.parse(row.tags || '[]'),
+      publishedAt: row.published_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  /** Full-text search across skill name, description, tags, and content. */
+  search(query: string): SkillSearchResult[] {
+    const escaped = this.escapeFts5Query(query);
+    if (!escaped) return this.list().map((s) => ({ ...s, snippet: '' }));
+
+    const rows = this.db.prepare(`
+      SELECT s.id, s.name, s.description, s.version, s.author, s.tags,
+             s.published_at, s.updated_at,
+             snippet(skills_fts, 3, '<b>', '</b>', '...', 32) AS snippet
+      FROM skills_fts f
+      JOIN skills s ON s.rowid = f.rowid
+      WHERE skills_fts MATCH ?
+      ORDER BY rank
+    `).all(escaped) as any[];
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      version: row.version,
+      author: row.author,
+      tags: JSON.parse(row.tags || '[]'),
+      publishedAt: row.published_at,
+      updatedAt: row.updated_at,
+      snippet: row.snippet || '',
+    }));
+  }
+
+  /** Remove a skill by name. Returns true if removed. */
+  remove(name: string): boolean {
+    const result = this.db.prepare('DELETE FROM skills WHERE name = ?').run(name);
+    if (result.changes > 0) {
+      this.logger.info({ name }, 'Skill removed');
+      return true;
+    }
+    return false;
+  }
+
+  private rowToRecord(row: any): SkillRecord {
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      version: row.version,
+      author: row.author,
+      tags: JSON.parse(row.tags || '[]'),
+      userInvocable: row.user_invocable === 1,
+      context: row.context || undefined,
+      allowedTools: row.allowed_tools || undefined,
+      skillMd: row.skill_md,
+      hasReferences: !!row.references_tar,
+      publishedAt: row.published_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  /** Escape a user query for FTS5 — wrap each token in double-quotes. */
+  private escapeFts5Query(query: string): string {
+    return query
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((token) => `"${token.replace(/"/g, '')}"`)
+      .join(' ');
+  }
+}

--- a/src/api/skills-installer.ts
+++ b/src/api/skills-installer.ts
@@ -2,11 +2,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as url from 'node:url';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import type { Logger } from '../utils/logger.js';
 
 /** Skills installed for all platforms. */
-const COMMON_SKILLS = ['metaskill', 'metamemory', 'metabot', 'phone-call'];
+const COMMON_SKILLS = ['metaskill', 'metamemory', 'metabot', 'phone-call', 'skill-hub'];
 
 /** Lark CLI AI Agent skills — installed via `npx skills add larksuite/cli` and
  *  symlinked into ~/.claude/skills/ automatically. We copy them to the bot
@@ -101,6 +101,32 @@ function ensureLarkCliConfig(appId: string, appSecret: string, logger: Logger): 
   } catch (err: any) {
     logger.warn({ err: err.message }, 'Failed to configure lark-cli — you can run manually: lark-cli config init');
   }
+}
+
+/**
+ * Install a skill from the Skill Hub into a bot's working directory.
+ * Writes SKILL.md and optionally extracts references/ from a tar buffer.
+ */
+export function installSkillFromHub(
+  workDir: string,
+  skillName: string,
+  skillMd: string,
+  referencesTar: Buffer | undefined,
+  logger: Logger,
+): void {
+  const destDir = path.join(workDir, '.claude', 'skills', skillName);
+  fs.mkdirSync(destDir, { recursive: true });
+  fs.writeFileSync(path.join(destDir, 'SKILL.md'), skillMd, 'utf-8');
+
+  if (referencesTar && referencesTar.length > 0) {
+    try {
+      execSync(`tar xf - -C "${destDir}"`, { input: referencesTar, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30_000 });
+    } catch (err: any) {
+      logger.warn({ err: err.message, skillName }, 'Failed to extract references tar');
+    }
+  }
+
+  logger.info({ skillName, dest: destDir }, 'Skill installed from Hub');
 }
 
 /** Locate the lark-cli executable. */

--- a/src/skills/skill-hub/SKILL.md
+++ b/src/skills/skill-hub/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: skill-hub
+description: "Discover, search, and install shared skills from the Skill Hub registry. Use when the user wants to find available skills, share a skill with other bots, or install a skill from the hub."
+user-invocable: true
+context: fork
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: "[list|search|publish|install] [args]"
+---
+
+# Skill Hub — Shared Skill Registry
+
+Discover and install skills shared across MetaBot instances and bots.
+
+## Quick Commands (mb shortcut)
+
+The `mb` CLI handles auth automatically. **Always prefer `mb` over raw curl:**
+
+```bash
+# Browse available skills
+mb skills                              # List all skills (local + peer)
+mb skills search <query>               # Search by keyword
+
+# Get skill details
+mb skills get <name>                   # View full skill info and SKILL.md content
+
+# Install a skill to a bot
+mb skills install <skillName> <botName>       # Install from local hub
+mb skills install <skillName> <botName> peer:<peerName>  # Install from peer
+
+# Publish a skill (share with others)
+mb skills publish <botName> <skillName>  # Publish a bot's skill to the hub
+
+# Remove a skill from the hub
+mb skills remove <name>                # Unpublish
+```
+
+## When to Use
+- User asks "what skills are available?"
+- User wants to install a skill to a bot
+- User wants to share/publish a skill for others to use
+- User asks to find skills for a specific purpose (e.g., "is there a skill for spreadsheets?")
+- Cross-bot skill sharing: one bot has a useful skill that another bot needs
+
+## Workflow Examples
+
+### Finding and installing a skill
+```bash
+mb skills search "calendar"             # Find calendar-related skills
+mb skills get lark-calendar             # See details
+mb skills install lark-calendar mybot   # Install to mybot
+```
+
+### Publishing a bot's skill
+```bash
+mb skills publish whis data-analysis    # Share whis's data-analysis skill
+mb skills                               # Verify it's listed
+```
+
+### Installing from a peer instance
+```bash
+mb skills                               # See all skills including peer skills
+mb skills install data-viz mybot peer:alice  # Install from peer "alice"
+```
+
+## Guidelines
+- Before publishing, ensure the skill is well-documented with clear SKILL.md
+- Use descriptive names and tags for discoverability
+- Search before creating to avoid duplicates
+- Published skills are available to all bots on all connected instances

--- a/tests/peer-manager.test.ts
+++ b/tests/peer-manager.test.ts
@@ -147,20 +147,15 @@ describe('PeerManager', () => {
   });
 
   it('findBotOnPeer returns bot from specific peer', async () => {
-    const fetchMock = vi.fn();
-    // First peer: alice
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({
-        bots: [{ name: 'bot-a', platform: 'feishu', workingDirectory: '/a' }],
-      }),
-    });
-    // Second peer: bob
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({
-        bots: [{ name: 'bot-b', platform: 'telegram', workingDirectory: '/b' }],
-      }),
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('9200/api/bots')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ bots: [{ name: 'bot-a', platform: 'feishu', workingDirectory: '/a' }] }) });
+      }
+      if (url.includes('9300/api/bots')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ bots: [{ name: 'bot-b', platform: 'telegram', workingDirectory: '/b' }] }) });
+      }
+      // skills endpoints
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ skills: [] }) });
     });
 
     vi.stubGlobal('fetch', fetchMock);
@@ -223,7 +218,7 @@ describe('PeerManager', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'http://remote:9100/api/bots',
       expect.objectContaining({
-        headers: { 'Authorization': 'Bearer my-secret' },
+        headers: expect.objectContaining({ 'Authorization': 'Bearer my-secret', 'X-MetaBot-Origin': 'peer' }),
       }),
     );
   });
@@ -244,7 +239,7 @@ describe('PeerManager', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:9200/api/bots',
       expect.objectContaining({
-        headers: {},
+        headers: expect.objectContaining({ 'X-MetaBot-Origin': 'peer' }),
       }),
     );
   });

--- a/tests/skill-hub-store.test.ts
+++ b/tests/skill-hub-store.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SkillHubStore } from '../src/api/skill-hub-store.js';
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(), child: () => createLogger() } as any;
+}
+
+const SAMPLE_SKILL = `---
+name: test-skill
+description: "A test skill for unit testing"
+tags: test, demo
+user-invocable: true
+context: fork
+allowed-tools: Read, Bash
+---
+
+# Test Skill
+
+This is a test skill.
+`;
+
+describe('SkillHubStore', () => {
+  let store: SkillHubStore;
+  let tmpDir: string;
+
+  function createStore() {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-hub-test-'));
+    store = new SkillHubStore(tmpDir, createLogger());
+    return store;
+  }
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes and retrieves a skill', () => {
+    createStore();
+    const record = store.publish({ name: 'test-skill', skillMd: SAMPLE_SKILL, author: 'test-bot' });
+    expect(record.name).toBe('test-skill');
+    expect(record.description).toBe('A test skill for unit testing');
+    expect(record.version).toBe(1);
+    expect(record.author).toBe('test-bot');
+    expect(record.tags).toEqual(['test', 'demo']);
+
+    const retrieved = store.get('test-skill');
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.skillMd).toBe(SAMPLE_SKILL);
+  });
+
+  it('bumps version on re-publish', () => {
+    createStore();
+    store.publish({ name: 'test-skill', skillMd: SAMPLE_SKILL, author: 'bot-a' });
+    const v2 = store.publish({ name: 'test-skill', skillMd: SAMPLE_SKILL, author: 'bot-b' });
+    expect(v2.version).toBe(2);
+    expect(v2.author).toBe('bot-b');
+  });
+
+  it('lists all skills', () => {
+    createStore();
+    store.publish({ name: 'skill-a', skillMd: '---\nname: skill-a\n---\nA', author: 'bot' });
+    store.publish({ name: 'skill-b', skillMd: '---\nname: skill-b\n---\nB', author: 'bot' });
+    const list = store.list();
+    expect(list).toHaveLength(2);
+    expect(list.map((s) => s.name).sort()).toEqual(['skill-a', 'skill-b']);
+  });
+
+  it('searches skills by keyword', () => {
+    createStore();
+    store.publish({ name: 'calendar-tool', skillMd: '---\nname: calendar-tool\ndescription: Manage calendars\n---\n# Calendar', author: 'bot' });
+    store.publish({ name: 'data-viz', skillMd: '---\nname: data-viz\ndescription: Data visualization\n---\n# Charts', author: 'bot' });
+    const results = store.search('calendar');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].name).toBe('calendar-tool');
+  });
+
+  it('removes a skill', () => {
+    createStore();
+    store.publish({ name: 'to-remove', skillMd: '---\nname: to-remove\n---\nX', author: 'bot' });
+    expect(store.get('to-remove')).toBeDefined();
+    const removed = store.remove('to-remove');
+    expect(removed).toBe(true);
+    expect(store.get('to-remove')).toBeUndefined();
+  });
+
+  it('returns false when removing non-existent skill', () => {
+    createStore();
+    expect(store.remove('nonexistent')).toBe(false);
+  });
+
+  it('handles skill without frontmatter', () => {
+    createStore();
+    const record = store.publish({ name: 'bare-skill', skillMd: '# Just markdown\nNo frontmatter here.', author: 'test' });
+    expect(record.name).toBe('bare-skill');
+    expect(record.description).toBe('');
+    expect(record.tags).toEqual([]);
+  });
+
+  it('getContent returns skillMd and referencesTar', () => {
+    createStore();
+    const tar = Buffer.from('fake-tar-data');
+    store.publish({ name: 'with-refs', skillMd: '---\nname: with-refs\n---\n# Refs', referencesTar: tar, author: 'bot' });
+    const content = store.getContent('with-refs');
+    expect(content).toBeDefined();
+    expect(content!.skillMd).toContain('with-refs');
+    expect(content!.referencesTar).toEqual(tar);
+  });
+});


### PR DESCRIPTION
## Summary
- New **Skill Hub** feature: a shared skill registry for cross-bot/cross-instance skill sharing
- SQLite storage with FTS5 full-text search for skill discovery
- REST API: `GET/POST/DELETE /api/skills`, search, publish-from-bot, install
- Cross-instance discovery via PeerManager (polls peer skills every 30s alongside bots)
- CLI: `mb skills [list|search|get|publish|install|remove]`
- Bot skill: `/skill-hub` for autonomous skill discovery and installation
- `installSkillFromHub()` writes SKILL.md + extracts references tar to bot working directory

## New files
| File | Purpose |
|------|---------|
| `src/api/skill-hub-store.ts` | SQLite store with CRUD + FTS5 |
| `src/api/routes/skill-hub-routes.ts` | REST API endpoints |
| `src/skills/skill-hub/SKILL.md` | Bot-facing skill |
| `tests/skill-hub-store.test.ts` | 8 unit tests |

## Test plan
- [x] All 183 tests pass (including 8 new skill-hub-store tests)
- [x] Build succeeds
- [x] Lint clean (no new warnings)
- [ ] Manual: `mb skills list` returns empty registry
- [ ] Manual: `mb skills publish <bot> <skill>` publishes successfully
- [ ] Manual: `mb skills install <skill> <bot>` installs to bot's .claude/skills/

🤖 Generated with [Claude Code](https://claude.com/claude-code)