### PR TITLE
refactor(install): unify install/update paths on install.sh

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -317,121 +317,19 @@ print(json.dumps({'botName': sys.argv[1], 'source': sys.argv[2]}))
   health|h)
     curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/health" | _json
     ;;
-  # --- Update from GitHub ---
+  # --- Update from GitHub (delegates to install.sh for single source of truth) ---
   update|up)
     METABOT_SRC="${METABOT_HOME:-$HOME/metabot}"
-    LOCAL_BIN="$HOME/.local/bin"
     if [[ ! -d "$METABOT_SRC/.git" ]]; then
       echo "Error: MetaBot repo not found at $METABOT_SRC"
       exit 1
     fi
-
-    echo "==> Pulling latest from GitHub..."
-    git -C "$METABOT_SRC" pull --ff-only || { echo "Error: git pull failed (try resolving conflicts manually)"; exit 1; }
-
-    echo "==> Installing dependencies..."
-    (cd "$METABOT_SRC" && npm install --include=dev --no-audit --no-fund 2>&1 | tail -1)
-
-    echo "==> Building..."
-    (cd "$METABOT_SRC" && npm run build 2>&1) || { echo "Error: build failed"; exit 1; }
-
-    echo "==> Updating CLI tools..."
-    mkdir -p "$LOCAL_BIN"
-    for cli in mb mm metabot; do
-      src="$METABOT_SRC/bin/$cli"
-      dst="$LOCAL_BIN/$cli"
-      if [[ -f "$src" ]]; then
-        if ! cmp -s "$src" "$dst" 2>/dev/null; then
-          cp "$src" "$dst"
-          chmod +x "$dst"
-          echo "    Updated: $cli"
-        fi
-      fi
-    done
-
-    echo "==> Updating skills..."
-    SKILLS_DIR="$HOME/.claude/skills"
-    mkdir -p "$SKILLS_DIR"
-    for skill in metaskill metamemory metabot voice phone-call skill-hub; do
-      case "$skill" in
-        metaskill)   src="$METABOT_SRC/src/skills/metaskill" ;;
-        metamemory)  src="$METABOT_SRC/src/memory/skill" ;;
-        metabot)     src="$METABOT_SRC/src/skills/metabot" ;;
-        voice)       src="$METABOT_SRC/src/skills/voice" ;;
-        phone-call)  src="$METABOT_SRC/src/skills/phone-call" ;;
-        skill-hub)   src="$METABOT_SRC/src/skills/skill-hub" ;;
-        *)           src="" ;;
-      esac
-      if [[ -n "$src" && -d "$src" ]]; then
-        mkdir -p "$SKILLS_DIR/$skill"
-        cp -r "$src/." "$SKILLS_DIR/$skill/"
-        echo "    Updated: $skill"
-      fi
-    done
-    # Clean up legacy feishu-doc skill
-    if [[ -d "$SKILLS_DIR/feishu-doc" ]]; then
-      rm -rf "$SKILLS_DIR/feishu-doc"
-      echo "    Removed legacy: feishu-doc"
+    if [[ ! -f "$METABOT_SRC/install.sh" ]]; then
+      echo "Error: install.sh not found at $METABOT_SRC/install.sh"
+      exit 1
     fi
