### PR TITLE
feat: AskUserQuestion on Feishu — bypassPermissions fix + card buttons

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -201,6 +201,52 @@ export class MessageBridge {
     });
   }
 
+  /**
+   * Handle a user click on an interactive card button (currently only used for
+   * AskUserQuestion answer buttons). The click is converted into the same
+   * synthetic reply that a numeric text-reply would produce, then handed to
+   * handleAnswer so both paths go through the exact same flow.
+   */
+  async handleCardAction(event: {
+    chatId: string;
+    userId: string;
+    messageId: string;
+    value: Record<string, unknown>;
+  }): Promise<void> {
+    const { chatId, userId, messageId, value } = event;
+    const task = this.runningTasks.get(chatId);
+    if (!task || !task.pendingQuestion) {
+      this.logger.debug({ chatId, userId }, 'Card action but no pending question — ignoring');
+      return;
+    }
+    if (value.action !== 'answer_question') {
+      this.logger.debug({ chatId, action: value.action }, 'Unknown card action — ignoring');
+      return;
+    }
+    if (value.toolUseId !== task.pendingQuestion.toolUseId) {
+      this.logger.warn(
+        { chatId, expected: task.pendingQuestion.toolUseId, got: value.toolUseId },
+        'Card action targets a stale question — ignoring',
+      );
+      return;
+    }
+    const optionIndex =
+      typeof value.optionIndex === 'number' ? value.optionIndex : -1;
+    const currentQ = task.pendingQuestion.questions[task.currentQuestionIndex];
+    if (!currentQ || optionIndex < 0 || optionIndex >= currentQ.options.length) {
+      this.logger.warn({ chatId, optionIndex }, 'Card action has invalid optionIndex — ignoring');
+      return;
+    }
+    const syntheticMsg: IncomingMessage = {
+      messageId,
+      chatId,
+      chatType: 'card_action',
+      userId,
+      text: String(optionIndex + 1),
+    };
+    await this.handleAnswer(syntheticMsg, task);
+  }
+
   async handleMessage(msg: IncomingMessage): Promise<void> {
     const { chatId, text } = msg;
 

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -361,8 +361,11 @@ export class MessageBridge {
       return;
     }
 
-    // All questions in this call answered — send combined result
-    const answerJson = JSON.stringify({ answers: task.collectedAnswers });
+    // All questions in this call answered — resolve the PreToolUse hook.
+    // resolveQuestion returns answers as updatedInput so the SDK short-circuits
+    // its own interaction prompt; sendAnswer is only a fallback for the legacy
+    // tool_result path (kept inside ExecutionHandle.resolveQuestion).
+    const collectedAnswers = task.collectedAnswers;
 
     if (task.questionTimeoutId) {
       clearTimeout(task.questionTimeoutId);
@@ -373,10 +376,9 @@ export class MessageBridge {
     task.collectedAnswers = {};
     task.processor.clearPendingQuestion();
 
-    const sessionId = task.processor.getSessionId() || '';
-    task.executionHandle.sendAnswer(pending.toolUseId, sessionId, answerJson);
+    task.executionHandle.resolveQuestion(pending.toolUseId, collectedAnswers);
 
-    this.logger.info({ chatId, answers: task.collectedAnswers, toolUseId: pending.toolUseId }, 'Sent all answers to Claude');
+    this.logger.info({ chatId, answers: collectedAnswers, toolUseId: pending.toolUseId }, 'Resolved AskUserQuestion hook with collected answers');
 
     // Check if there are more queued AskUserQuestion calls
     const nextPending = task.processor.getPendingQuestion();
@@ -436,14 +438,13 @@ export class MessageBridge {
       }
     }
 
-    const answerJson = JSON.stringify({ answers: task.collectedAnswers });
+    const collectedAnswers = task.collectedAnswers;
     task.pendingQuestion = null;
     task.currentQuestionIndex = 0;
     task.collectedAnswers = {};
     task.processor.clearPendingQuestion();
 
-    const sid = task.processor.getSessionId() || '';
-    task.executionHandle.sendAnswer(pending.toolUseId, sid, answerJson);
+    task.executionHandle.resolveQuestion(pending.toolUseId, collectedAnswers);
   }
 
   /** Check if message is a media message with default (auto-generated) text. */
@@ -1075,14 +1076,17 @@ export class MessageBridge {
             // Wait for the caller to provide an answer
             const answerJson = await options.onQuestion(pending);
             processor.clearPendingQuestion();
-            const sid = processor.getSessionId() || '';
-            executionHandle.sendAnswer(pending.toolUseId, sid, answerJson);
+            // Parse answers from the caller's JSON and resolve the PreToolUse hook.
+            try {
+              const parsed = JSON.parse(answerJson);
+              executionHandle.resolveQuestion(pending.toolUseId, parsed.answers || {});
+            } catch {
+              executionHandle.resolveQuestion(pending.toolUseId, { _answer: answerJson });
+            }
           } else {
             // Auto-answer when no onQuestion handler is provided
             processor.clearPendingQuestion();
-            const sid = processor.getSessionId() || '';
-            const autoAnswer = JSON.stringify({ answers: { _auto: 'Please decide on your own and proceed.' } });
-            executionHandle.sendAnswer(pending.toolUseId, sid, autoAnswer);
+            executionHandle.resolveQuestion(pending.toolUseId, { _auto: 'Please decide on your own and proceed.' });
           }
           continue;
         }

