### PR TITLE
fix: add skill-hub and voice to install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -513,6 +513,18 @@ New-Item -ItemType Directory -Path (Join-Path $SkillsDir "metabot") -Force | Out
 Copy-Item (Join-Path $MetabotHome "src\skills\metabot\SKILL.md") (Join-Path $SkillsDir "metabot\SKILL.md") -Force
 Write-Success "metabot skill installed -> $(Join-Path $SkillsDir 'metabot')"
 
+# Install voice skill
+Write-Info "Installing voice skill..."
+New-Item -ItemType Directory -Path (Join-Path $SkillsDir "voice") -Force | Out-Null
+Copy-Item (Join-Path $MetabotHome "src\skills\voice\SKILL.md") (Join-Path $SkillsDir "voice\SKILL.md") -Force
+Write-Success "voice skill installed -> $(Join-Path $SkillsDir 'voice')"
+
+# Install skill-hub skill
+Write-Info "Installing skill-hub skill..."
+New-Item -ItemType Directory -Path (Join-Path $SkillsDir "skill-hub") -Force | Out-Null
+Copy-Item (Join-Path $MetabotHome "src\skills\skill-hub\SKILL.md") (Join-Path $SkillsDir "skill-hub\SKILL.md") -Force
+Write-Success "skill-hub skill installed -> $(Join-Path $SkillsDir 'skill-hub')"
+
 # Install feishu-doc skill (only when Feishu is configured)
 $HasFeishu = $false
 if (-not $SkipConfig -and $SetupFeishu) {
@@ -549,7 +561,7 @@ if (-not $SkipConfig) {
 if ($DeployWorkDir) {
     $SkillsDest = Join-Path $DeployWorkDir ".claude\skills"
 
-    $deploySkills = @("metaskill", "metamemory", "metabot")
+    $deploySkills = @("metaskill", "metamemory", "metabot", "voice", "skill-hub")
     if ($HasFeishu) { $deploySkills += "feishu-doc" }
 
     foreach ($skill in $deploySkills) {

--- a/install.sh
+++ b/install.sh
@@ -592,6 +592,12 @@ mkdir -p "$SKILLS_DIR/voice"
 cp "$METABOT_HOME/src/skills/voice/SKILL.md" "$SKILLS_DIR/voice/SKILL.md"
 success "voice skill installed → $SKILLS_DIR/voice"
 
+# Install skill-hub skill (bundled in src/skills/skill-hub/)
+info "Installing skill-hub skill..."
+mkdir -p "$SKILLS_DIR/skill-hub"
+cp "$METABOT_HOME/src/skills/skill-hub/SKILL.md" "$SKILLS_DIR/skill-hub/SKILL.md"
+success "skill-hub skill installed → $SKILLS_DIR/skill-hub"
+
 # Detect Feishu bots
 HAS_FEISHU=false
 if [[ "$SKIP_CONFIG" == "false" && "$SETUP_FEISHU" == "true" ]]; then
@@ -682,7 +688,7 @@ if [[ -n "${DEPLOY_WORK_DIR:-}" ]]; then
   SKILLS_DEST="$DEPLOY_WORK_DIR/.claude/skills"
 
   # Copy skills (common + lark-cli skills if Feishu)
-  DEPLOY_SKILLS="metaskill metamemory metabot voice"
+  DEPLOY_SKILLS="metaskill metamemory metabot voice skill-hub"
   if [[ "$SETUP_LARK_CLI" == "true" ]]; then
     for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
       [[ -d "$SKILLS_DIR/$lark_skill" ]] && DEPLOY_SKILLS="$DEPLOY_SKILLS $lark_skill"


### PR DESCRIPTION
## Summary
- Add `skill-hub` skill installation to `install.sh` (Phase 6) and deploy list
- Add `voice` and `skill-hub` skill installation to `install.ps1` and deploy list
- Previously these skills were missing from install, so new installations wouldn't get them

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 183 tests pass
- [x] Verified install.sh has skill-hub in both install and deploy sections
- [x] Verified install.ps1 has voice + skill-hub in both install and deploy sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)