-
-    # Check if lark-cli skills were previously installed (opt-in via install.sh)
-    has_lark_skills=false
-    if [[ -d "$SKILLS_DIR/lark-doc" ]]; then
-      has_lark_skills=true
-    fi
-
-    # Update workspace skills if bots.json exists
-    if [[ -f "$METABOT_SRC/bots.json" ]] && command -v node &>/dev/null; then
-      work_dir=$(node -e "
-        const c=JSON.parse(require('fs').readFileSync('$METABOT_SRC/bots.json','utf-8'));
-        const b=[...(c.feishuBots||[]),...(c.telegramBots||[]),...(c.wechatBots||[])];
-        if(b[0])console.log(b[0].defaultWorkingDirectory);
-      " 2>/dev/null || true)
-      if [[ -n "${work_dir:-}" ]]; then
-        ws_skills_dir="$work_dir/.claude/skills"
-        mkdir -p "$ws_skills_dir"
-        for skill in metaskill metamemory metabot voice phone-call skill-hub; do
-          if [[ -d "$SKILLS_DIR/$skill" ]]; then
-            mkdir -p "$ws_skills_dir/$skill"
-            cp -r "$SKILLS_DIR/$skill/." "$ws_skills_dir/$skill/"
-          fi
-        done
-        # Copy lark-cli skills if previously installed
-        if [[ "${has_lark_skills:-false}" == "true" ]]; then
-          for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
-            if [[ -d "$SKILLS_DIR/$lark_skill" ]]; then
-              mkdir -p "$ws_skills_dir/$lark_skill"
-              cp -r "$SKILLS_DIR/$lark_skill/." "$ws_skills_dir/$lark_skill/"
-            fi
-          done
-        fi
-        # Clean up legacy feishu-doc in workspace
-        if [[ -d "$ws_skills_dir/feishu-doc" ]]; then
-          rm -rf "$ws_skills_dir/feishu-doc"
-        fi
-        if [[ -f "$METABOT_SRC/src/workspace/CLAUDE.md" ]]; then
-          cp "$METABOT_SRC/src/workspace/CLAUDE.md" "$work_dir/CLAUDE.md"
-        fi
-      fi
-    fi
-
-    echo "==> Restarting service..."
-    if command -v pm2 &>/dev/null && pm2 list 2>/dev/null | grep -q metabot; then
-      pm2 restart metabot && echo "    Restarted via pm2"
-    elif pgrep -f "tsx src/index" &>/dev/null; then
-      pkill -f "tsx src/index"
-      (cd "$METABOT_SRC" && nohup npm run dev > /tmp/metabot.log 2>&1 &)
-      echo "    Restarted dev server (PID $!)"
-    elif pgrep -f "node dist/index" &>/dev/null; then
-      pkill -f "node dist/index"
-      (cd "$METABOT_SRC" && nohup npm start > /tmp/metabot.log 2>&1 &)
-      echo "    Restarted production server (PID $!)"
-    else
-      echo "    No running MetaBot process found. Start manually:"
-      echo "    cd $METABOT_SRC && npm run dev"
-    fi
-
-    echo "==> Update complete!"
+    echo "==> Delegating to $METABOT_SRC/install.sh..."
+    exec bash "$METABOT_SRC/install.sh"
     ;;
   # --- Text-to-Speech ---
   voice|v)