--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -165,6 +165,13 @@ export type SDKMessage = {
 export interface ExecutionHandle {
   stream: AsyncGenerator<SDKMessage>;
   sendAnswer(toolUseId: string, sessionId: string, answerText: string): void;
+  /**
+   * Resolve a pending AskUserQuestion PreToolUse hook with the user's answers.
+   * Use this instead of sendAnswer when running in bypassPermissions mode —
+   * sendAnswer enqueues a tool_result that never reaches the SDK because the
+   * internal permission check short-circuits before auto-allow.
+   */
+  resolveQuestion(toolUseId: string, answers: Record<string, string>): void;
   finish(): void;
 }
 
@@ -283,6 +290,59 @@ export class ClaudeExecutor {
       queryOptions.allowedTools = options.allowedTools;
     }
 
+    // AskUserQuestion PreToolUse hook: the SDK marks AskUserQuestion as
+    // requiresUserInteraction=true, so in bypassPermissions mode it is denied
+    // before auto-allow can fire. We intercept the PreToolUse event, pause until
+    // the bridge collects the user's answers, then return them as updatedInput.
+    // Providing updatedInput satisfies the interaction requirement and the SDK
+    // resolves the tool call with {answers} filled in.
+    const pendingQuestionResolvers = new Map<string, (answers: Record<string, string>) => void>();
+
+    const askUserQuestionHook = async (
+      input: { hook_event_name: string; tool_name: string; tool_input: unknown; tool_use_id: string },
+      _toolUseId: string | undefined,
+      { signal }: { signal: AbortSignal },
+    ): Promise<Record<string, unknown>> => {
+      const toolInput = input.tool_input as Record<string, unknown>;
+      const id = input.tool_use_id;
+
+      const answers = await new Promise<Record<string, string>>((resolve) => {
+        pendingQuestionResolvers.set(id, resolve);
+
+        // Safety timeout: auto-resolve with empty answers after 6 minutes
+        // (slightly longer than bridge's 5-minute QUESTION_TIMEOUT_MS) to
+        // prevent indefinite hang if the bridge fails to deliver an answer.
+        const timeout = setTimeout(() => {
+          if (pendingQuestionResolvers.delete(id)) {
+            logger.warn({ toolUseId: id }, 'AskUserQuestion hook timed out after 6 minutes — returning empty answers');
+            resolve({});
+          }
+        }, 6 * 60 * 1000);
+
+        const onAbort = () => {
+          clearTimeout(timeout);
+          pendingQuestionResolvers.delete(id);
+          resolve({});
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      });
+
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: { ...toolInput, answers },
+        },
+      };
+    };
+
+    queryOptions.hooks = {
+      PreToolUse: [{
+        matcher: 'AskUserQuestion',
+        hooks: [askUserQuestionHook as any],
+      }],
+    };
+
     const stream = query({
       prompt: inputQueue,
       options: queryOptions as any,
@@ -344,6 +404,29 @@ export class ClaudeExecutor {
           session_id: sid,
         };
         inputQueue.enqueue(answerMessage);
+      },
+      resolveQuestion: (toolUseId: string, answers: Record<string, string>) => {
+        const resolver = pendingQuestionResolvers.get(toolUseId);
+        if (resolver) {
+          pendingQuestionResolvers.delete(toolUseId);
+          logger.info({ toolUseId, answerCount: Object.keys(answers).length }, 'Resolving AskUserQuestion hook');
+          resolver(answers);
+        } else {
+          // Fallback: enqueue tool_result via inputQueue. Used if the hook
+          // didn't capture this toolUseId (e.g., legacy sendAnswer path) or
+          // the SDK version differs.
+          logger.warn({ toolUseId }, 'No pending AskUserQuestion resolver — falling back to sendAnswer path');
+          const answerMessage: SDKUserMessage = {
+            type: 'user',
+            message: {
+              role: 'user' as const,
+              content: [{ type: 'tool_result', tool_use_id: toolUseId, content: JSON.stringify({ answers }) }],
+            },
+            parent_tool_use_id: null,
+            session_id: '',
+          };
+          inputQueue.enqueue(answerMessage);
+        }
       },
       finish: () => {
         inputQueue.finish();

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -52,23 +52,38 @@ export function buildCard(state: CardState): string {
     });
   }
 
