### PR TITLE
refactor: extract engine abstraction (prep for Kimi support)

### DIFF
--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -2,7 +2,7 @@ import type { BotConfigBase } from '../config.js';
 import type { Logger } from '../utils/logger.js';
 import type { IncomingMessage } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
-import { SessionManager } from '../claude/session-manager.js';
+import { SessionManager } from '../engines/index.js';
 import { MemoryClient } from '../memory/memory-client.js';
 import { AuditLogger } from '../utils/audit-logger.js';
 import type { DocSync } from '../sync/doc-sync.js';

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -6,9 +6,8 @@ import type { Logger } from '../utils/logger.js';
 import type { IncomingMessage, CardState, PendingQuestion } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
 import type { DocSync } from '../sync/doc-sync.js';
-import { ClaudeExecutor, type ExecutionHandle } from '../claude/executor.js';
-import { StreamProcessor } from '../claude/stream-processor.js';
-import { SessionManager } from '../claude/session-manager.js';
+import type { Engine, Executor, ExecutionHandle } from '../engines/index.js';
+import { createEngine, StreamProcessor, SessionManager } from '../engines/index.js';
 import { RateLimiter } from './rate-limiter.js';
 import { OutputsManager } from './outputs-manager.js';
 import { MemoryClient } from '../memory/memory-client.js';