--- a/bin/metabot
+++ b/bin/metabot
@@ -23,122 +23,16 @@ cmd_update() {
     exit 1
   fi
 
-  # Always re-exec from the repo copy before doing anything.
-  # This prevents the running script (e.g. ~/.local/bin/metabot) from being
-  # overwritten mid-execution when we copy CLI tools later.
-  if [[ -z "${METABOT_REEXEC:-}" ]] && [[ -f "$METABOT_HOME/bin/metabot" ]]; then
-    export METABOT_REEXEC=1
-    exec "$METABOT_HOME/bin/metabot" update
+  if [[ ! -f "$METABOT_HOME/install.sh" ]]; then
+    error "install.sh not found at $METABOT_HOME/install.sh"
+    exit 1
   fi
 
-  info "Pulling latest code..."
-  cd "$METABOT_HOME"
-  local old_head
-  old_head="$(git rev-parse HEAD)"
-  git pull --ff-only || { error "git pull failed"; exit 1; }
-
-  # Re-exec if git pull updated this script (the repo copy we're running from)
-  if ! git diff --quiet "$old_head" HEAD -- bin/metabot 2>/dev/null; then
-    info "metabot CLI updated, re-launching with new version..."
-    exec "$METABOT_HOME/bin/metabot" update
-  fi
-
-  info "Installing dependencies..."
-  npm install --production=false
-
-  info "Building..."
-  npm run build
-
-  # Update CLI tools in ~/.local/bin
-  LOCAL_BIN="$HOME/.local/bin"
-  if [[ -d "$LOCAL_BIN" ]]; then
-    info "Updating CLI tools..."
-    for cli in mb mm metabot; do
-      if [[ -f "$METABOT_HOME/bin/$cli" ]]; then
-        cp "$METABOT_HOME/bin/$cli" "$LOCAL_BIN/$cli"
-        chmod +x "$LOCAL_BIN/$cli"
-      fi
-    done
-    success "CLI tools updated"
-  fi
-
-  # Update skills in ~/.claude/skills
-  SKILLS_DIR="$HOME/.claude/skills"
-  mkdir -p "$SKILLS_DIR"
-  info "Updating skills..."
-  local src=""
-  for skill in metaskill metamemory metabot voice skill-hub; do
-    case "$skill" in
-      metaskill)  src="$METABOT_HOME/src/skills/metaskill" ;;
-      metamemory) src="$METABOT_HOME/src/memory/skill" ;;
-      metabot)    src="$METABOT_HOME/src/skills/metabot" ;;
-      voice)      src="$METABOT_HOME/src/skills/voice" ;;
-      skill-hub)  src="$METABOT_HOME/src/skills/skill-hub" ;;
-      *)          src="" ;;
-    esac
-    if [[ -n "$src" && -d "$src" ]]; then
-      mkdir -p "$SKILLS_DIR/$skill"
-      cp -r "$src/." "$SKILLS_DIR/$skill/"
-    fi
-  done
-  # Clean up legacy feishu-doc skill
-  if [[ -d "$SKILLS_DIR/feishu-doc" ]]; then
-    rm -rf "$SKILLS_DIR/feishu-doc"
-    info "Removed legacy feishu-doc skill"
-  fi
-
-  # Update lark-cli skills only if previously installed (opt-in via install.sh)
-  local has_lark_skills=false
-  if [[ -d "$SKILLS_DIR/lark-doc" ]]; then
-    has_lark_skills=true
-  fi
-  success "Skills updated"
-
-  # Update workspace skills if bots.json exists
-  if [[ -f "$METABOT_HOME/bots.json" ]] && command -v node &>/dev/null; then
-    local work_dir
-    work_dir=$(node -e "
-      const c=JSON.parse(require('fs').readFileSync('$METABOT_HOME/bots.json','utf-8'));
-      const b=[...(c.feishuBots||[]),...(c.telegramBots||[]),...(c.wechatBots||[])];
-      if(b[0])console.log(b[0].defaultWorkingDirectory);
-    " 2>/dev/null || true)
-    if [[ -n "$work_dir" ]]; then
-      local ws_skills_dir="$work_dir/.claude/skills"
-      mkdir -p "$ws_skills_dir"
-
-      # Copy common skills
-      for skill in metaskill metamemory metabot voice skill-hub; do
-        if [[ -d "$SKILLS_DIR/$skill" ]]; then
-          mkdir -p "$ws_skills_dir/$skill"
-          cp -r "$SKILLS_DIR/$skill/." "$ws_skills_dir/$skill/"
-        fi
-      done
-      # Copy lark-cli skills if previously installed
-      if [[ "$has_lark_skills" == "true" ]]; then
-        for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
-          if [[ -d "$SKILLS_DIR/$lark_skill" ]]; then
-            mkdir -p "$ws_skills_dir/$lark_skill"
-            cp -r "$SKILLS_DIR/$lark_skill/." "$ws_skills_dir/$lark_skill/"
-          fi
-        done
-      fi
-      # Clean up legacy feishu-doc in workspace
-      if [[ -d "$ws_skills_dir/feishu-doc" ]]; then
-        rm -rf "$ws_skills_dir/feishu-doc"
-      fi
-      # Update CLAUDE.md
-      if [[ -f "$METABOT_HOME/src/workspace/CLAUDE.md" ]]; then
-        cp "$METABOT_HOME/src/workspace/CLAUDE.md" "$work_dir/CLAUDE.md"
-      fi
-      success "Workspace skills updated"
-    fi
-  fi
-
-  info "Restarting MetaBot..."
-  pm2 restart metabot 2>/dev/null || pm2 start ecosystem.config.cjs
-  pm2 save --force 2>/dev/null || true
-
-  success "MetaBot updated and restarted!"
+  # Re-exec via install.sh so update and fresh-install go through the same code path.
+  # install.sh Phase 2 handles the git pull (and re-execs itself if install.sh
+  # was updated); Phase 4 skips the interactive prompts when .env exists.
+  info "Delegating to $METABOT_HOME/install.sh (single source of truth)..."
+  exec bash "$METABOT_HOME/install.sh"
 }
 
 cmd_start()   { pm2 start "$METABOT_HOME/ecosystem.config.cjs"; pm2 save --force 2>/dev/null || true; }

--- a/install.sh
+++ b/install.sh
@@ -593,10 +593,12 @@ cp "$METABOT_HOME/src/skills/voice/SKILL.md" "$SKILLS_DIR/voice/SKILL.md"
 success "voice skill installed → $SKILLS_DIR/voice"
 
 # Install skill-hub skill (bundled in src/skills/skill-hub/)