-  // Pending question section
+  // Pending question section — interactive buttons + text-fallback hint
   if (state.pendingQuestion) {
     elements.push({ tag: 'hr' });
-    const questionLines: string[] = [];
-    for (const q of state.pendingQuestion.questions) {
-      questionLines.push(`**[${q.header}] ${q.question}**`);
-      questionLines.push('');
-      q.options.forEach((opt, i) => {
-        questionLines.push(`**${i + 1}.** ${opt.label} — _${opt.description}_`);
+    state.pendingQuestion.questions.forEach((q, qi) => {
+      // Question prompt
+      const descLines = q.options.map(
+        (opt, i) => `**${i + 1}.** ${opt.label} — _${opt.description}_`,
+      );
+      elements.push({
+        tag: 'markdown',
+        content: [`**[${q.header}] ${q.question}**`, '', ...descLines].join('\n'),
       });
-      questionLines.push(`**${q.options.length + 1}.** Other（输入自定义回答）`);
-      questionLines.push('');
-    }
-    questionLines.push('_回复数字选择，或直接输入自定义答案_');
+      // Interactive buttons: one per option + an explicit "Other" button
+      const actions = q.options.map((opt, oi) => ({
+        tag: 'button',
+        text: { tag: 'plain_text', content: `${oi + 1}. ${opt.label}` },
+        type: 'primary',
+        value: {
+          action: 'answer_question',
+          toolUseId: state.pendingQuestion!.toolUseId,
+          questionIndex: qi,
+          optionIndex: oi,
+        },
+      }));
+      elements.push({
+        tag: 'action',
+        actions,
+      });
+    });
     elements.push({
       tag: 'markdown',
-      content: questionLines.join('\n'),
+      content: '_点击按钮选择，或直接输入自定义答案_',
     });
   }
 
@@ -116,7 +131,9 @@ export function buildCard(state: CardState): string {
   }
 
   const card = {
-    config: { wide_screen_mode: true },
+    // update_multi lets us re-render the same card after an action click
+    // without hitting Feishu error 108002 ("card has already been updated").
+    config: { wide_screen_mode: true, update_multi: true },
     header: {
       template: config.color,
       title: {

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -9,6 +9,17 @@ import type { IncomingMessage } from '../types.js';
 
 export type MessageHandler = (msg: IncomingMessage) => void;
 
+/** Payload delivered when a user clicks a button on an interactive card. */
+export interface CardActionEvent {
+  chatId: string;
+  userId: string;
+  messageId: string;
+  /** Arbitrary value object set by the card builder on the clicked button. */
+  value: Record<string, unknown>;
+}
+
+export type CardActionHandler = (event: CardActionEvent) => void;
+
 // Cache for group member counts (to avoid calling Feishu API on every message)
 const MEMBER_COUNT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const memberCountCache = new Map<string, { count: number; ts: number }>();
@@ -66,8 +77,45 @@ export function createEventDispatcher(
   onMessage: MessageHandler,
   botOpenId?: string,
   messageSender?: MessageSender,
+  onCardAction?: CardActionHandler,
 ): lark.EventDispatcher {
   const dispatcher = new lark.EventDispatcher({});
+
+  // Register the card action trigger handler (fired when a user clicks a button
+  // on an interactive card). The lark SDK types omit this event so we cast.
+  if (onCardAction) {
+    (dispatcher as unknown as {
+      register: (handlers: Record<string, (data: unknown) => unknown>) => void;
+    }).register({
+      'card.action.trigger': (data: unknown) => {
+        try {
+          const d = data as {
+            operator?: { open_id?: string };
+            action?: { value?: unknown };
+            context?: { open_message_id?: string; open_chat_id?: string };
+          };
+          const userId = d.operator?.open_id;
+          const messageId = d.context?.open_message_id;
+          const chatId = d.context?.open_chat_id;
+          const raw = d.action?.value;
+          if (!userId || !messageId || !chatId || !raw || typeof raw !== 'object') {
+            logger.warn({ data }, 'Card action missing required fields');
+            return { toast: { type: 'error', content: 'Invalid card action' } };
+          }
+          onCardAction({
+            chatId,
+            userId,
+            messageId,
+            value: raw as Record<string, unknown>,
+          });
+          return { toast: { type: 'success', content: '已收到' } };
+        } catch (err) {
+          logger.error({ err }, 'Error handling card action');
+          return { toast: { type: 'error', content: 'Internal error' } };
+        }
+      },
+    });
+  }
 
   dispatcher.register({
     'im.message.receive_v1': async (data: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,11 +62,22 @@ async function startFeishuBot(botConfig: BotConfig, logger: Logger, memoryServer
   const bridge = new MessageBridge(botConfig, botLogger, sender, memoryServerUrl, memorySecret);
 
   // Create event dispatcher wired to the bridge
-  const dispatcher = createEventDispatcher(botConfig, botLogger, (msg) => {
-    bridge.handleMessage(msg).catch((err) => {
-      botLogger.error({ err, msg }, 'Unhandled error in message bridge');
-    });
-  }, botOpenId, rawSender);
+  const dispatcher = createEventDispatcher(
+    botConfig,
+    botLogger,
+    (msg) => {
+      bridge.handleMessage(msg).catch((err) => {
+        botLogger.error({ err, msg }, 'Unhandled error in message bridge');
+      });
+    },
+    botOpenId,
+    rawSender,
+    (event) => {
+      bridge.handleCardAction(event).catch((err) => {
+        botLogger.error({ err, event }, 'Unhandled error in card action handler');
+      });
+    },
+  );
 
   // Create WebSocket client
   const wsClient = new lark.WSClient({

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -89,6 +89,21 @@ describe('buildCard', () => {
     expect(qEl).toBeDefined();
     expect(qEl.content).toContain('Production');
     expect(qEl.content).toContain('Staging');
+    // update_multi must be set so Feishu accepts card updates after an action click
+    expect(json.config.update_multi).toBe(true);
+    // Interactive buttons: one action element with one button per option
+    const actionEl = json.elements.find((e: any) => e.tag === 'action');
+    expect(actionEl).toBeDefined();
+    expect(actionEl.actions).toHaveLength(2);
+    expect(actionEl.actions[0].tag).toBe('button');
+    expect(actionEl.actions[0].text.content).toContain('Production');
+    expect(actionEl.actions[0].value).toEqual({
+      action: 'answer_question',
+      toolUseId: 'q1',
+      questionIndex: 0,
+      optionIndex: 0,
+    });
+    expect(actionEl.actions[1].value.optionIndex).toBe(1);
   });
 
   it('truncates long content', () => {


### PR DESCRIPTION
Two-part fix to make AskUserQuestion usable end-to-end on Feishu.

> **⚠️ Setup required:** After deploying this change you must enable the
> **card button callback** (event `card.action.trigger`) in the Feishu
> Open Platform → your app → Event subscriptions. Without it, button
> clicks will not reach the bot and the old text-reply path must be
> used instead.

## fix: bypassPermissions mode (524424f)

The SDK marks AskUserQuestion as `requiresUserInteraction=true`, so in
`bypassPermissions` mode the internal permission check denies the tool
call before auto-allow fires — the bridge never sees `pendingQuestion`
and the conversation stalls.

Register a PreToolUse hook on AskUserQuestion that waits for the bridge
to supply answers, then returns `permissionDecision: 'allow'` with
`updatedInput: { ...input, answers }`. Providing `updatedInput` satisfies
the SDK's interaction requirement and the tool call resolves with answers
filled in.

- `ExecutionHandle.resolveQuestion(toolUseId, answers)` added; `sendAnswer`
  kept as a fallback for legacy `tool_result` paths.
- `handleAnswer` / `autoAnswerRemainingQuestions` / API-task
  `waiting_for_input` branch all switch to `resolveQuestion`.
- 6-min hook-side timeout (longer than bridge's 5-min QUESTION_TIMEOUT_MS)
  + AbortSignal cleanup prevent indefinite hangs.

## feat: interactive card buttons (758a515)

Render one `action` element per question with one primary button per
option; clicks go through the same flow as a numeric text reply.

- Button `value = { action, toolUseId, questionIndex, optionIndex }` for
  stable click routing.
- `update_multi: true` on card config so Feishu accepts re-renders after
  a click (otherwise error 108002).
- `card.action.trigger` handler in `event-handler.ts` (lark SDK types
  omit this event — cast past them); forwards payload to a new optional
  `onCardAction` callback on `createEventDispatcher`.
- `MessageBridge.handleCardAction` validates `toolUseId` + `optionIndex`,
  synthesizes the same numeric `IncomingMessage` a typed reply produces,
  and dispatches through the existing `handleAnswer` — one path for
  timeouts, multi-question progression, and hook resolution.
- Text-reply fallback preserved; hint updated to
  「点击按钮选择，或直接输入自定义答案」.

## Verification

Automated:

- `npx tsc --noEmit` — clean
- `npm test` — 183/183 passing (10 card-builder cases cover the new
  `action` element shape and `update_multi: true`)

Manual tests on Feishu:

| # | Scenario | Button render | Click routed | Hook resolved | Answer returned | Passed |
|---|----------|:-:|:-:|:-:|----------|:-:|
| 1 | 1 question · 3 options · single-select | ✅ | ✅ | ✅ | `按钮测试 = 选项 A` | ✅ |
| 2 | 2 sequential questions (Q1→Q2, `(n/N)` progress) · Q1 single-select / Q2 multiSelect | ✅ | ✅ | ✅ | `Q1/2 = Yes`, `Q2/2 = Beta` | ✅ |
| 3 | 1 question · 4 options · single-select | ✅ | ✅ | ✅ | `4opt = 甲` | ✅ |
