### PR TITLE
feat: show cumulative session cost on Feishu cards

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -1276,6 +1276,12 @@ export class MessageBridge {
    * sends a plain text fallback so the user at least sees the result.
    */
   private async sendFinalCard(messageId: string, state: CardState, chatId?: string): Promise<void> {
+    // Accumulate usage into session and inject cumulative cost for display
+    if (chatId && (state.status === 'complete' || state.status === 'error')) {
+      this.sessionManager.addUsage(chatId, state.totalTokens ?? 0, state.costUsd ?? 0, state.durationMs ?? 0);
+      const session = this.sessionManager.getSession(chatId);
+      state.sessionCostUsd = session.cumulativeCostUsd;
+    }
     for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
       try {
         await this.sender.updateCard(messageId, state);
@@ -1354,7 +1360,7 @@ export class MessageBridge {
     const durationStr = durationMs >= 60_000
       ? `${(durationMs / 60_000).toFixed(1)}min`
       : `${(durationMs / 1000).toFixed(0)}s`;
-    const costStr = state.costUsd ? ` · $${state.costUsd.toFixed(2)}` : '';
+    const costStr = state.sessionCostUsd ? ` · $${state.sessionCostUsd.toFixed(2)}` : (state.costUsd ? ` · $${state.costUsd.toFixed(2)}` : '');
     const statusWord = state.status === 'complete' ? 'Done' : 'Failed';
 
     // Model display name: strip "claude-" prefix for brevity (e.g. "opus-4-6")

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -92,6 +92,9 @@ export function buildCard(state: CardState): string {
       parts.push(`ctx: ${tokensK}/${ctxK} (${pct}%)`);
     }
     if (state.status === 'complete' || state.status === 'error') {
+      if (state.sessionCostUsd != null) {
+        parts.push(`$${state.sessionCostUsd.toFixed(2)}`);
+      }
       if (state.model) {
         parts.push(state.model.replace(/^claude-/, ''));
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface CardState {
   totalTokens?: number;
   /** Context window size of the primary model */
   contextWindow?: number;
+  /** Cumulative session cost (USD), accumulated across queries until /reset */
+  sessionCostUsd?: number;
 }
 
 export interface IncomingMessage {


### PR DESCRIPTION
## Summary
- Feishu cards now show the **cumulative session cost** (accumulated across all queries until `/reset`) instead of just the single-query cost
- Calls `sessionManager.addUsage()` (previously unused) in `sendFinalCard` to accumulate cost/tokens/duration
- Adds `sessionCostUsd` field to `CardState` for display
- Completion notice text also uses cumulative cost

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 183 tests pass
- [ ] Manual: send multiple messages in Feishu, verify cost accumulates; `/reset` resets it

🤖 Generated with [Claude Code](https://claude.com/claude-code)