-info "Installing skill-hub skill..."
-mkdir -p "$SKILLS_DIR/skill-hub"
-cp "$METABOT_HOME/src/skills/skill-hub/SKILL.md" "$SKILLS_DIR/skill-hub/SKILL.md"
-success "skill-hub skill installed → $SKILLS_DIR/skill-hub"
+if [[ -d "$METABOT_HOME/src/skills/skill-hub" ]]; then
+  info "Installing skill-hub skill..."
+  mkdir -p "$SKILLS_DIR/skill-hub"
+  cp -r "$METABOT_HOME/src/skills/skill-hub/." "$SKILLS_DIR/skill-hub/"
+  success "skill-hub skill installed → $SKILLS_DIR/skill-hub"
+fi
 
 # Detect Feishu bots
 HAS_FEISHU=false
@@ -609,13 +611,19 @@ elif [[ "$SKIP_CONFIG" == "true" && -f "$METABOT_HOME/bots.json" ]]; then
   fi
 fi
 
-# Install lark-cli and AI Agent skills — only when Feishu is configured
+# Install lark-cli and AI Agent skills — only when Feishu is configured.
+# On re-runs (update flow), skip the prompt when lark skills are already present.
 SETUP_LARK_CLI=false
 if [[ "$HAS_FEISHU" == "true" ]]; then
-  echo ""
-  info "lark-cli provides 19 AI Agent skills for Feishu (docs, sheets, calendar, IM, etc.)"
-  if prompt_yn "Install lark-cli and Feishu AI Agent skills?" "y"; then
+  if [[ -d "$SKILLS_DIR/lark-doc" ]]; then
+    info "lark-cli skills already installed — refreshing"
     SETUP_LARK_CLI=true
+  else
+    echo ""
+    info "lark-cli provides 19 AI Agent skills for Feishu (docs, sheets, calendar, IM, etc.)"
+    if prompt_yn "Install lark-cli and Feishu AI Agent skills?" "y"; then
+      SETUP_LARK_CLI=true
+    fi
   fi
 fi
 
@@ -748,169 +756,18 @@ fi
 METAMEMORY_INSTALLED=true
 success "MetaMemory will start automatically with MetaBot on port 8100"
 
-# Install mm() shell shortcut for MetaMemory CLI
+# Clean up legacy inline mm()/mb() bash functions from ~/.bash_aliases.
+# These were superseded by the standalone executables at ~/.local/bin/{mm,mb},
+# but a shell function shadows a PATH executable, so leaving the legacy blocks
+# in place masks new subcommands (e.g. `mb skills`). Authoritative CLIs live in
+# bin/{mm,mb,metabot} and are copied to ~/.local/bin below.
 BASH_ALIASES="$HOME/.bash_aliases"
-if ! grep -q 'mm()' "$BASH_ALIASES" 2>/dev/null; then
-  info "Installing mm() shell shortcut..."
-  cat >> "$BASH_ALIASES" << 'MMEOF'
-
-# MetaMemory shortcuts (installed by MetaBot)
-export MEMORY_URL="http://localhost:8100"
-export MEMORY_AUTH="Authorization: Bearer ${MEMORY_ADMIN_TOKEN:-${MEMORY_TOKEN:-${MEMORY_SECRET:-${API_SECRET:-changeme}}}}"
-
-mm() {
-  local cmd="${1:-help}"
-  shift 2>/dev/null
-  case "$cmd" in
-    search|s)
-      curl -s -H "$MEMORY_AUTH" "$MEMORY_URL/api/search?q=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$*'))")"
-      ;;
-    get|g)
-      curl -s -H "$MEMORY_AUTH" "$MEMORY_URL/api/documents/$1"
-      ;;
-    list|ls)
-      curl -s -H "$MEMORY_AUTH" "$MEMORY_URL/api/documents?folder_id=${1:-root}&limit=50"
-      ;;
-    folders|f)
-      curl -s -H "$MEMORY_AUTH" "$MEMORY_URL/api/folders"
-      ;;
-    create|c)
-      local title="$1"; shift
-      local content="$*"
-      curl -s -X POST "$MEMORY_URL/api/documents" \
-        -H "$MEMORY_AUTH" -H "Content-Type: application/json" \
-        -d "{\"title\":\"$title\",\"folder_id\":\"root\",\"content\":\"$content\"}"
-      ;;
-    health|h)
-      curl -s -H "$MEMORY_AUTH" "$MEMORY_URL/api/health"
-      ;;
-    *)
-      echo "mm - MetaMemory CLI"
-      echo "  mm search <query>       - Search documents"
-      echo "  mm get <doc_id>         - Get document by ID"
-      echo "  mm list [folder_id]     - List documents (default: root)"
-      echo "  mm folders              - List folder tree"
-      echo "  mm create <title> <md>  - Create a document"
-      echo "  mm health               - Health check"
-      ;;
-  esac
-}
-MMEOF
-  # Patch the actual API_SECRET into the file
-  if [[ -n "${API_SECRET:-}" ]]; then
-    sed_i "s|\${API_SECRET:-changeme}|${API_SECRET}|g" "$BASH_ALIASES"
-  fi
-  success "mm() shortcut installed"
-else
-  info "mm() shortcut already exists, skipping"
+if [[ -f "$BASH_ALIASES" ]] && grep -qE '^# (MetaMemory|MetaBot API) shortcuts \(installed by MetaBot\)$' "$BASH_ALIASES" 2>/dev/null; then
+  info "Removing legacy inline mm()/mb() functions from $BASH_ALIASES..."
+  sed_i -e '/^# MetaMemory shortcuts (installed by MetaBot)$/,/^}$/d' \
+        -e '/^# MetaBot API shortcuts (installed by MetaBot)$/,/^}$/d' "$BASH_ALIASES"
+  success "Legacy inline shortcuts removed (CLI lives at ~/.local/bin/{mm,mb})"
 fi