@@ -98,7 +97,8 @@ export interface ActivityEventData {
 }
 
 export class MessageBridge {
-  private executor: ClaudeExecutor;
+  private engine: Engine;
+  private executor: Executor;
   private sessionManager: SessionManager;
   private outputsManager: OutputsManager;
   private audit: AuditLogger;
@@ -119,7 +119,8 @@ export class MessageBridge {
     memoryServerUrl: string,
     memorySecret?: string,
   ) {
-    this.executor = new ClaudeExecutor(config, logger);
+    this.engine = createEngine(config, logger);
+    this.executor = this.engine.createExecutor();
     this.sessionManager = new SessionManager(config.claude.defaultWorkingDirectory, logger, config.name);
     this.outputsManager = new OutputsManager(config.claude.outputsBaseDir, logger);
     this.audit = new AuditLogger(logger);

--- a/src/bridge/output-handler.ts
+++ b/src/bridge/output-handler.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import type { Logger } from '../utils/logger.js';
 import type { CardState } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
-import { StreamProcessor, extractImagePaths } from '../claude/stream-processor.js';
+import { StreamProcessor, extractImagePaths } from '../engines/index.js';
 import { OutputsManager } from './outputs-manager.js';
 
 export class OutputHandler {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-/** Shared config fields used by MessageBridge and ClaudeExecutor (platform-agnostic). */
+/** Agent engine backing a bot. `claude` uses Claude Code; `kimi` uses Kimi Code (Phase 2). */
+export type EngineName = 'claude' | 'kimi';
+
+/** Shared config fields used by MessageBridge and Executors (platform-agnostic). */
 export interface BotConfigBase {
   name: string;
   description?: string;
@@ -12,6 +15,8 @@ export interface BotConfigBase {
   maxConcurrentTasks?: number;
   budgetLimitDaily?: number;
   ttsVoice?: string;
+  /** Agent engine. Defaults to 'claude' for backward compatibility. */
+  engine?: EngineName;
   claude: {
     defaultWorkingDirectory: string;
     maxTurns: number | undefined;
@@ -23,6 +28,13 @@ export interface BotConfigBase {
     apiKey: string | undefined;
     outputsBaseDir: string;
     downloadsDir: string;
+  };
+  /** Kimi-specific overrides. Populated only when engine === 'kimi'. Phase 2. */
+  kimi?: {
+    executable?: string;
+    model?: string;
+    thinking?: boolean;
+    apiKey?: string;
   };
 }
 
@@ -105,7 +117,21 @@ function expandUserPath(value: string): string {
 
 // --- Feishu JSON entry (used in bots.json) ---
 
-export interface FeishuBotJsonEntry {
+/** Kimi-specific overrides in bots.json. */
+export interface KimiJsonConfig {
+  executable?: string;
+  model?: string;
+  thinking?: boolean;
+  apiKey?: string;
+}
+
+/** Fields shared across all bot JSON entries (engine selection, Kimi overrides). */
+interface EngineJsonFields {
+  engine?: EngineName;
+  kimi?: KimiJsonConfig;
+}
+
+export interface FeishuBotJsonEntry extends EngineJsonFields {
   name: string;
   description?: string;
   specialties?: string[];
@@ -136,6 +162,8 @@ function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
     ...(entry.budgetLimitDaily != null ? { budgetLimitDaily: entry.budgetLimitDaily } : {}),
     ...(entry.ttsVoice ? { ttsVoice: entry.ttsVoice } : {}),
     ...(entry.groupNoMention ? { groupNoMention: true } : {}),
+    ...(entry.engine ? { engine: entry.engine } : {}),
+    ...(entry.kimi ? { kimi: entry.kimi } : {}),
     feishu: {
       appId: entry.feishuAppId,
       appSecret: entry.feishuAppSecret,
@@ -146,7 +174,7 @@ function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
 
 // --- Telegram JSON entry (used in bots.json) ---
 
-export interface TelegramBotJsonEntry {
+export interface TelegramBotJsonEntry extends EngineJsonFields {
   name: string;
   description?: string;
   specialties?: string[];
@@ -173,6 +201,8 @@ function telegramBotFromJson(entry: TelegramBotJsonEntry): TelegramBotConfig {
     ...(entry.maxConcurrentTasks != null ? { maxConcurrentTasks: entry.maxConcurrentTasks } : {}),
     ...(entry.budgetLimitDaily != null ? { budgetLimitDaily: entry.budgetLimitDaily } : {}),
     ...(entry.ttsVoice ? { ttsVoice: entry.ttsVoice } : {}),
+    ...(entry.engine ? { engine: entry.engine } : {}),
+    ...(entry.kimi ? { kimi: entry.kimi } : {}),
     telegram: {
       botToken: entry.telegramBotToken,
     },
@@ -182,7 +212,7 @@ function telegramBotFromJson(entry: TelegramBotJsonEntry): TelegramBotConfig {
 
 // --- Web bot JSON entry (used in bots.json — no IM credentials needed) ---
 
-export interface WebBotJsonEntry {
+export interface WebBotJsonEntry extends EngineJsonFields {
   name: string;
   description?: string;
   specialties?: string[];
@@ -207,13 +237,15 @@ export function webBotFromJson(entry: WebBotJsonEntry): BotConfigBase {
     ...(entry.maxConcurrentTasks != null ? { maxConcurrentTasks: entry.maxConcurrentTasks } : {}),
     ...(entry.budgetLimitDaily != null ? { budgetLimitDaily: entry.budgetLimitDaily } : {}),
     ...(entry.ttsVoice ? { ttsVoice: entry.ttsVoice } : {}),
+    ...(entry.engine ? { engine: entry.engine } : {}),
+    ...(entry.kimi ? { kimi: entry.kimi } : {}),
     claude: buildClaudeConfig(entry),
   };
 }
 
 // --- WeChat JSON entry (used in bots.json) ---
 
-export interface WechatBotJsonEntry {
+export interface WechatBotJsonEntry extends EngineJsonFields {
   name: string;
   description?: string;
   ilinkBaseUrl?: string;
@@ -231,6 +263,8 @@ function wechatBotFromJson(entry: WechatBotJsonEntry): WechatBotConfig {
   return {
     name: entry.name,
     ...(entry.description ? { description: entry.description } : {}),
+    ...(entry.engine ? { engine: entry.engine } : {}),
+    ...(entry.kimi ? { kimi: entry.kimi } : {}),
     wechat: {
       ilinkBaseUrl: entry.ilinkBaseUrl,
       botToken: entry.wechatBotToken,

--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -5,9 +5,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { SDKUserMessage, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
-import type { BotConfigBase } from '../config.js';
-import type { Logger } from '../utils/logger.js';
-import { AsyncQueue } from '../utils/async-queue.js';
+import type { BotConfigBase } from '../../config.js';
+import type { Logger } from '../../utils/logger.js';
+import { AsyncQueue } from '../../utils/async-queue.js';
 
 const isWindows = process.platform === 'win32';
 

--- a/src/engines/claude/index.ts
+++ b/src/engines/claude/index.ts
@@ -1,0 +1,34 @@
+import type { BotConfigBase } from '../../config.js';
+import type { Logger } from '../../utils/logger.js';
+import type { Engine, Executor } from '../types.js';
+import { ClaudeExecutor } from './executor.js';
+import { StreamProcessor } from './stream-processor.js';
+
+export class ClaudeEngine implements Engine {
+  readonly name = 'claude' as const;
+
+  constructor(
+    private config: BotConfigBase,
+    private logger: Logger,
+  ) {}
+
+  createExecutor(): Executor {
+    return new ClaudeExecutor(this.config, this.logger);
+  }
+
+  createStreamProcessor(userPrompt: string): StreamProcessor {
+    return new StreamProcessor(userPrompt);
+  }
+}
+
+export { ClaudeExecutor } from './executor.js';
+export { StreamProcessor, extractImagePaths } from './stream-processor.js';
+export { SessionManager } from './session-manager.js';
+export type { UserSession } from './session-manager.js';
+export type {
+  SDKMessage,
+  ExecutionHandle,
+  ExecutorOptions,
+  ApiContext,
+} from './executor.js';
+export type { DetectedTool } from './stream-processor.js';

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import type { Logger } from '../utils/logger.js';
+import type { Logger } from '../../utils/logger.js';
 
 export interface UserSession {
   sessionId: string | undefined;

--- a/src/engines/claude/stream-processor.ts
+++ b/src/engines/claude/stream-processor.ts
@@ -1,5 +1,5 @@
 import type { SDKMessage } from './executor.js';
-import type { CardState, ToolCall, PendingQuestion } from '../feishu/card-builder.js';
+import type { CardState, ToolCall, PendingQuestion } from '../../feishu/card-builder.js';
 
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.tiff']);
 

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -1,0 +1,56 @@
+import type { BotConfigBase } from '../config.js';
+import type { Logger } from '../utils/logger.js';
+import type { Engine, EngineName } from './types.js';
+import { ClaudeEngine } from './claude/index.js';
+import { KimiEngine } from './kimi/index.js';
+
+/**
+ * Create an Engine for the given bot config.
+ *
+ * Engine selection:
+ *   1. `config.engine` field (explicit)
+ *   2. `METABOT_ENGINE` env var (global default)
+ *   3. `'claude'` (fallback)
+ */
+export function createEngine(config: BotConfigBase, logger: Logger): Engine {
+  const name = resolveEngineName(config);
+  switch (name) {
+    case 'claude':
+      return new ClaudeEngine(config, logger);
+    case 'kimi':
+      return new KimiEngine(config, logger);
+    default: {
+      const _exhaustive: never = name;
+      throw new Error(`Unknown engine: ${_exhaustive}`);
+    }
+  }
+}
+
+function resolveEngineName(config: BotConfigBase): EngineName {
+  const explicit = config.engine;
+  if (explicit) return explicit;
+  const envDefault = process.env.METABOT_ENGINE as EngineName | undefined;
+  if (envDefault === 'claude' || envDefault === 'kimi') return envDefault;
+  return 'claude';
+}
+
+export type { Engine, EngineName, Executor } from './types.js';
+export { ClaudeEngine } from './claude/index.js';
+export { KimiEngine } from './kimi/index.js';
+
+// Re-export shared types and classes currently used by the bridge and web/api layers.
+// Moving these behind the engine boundary lets consumers import from a single place.
+export {
+  ClaudeExecutor,
+  StreamProcessor,
+  SessionManager,
+  extractImagePaths,
+} from './claude/index.js';
+export type {
+  UserSession,
+  SDKMessage,
+  ExecutionHandle,
+  ExecutorOptions,
+  ApiContext,
+  DetectedTool,
+} from './claude/index.js';

--- a/src/engines/kimi/index.ts
+++ b/src/engines/kimi/index.ts
@@ -1,0 +1,31 @@
+import type { BotConfigBase } from '../../config.js';
+import type { Logger } from '../../utils/logger.js';
+import type { Engine, Executor } from '../types.js';
+import { StreamProcessor } from '../claude/stream-processor.js';
+
+/**
+ * Kimi engine placeholder. The real implementation lands in Phase 2,
+ * wrapping `@moonshot-ai/kimi-agent-sdk`. Constructing this engine today
+ * throws at executor-creation time so multi-bot configs that declare
+ * `"engine": "kimi"` fail loudly instead of silently falling back to Claude.
+ */
+export class KimiEngine implements Engine {
+  readonly name = 'kimi' as const;
+
+  constructor(
+    _config: BotConfigBase,
+    _logger: Logger,
+  ) {}
+
+  createExecutor(): Executor {
+    throw new Error(
+      'Kimi engine not yet implemented (Phase 2). ' +
+      'Remove `engine: "kimi"` from this bot or switch to `engine: "claude"` for now.'
+    );
+  }
+
+  createStreamProcessor(userPrompt: string): StreamProcessor {
+    // Reuse Claude StreamProcessor for type compatibility until Phase 2.
+    return new StreamProcessor(userPrompt);
+  }
+}

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -1,0 +1,56 @@
+import type { BotConfigBase } from '../config.js';
+import type { Logger } from '../utils/logger.js';
+import type {
+  ClaudeExecutor,
+  ExecutionHandle,
+  ExecutorOptions,
+  SDKMessage,
+  ApiContext,
+} from './claude/executor.js';
+import type { StreamProcessor } from './claude/stream-processor.js';
+
+export type EngineName = 'claude' | 'kimi';
+
+/**
+ * An Engine is a programmable agent backend (Claude Code, Kimi Code, …).
+ * It produces an Executor that the bridge drives for a single chat session.
+ *
+ * In Phase 1 we only ship the Claude implementation; the interface lets us
+ * drop in a Kimi implementation without touching the bridge.
+ */
+export interface Engine {
+  readonly name: EngineName;
+  /** Returns the executor used to run queries for this engine. */
+  createExecutor(): Executor;
+  /** Returns the StreamProcessor class used to process engine messages into CardState. */
+  createStreamProcessor(userPrompt: string): StreamProcessorLike;
+}
+
+/**
+ * Executor abstraction. Both engines must support the multi-turn
+ * `startExecution` path (streaming + sendAnswer + resolveQuestion + finish)
+ * and the one-shot `execute` path used by voice mode.
+ *
+ * Phase 1 aliases these to the Claude types. Phase 2 will generalise
+ * SDKMessage into a union (EngineMessage) with Kimi-specific events.
+ */
+export interface Executor {
+  startExecution(options: ExecutorOptions): ExecutionHandle;
+  execute(options: ExecutorOptions): AsyncGenerator<SDKMessage>;
+}
+
+export type StreamProcessorLike = StreamProcessor;
+
+export type {
+  ClaudeExecutor,
+  ExecutionHandle,
+  ExecutorOptions,
+  SDKMessage,
+  ApiContext,
+};
+
+/** Context passed to engine factory. */
+export interface EngineContext {
+  config: BotConfigBase;
+  logger: Logger;
+}

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { SessionManager } from '../src/claude/session-manager.js';
+import { SessionManager } from '../src/engines/claude/session-manager.js';
 
 function createLogger() {
   return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(), child: vi.fn() } as any;

--- a/tests/stream-processor.test.ts
+++ b/tests/stream-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { StreamProcessor, extractImagePaths } from '../src/claude/stream-processor.js';
-import type { SDKMessage } from '../src/claude/executor.js';
+import { StreamProcessor, extractImagePaths } from '../src/engines/claude/stream-processor.js';
+import type { SDKMessage } from '../src/engines/claude/executor.js';
 
 function msg(overrides: Partial<SDKMessage>): SDKMessage {
   return { type: 'system', session_id: 'sess-1', ...overrides } as SDKMessage;


### PR DESCRIPTION
## Summary

Prep work for first-class Kimi (Moonshot AI) support. Moves the Claude-specific code into `src/engines/claude/` and introduces an `Engine` interface so a single MetaBot instance can route each bot to either Claude or Kimi based on config.

- `src/engines/types.ts` — `Engine` + `Executor` interfaces
- `src/engines/index.ts` — `createEngine()` factory (dispatches on `config.engine` → `METABOT_ENGINE` env → default `'claude'`)
- `src/engines/claude/index.ts` — `ClaudeEngine` wrapping the existing executor/stream-processor/session-manager
- `src/engines/kimi/index.ts` — Phase 2 placeholder that throws at `createExecutor()` so misconfigured bots fail loudly instead of silently running on Claude
- `BotConfigBase` + all 4 `*JsonConfig` entries gain optional `engine` and `kimi` fields
- `message-bridge`, `command-handler`, `output-handler`, and two tests retarget imports to the new paths

No behavior change for existing Claude bots — the factory defaults to `'claude'`.

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 183 tests pass (18 files)
- [ ] Manual smoke: start a Claude bot and confirm a message round-trip still works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)