-
-# Install mb() shell shortcut for MetaBot API (Agent Bus, Scheduling, Bot Management)
-if ! grep -q 'mb()' "$BASH_ALIASES" 2>/dev/null; then
-  info "Installing mb() shell shortcut..."
-  cat >> "$BASH_ALIASES" << 'MBEOF'
-
-# MetaBot API shortcuts (installed by MetaBot)
-export METABOT_URL="http://localhost:${METABOT_API_PORT:-9100}"
-export METABOT_AUTH="Authorization: Bearer ${METABOT_API_SECRET:-changeme}"
-
-mb() {
-  local cmd="${1:-help}"
-  shift 2>/dev/null
-  case "$cmd" in
-    # --- Bot management ---
-    bots|b)
-      curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/bots" | python3 -m json.tool 2>/dev/null || curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/bots"
-      ;;
-    bot)
-      curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/bots/$1" | python3 -m json.tool 2>/dev/null || curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/bots/$1"
-      ;;
-    # --- Task delegation ---
-    task|t)
-      local bot="$1" chat="$2"; shift 2 2>/dev/null
-      local prompt="$*"
-      if [[ -z "$bot" || -z "$chat" || -z "$prompt" ]]; then
-        echo "Usage: mb task <botName> <chatId> <prompt>"
-        return 1
-      fi
-      curl -s -X POST "$METABOT_URL/api/tasks" \
-        -H "$METABOT_AUTH" -H "Content-Type: application/json" \
-        -d "{\"botName\":\"$bot\",\"chatId\":\"$chat\",\"prompt\":\"$prompt\",\"sendCards\":true}"
-      ;;
-    # --- Scheduling ---
-    schedule|sched|sc)
-      local subcmd="${1:-list}"; shift 2>/dev/null
-      case "$subcmd" in
-        list|ls)
-          curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/schedule" | python3 -m json.tool 2>/dev/null || curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/schedule"
-          ;;
-        add|a)
-          local bot="$1" chat="$2" delay="$3"; shift 3 2>/dev/null
-          local prompt="$*"
-          if [[ -z "$bot" || -z "$chat" || -z "$delay" || -z "$prompt" ]]; then
-            echo "Usage: mb schedule add <botName> <chatId> <delaySeconds> <prompt>"
-            return 1
-          fi
-          curl -s -X POST "$METABOT_URL/api/schedule" \
-            -H "$METABOT_AUTH" -H "Content-Type: application/json" \
-            -d "{\"botName\":\"$bot\",\"chatId\":\"$chat\",\"delaySeconds\":$delay,\"prompt\":\"$prompt\"}"
-          ;;
-        cancel|rm)
-          if [[ -z "$1" ]]; then echo "Usage: mb schedule cancel <id>"; return 1; fi
-          curl -s -X DELETE "$METABOT_URL/api/schedule/$1" -H "$METABOT_AUTH"
-          ;;
-        *)
-          echo "mb schedule - Task scheduling"
-          echo "  mb schedule list                                    - List pending tasks"
-          echo "  mb schedule add <bot> <chatId> <delaySec> <prompt>  - Schedule a task"
-          echo "  mb schedule cancel <id>                             - Cancel a task"
-          ;;
-      esac
-      ;;
-    # --- Health ---
-    health|h)
-      curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/health" | python3 -m json.tool 2>/dev/null || curl -s -H "$METABOT_AUTH" "$METABOT_URL/api/health"
-      ;;
-    # --- Help ---
-    *)
-      echo "mb - MetaBot API CLI"
-      echo ""
-      echo "  Bots:"
-      echo "    mb bots                          - List all bots"
-      echo "    mb bot <name>                    - Get bot details"
-      echo ""
-      echo "  Tasks:"
-      echo "    mb task <bot> <chatId> <prompt>  - Delegate task to a bot"
-      echo ""
-      echo "  Scheduling:"
-      echo "    mb schedule list                 - List pending scheduled tasks"
-      echo "    mb schedule add <bot> <chatId> <delaySec> <prompt>"
-      echo "    mb schedule cancel <id>          - Cancel a scheduled task"
-      echo ""
-      echo "  System:"
-      echo "    mb health                        - Health check"
-      ;;
-  esac
-}
-MBEOF
-  # Patch the actual secrets into the file
-  if [[ -n "${API_PORT:-}" ]]; then
-    sed_i "s|\${METABOT_API_PORT:-9100}|${API_PORT}|g" "$BASH_ALIASES"
-  fi
-  if [[ -n "${API_SECRET:-}" ]]; then
-    sed_i "s|\${METABOT_API_SECRET:-changeme}|${API_SECRET}|g" "$BASH_ALIASES"
-  fi
-  success "mb() shortcut installed"
-else
-  info "mb() shortcut already exists, skipping"
-fi
-
-# Ensure ~/.bashrc sources ~/.bash_aliases (Ubuntu default, but not universal)
-if [[ -f "$HOME/.bashrc" ]] && ! grep -q 'bash_aliases' "$HOME/.bashrc"; then
-  echo -e '\n# Load bash aliases\nif [ -f ~/.bash_aliases ]; then\n    . ~/.bash_aliases\nfi' >> "$HOME/.bashrc"
-fi
-# Source it in the current shell so mm/mb work immediately after install
-source "$BASH_ALIASES" 2>/dev/null || true
 
 # Install mm/mb/metabot as standalone executables in ~/.local/bin (no source needed)
 LOCAL_BIN="$HOME/.local/bin"


### PR DESCRIPTION
## Summary

- **Single source of truth**: \`metabot update\` and \`mb update\` now \`exec bash install.sh\` instead of reimplementing the update flow. Three parallel code paths had drifted (e.g. \`install.sh\` was missing \`skill-hub\` before #183; \`bin/metabot\` update loop was missing it before #184) — collapsing to one path removes the drift entirely.
- **Fixes \`mb skills\` shadow bug**: removed the inline \`mm()\`/\`mb()\` bash functions that \`install.sh\` used to write into \`~/.bash_aliases\`. Shell functions take priority over PATH executables, so the inline \`mb()\` (which lacks the \`skills\` subcommand) shadowed the full \`~/.local/bin/mb\` — \`mb skills list\` silently fell through to the help branch. Migration step strips legacy blocks from any existing \`~/.bash_aliases\`.
- **Misc install.sh polish**: skips the lark-cli prompt on re-run when skills are already installed; \`cp -r\` the full \`src/skills/skill-hub/\` directory (captures any future \`references/\` bundle) instead of just \`SKILL.md\`.

Net diff: ~43 insertions, ~390 deletions.

## Test plan

- [x] \`bash -n install.sh bin/metabot bin/mb\` — syntax OK
- [x] \`npm run lint\` — 0 errors (3 pre-existing warnings unchanged)
- [x] \`npm test\` — 183/183 passing
- [x] \`npm run build\` — green
- [x] Simulated the \`sed\` cleanup on a synthetic \`~/.bash_aliases\` that had both legacy blocks plus user-defined aliases above and below — user aliases preserved, both legacy blocks removed
- [ ] **Manual**: run \`metabot update\` on an existing install; confirm it delegates to \`install.sh\`, skips Phase 4 (\`.env\` exists), installs \`skill-hub\`, cleans up legacy inline \`mm()\`/\`mb()\` if present, restarts via PM2
- [ ] **Manual**: run \`mb skills list\` after update; confirm the PATH executable now wins (it was masked by the legacy inline \`mb()\` before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)