### PR TITLE
feat(kimi): install.sh engine selection + metaskill dual-engine + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,46 @@ ANTHROPIC_AUTH_TOKEN=你的key
 </details>
 
 <details>
+<summary><strong>Kimi 引擎（原生支持 Kimi 订阅）</strong></summary>
+
+除了走 Anthropic 兼容 API，MetaBot 也内置了**原生 Kimi 引擎**，直接使用你的 Kimi 订阅（经由 kimi-cli 登录），无需 API Key。每个 Bot 可以独立选择引擎：
+
+```json
+{
+  "feishuBots": [
+    {
+      "name": "bulma",
+      "engine": "kimi",
+      "feishuAppId": "cli_xxx",
+      "feishuAppSecret": "secret",
+      "defaultWorkingDirectory": "/path/to/workdir",
+      "kimi": { "thinking": true }
+    }
+  ]
+}
+```
+
+**前置条件**：
+1. 安装 [uv](https://astral.sh/uv)，然后 `uv tool install kimi-cli`
+2. 运行 `kimi login` 完成订阅授权
+3. 将 Bot 配置中 `engine` 设为 `"kimi"`
+
+**引擎差异**：
+
+| 功能 | Claude | Kimi |
+|------|--------|------|
+| 流式卡片 / 工具调用展示 | ✅ | ✅（通过事件翻译） |
+| 权限模式 | `bypassPermissions` | `yoloMode: true` |
+| 工作区说明文档 | `CLAUDE.md` | `AGENTS.md`（安装脚本会自动建软链） |
+| `.claude/skills/` 自动加载 | ✅ | ✅（Kimi CLI 自带 brand fallback） |
+| `.claude/agents/*.md` 子 Agent | ✅ | ❌（Kimi 仅内置 `default`/`okabe`） |
+| MCP 服务器配置 | `.mcp.json` 项目级 | `~/.kimi/mcp.json` 用户级 |
+
+安装脚本 (`install.sh`) 会在引擎选择步骤询问 Claude vs Kimi，选 Kimi 时自动装 uv + kimi-cli 并写入正确的 `bots.json`。
+
+</details>
+
+<details>
 <summary><strong>cc-switch 兼容</strong></summary>
 
 兼容 [cc-switch](https://github.com/farion1231/cc-switch)、[cc-switch-cli](https://github.com/SaladDay/cc-switch-cli)、[CCS](https://github.com/kaitranntt/ccs) 等认证切换工具。用 `cc switch` 切换 API/订阅模式后，MetaBot **无需重启**即可生效。

--- a/README_EN.md
+++ b/README_EN.md
@@ -288,6 +288,46 @@ ANTHROPIC_AUTH_TOKEN=your-key
 </details>
 
 <details>
+<summary><strong>Kimi engine (native Kimi subscription)</strong></summary>
+
+In addition to the Anthropic-compatible API route, MetaBot ships a **first-class Kimi engine** that uses your Kimi subscription directly (via `kimi-cli` login) — no API key required. Engine choice is per-bot:
+
+```json
+{
+  "feishuBots": [
+    {
+      "name": "bulma",
+      "engine": "kimi",
+      "feishuAppId": "cli_xxx",
+      "feishuAppSecret": "secret",
+      "defaultWorkingDirectory": "/path/to/workdir",
+      "kimi": { "thinking": true }
+    }
+  ]
+}
+```
+
+**Prerequisites:**
+1. Install [uv](https://astral.sh/uv), then `uv tool install kimi-cli`
+2. Run `kimi login` to authenticate your subscription
+3. Set `engine: "kimi"` on the bot config
+
+**Engine differences:**
+
+| Feature | Claude | Kimi |
+|---------|--------|------|
+| Streaming card / tool-call display | ✅ | ✅ (events are translated) |
+| Permission mode | `bypassPermissions` | `yoloMode: true` |
+| Workspace instructions file | `CLAUDE.md` | `AGENTS.md` (installer symlinks `CLAUDE.md` → `AGENTS.md`) |
+| `.claude/skills/` auto-discovery | ✅ | ✅ (Kimi CLI brand fallback) |
+| `.claude/agents/*.md` subagents | ✅ | ❌ (Kimi only ships builtin `default`/`okabe`) |
+| MCP server config | `.mcp.json` (project) | `~/.kimi/mcp.json` (user-level) |
+
+`install.sh` asks which engine to use; selecting Kimi installs uv + kimi-cli and writes the correct `bots.json`.
+
+</details>
+
+<details>
 <summary><strong>cc-switch compatibility</strong></summary>
 
 Compatible with [cc-switch](https://github.com/farion1231/cc-switch), [cc-switch-cli](https://github.com/SaladDay/cc-switch-cli), [CCS](https://github.com/kaitranntt/ccs). Switching via `cc switch` takes effect **without restarting** MetaBot.

--- a/install.sh
+++ b/install.sh
@@ -278,6 +278,9 @@ else
   success "PM2 already installed"
 fi
 
+# Claude and Kimi CLI installs are driven by the engine choice in Phase 4.
+# We still ensure the Claude CLI is present as a default convenience, since
+# most users start with Claude and may mix engines later.
 if command -v claude &>/dev/null; then
   success "Claude CLI found: $(command -v claude)"
 else
@@ -289,6 +292,36 @@ else
     warn "Claude CLI install failed. Install manually: sudo npm install -g @anthropic-ai/claude-code"
   fi
 fi
+
+# Install uv + kimi-cli helper. Used by the Kimi engine path below.
+install_kimi_cli() {
+  if command -v kimi &>/dev/null; then
+    success "Kimi CLI found: $(command -v kimi)"
+    return 0
+  fi
+  # Need uv first (kimi-cli is a Python tool distributed via uv)
+  if ! command -v uv &>/dev/null; then
+    info "Installing uv (required by kimi-cli)..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true
+    # uv installs to ~/.local/bin — make sure it's on PATH for this script
+    export PATH="$HOME/.local/bin:$PATH"
+    if ! command -v uv &>/dev/null; then
+      warn "uv install failed. Install manually from https://astral.sh/uv and re-run."
+      return 1
+    fi
+    success "uv installed: $(uv --version)"
+  fi
+  info "Installing kimi-cli via uv..."
+  if uv tool install kimi-cli 2>&1 | tail -3; then
+    export PATH="$HOME/.local/bin:$PATH"
+    if command -v kimi &>/dev/null; then
+      success "Kimi CLI installed: $(command -v kimi)"
+      return 0
+    fi
+  fi
+  warn "Kimi CLI install failed. Install manually: uv tool install kimi-cli"
+  return 1
+}
 
 # ============================================================================
 # Phase 4: Interactive configuration
@@ -312,18 +345,40 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
   mkdir -p "$WORK_DIR"
   success "Working directory: ${WORK_DIR}"
 
-  # ------ 4b: Claude AI authentication ------
+  # ------ 4b: Engine selection ------
   echo ""
-  echo -e "${BOLD}Claude AI Authentication:${NC}"
-  echo "  1) Claude Code Subscription (OAuth — run 'claude login' after install)"
-  echo "  2) Anthropic API Key (sk-ant-...)"
-  echo "  3) Third-party provider (Kimi/Moonshot, DeepSeek, GLM, etc.)"
-  prompt_choice AUTH_CHOICE "1"
+  echo -e "${BOLD}Agent Engine:${NC}"
+  echo "  1) Claude Code (Anthropic)"
+  echo "  2) Kimi (Moonshot AI — requires kimi-cli login, uses your subscription)"
+  prompt_choice ENGINE_CHOICE "1"
 
+  BOT_ENGINE="claude"
   CLAUDE_AUTH_ENV_LINES=""
   CLAUDE_AUTH_METHOD="subscription"
 
+  if [[ "$ENGINE_CHOICE" == "2" ]]; then
+    BOT_ENGINE="kimi"
+    CLAUDE_AUTH_METHOD="kimi"
+    echo ""
+    info "Installing kimi-cli..."
+    install_kimi_cli || warn "Continuing despite kimi-cli install failure — you can install it later."
+    info "After install, run 'kimi login' in a separate terminal to authenticate."
+    # Skip the Claude provider prompt entirely for Kimi — it has its own auth.
+    AUTH_CHOICE="kimi"
+  else
+    # ------ 4b-claude: Claude AI authentication ------
+    echo ""
+    echo -e "${BOLD}Claude AI Authentication:${NC}"
+    echo "  1) Claude Code Subscription (OAuth — run 'claude login' after install)"
+    echo "  2) Anthropic API Key (sk-ant-...)"
+    echo "  3) Third-party provider (Kimi/Moonshot, DeepSeek, GLM, etc.)"
+    prompt_choice AUTH_CHOICE "1"
+  fi
+
   case "$AUTH_CHOICE" in
+    kimi)
+      : # handled above
+      ;;
     1)
       CLAUDE_AUTH_METHOD="subscription"
       info "Using Claude Code Subscription. Run 'claude login' after install."
@@ -500,25 +555,31 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
 
   if [[ "$SETUP_FEISHU" == "true" ]]; then
     FEISHU_BOTS_JSON=$(node -e "
-      console.log(JSON.stringify([{
+      const engine = process.argv[5];
+      const bot = {
         name: process.argv[1],
         feishuAppId: process.argv[2],
         feishuAppSecret: process.argv[3],
-        defaultWorkingDirectory: process.argv[4]
-      }], null, 2))
-    " "$BOT_NAME" "$FEISHU_APP_ID" "$FEISHU_APP_SECRET" "$WORK_DIR")
+        defaultWorkingDirectory: process.argv[4],
+      };
+      if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      console.log(JSON.stringify([bot], null, 2))
+    " "$BOT_NAME" "$FEISHU_APP_ID" "$FEISHU_APP_SECRET" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
 
   if [[ "$SETUP_TELEGRAM" == "true" ]]; then
     TG_NAME="$BOT_NAME"
     [[ "$SETUP_FEISHU" == "true" ]] && TG_NAME="${BOT_NAME}-telegram"
     TELEGRAM_BOTS_JSON=$(node -e "
-      console.log(JSON.stringify([{
+      const engine = process.argv[4];
+      const bot = {
         name: process.argv[1],
         telegramBotToken: process.argv[2],
-        defaultWorkingDirectory: process.argv[3]
-      }], null, 2))
-    " "$TG_NAME" "$TELEGRAM_BOT_TOKEN" "$WORK_DIR")
+        defaultWorkingDirectory: process.argv[3],
+      };
+      if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      console.log(JSON.stringify([bot], null, 2))
+    " "$TG_NAME" "$TELEGRAM_BOT_TOKEN" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
 
   if [[ "$SETUP_WECHAT" == "true" ]]; then
@@ -526,11 +587,14 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     # Append suffix if other platforms are also configured
     [[ "$SETUP_FEISHU" == "true" || "$SETUP_TELEGRAM" == "true" ]] && WX_NAME="${BOT_NAME}-wechat"
     WECHAT_BOTS_JSON=$(node -e "
-      console.log(JSON.stringify([{
+      const engine = process.argv[3];
+      const bot = {
         name: process.argv[1],
-        defaultWorkingDirectory: process.argv[2]
-      }], null, 2))
-    " "$WX_NAME" "$WORK_DIR")
+        defaultWorkingDirectory: process.argv[2],
+      };
+      if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      console.log(JSON.stringify([bot], null, 2))
+    " "$WX_NAME" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
 
   node -e "
@@ -702,10 +766,16 @@ if [[ -n "${DEPLOY_WORK_DIR:-}" ]]; then
     fi
   done
 
-  # Deploy CLAUDE.md to working directory
+  # Deploy CLAUDE.md to working directory (+ AGENTS.md symlink for Kimi engine)
   if [[ -f "$METABOT_HOME/src/workspace/CLAUDE.md" ]]; then
     cp "$METABOT_HOME/src/workspace/CLAUDE.md" "$DEPLOY_WORK_DIR/CLAUDE.md"
     success "Deployed CLAUDE.md → $DEPLOY_WORK_DIR/CLAUDE.md"
+    # Kimi engine reads AGENTS.md not CLAUDE.md — symlink so both engines see the same doc
+    if [[ ! -e "$DEPLOY_WORK_DIR/AGENTS.md" ]]; then
+      (cd "$DEPLOY_WORK_DIR" && ln -s CLAUDE.md AGENTS.md 2>/dev/null) \
+        && success "Linked AGENTS.md → CLAUDE.md (for Kimi engine compatibility)" \
+        || warn "Could not create AGENTS.md symlink"
+    fi
   fi
 else
   warn "Could not determine working directory, skipping workspace deployment"
@@ -1009,6 +1079,7 @@ if [[ "${SKIP_CONFIG}" == "false" ]]; then
   echo -e "  ${BOLD}Working Dir:${NC}    ${WORK_DIR}"
   echo -e "  ${BOLD}API:${NC}            http://localhost:${API_PORT}"
   echo -e "  ${BOLD}API Secret:${NC}     ${API_SECRET:0:8}...${API_SECRET: -4}"
+  echo -e "  ${BOLD}Engine:${NC}         ${BOT_ENGINE:-claude}"
   echo -e "  ${BOLD}Auth Method:${NC}    ${CLAUDE_AUTH_METHOD}"
   if [[ "${CLAUDE_AUTH_METHOD}" == "third_party" ]]; then
     echo -e "  ${BOLD}Provider:${NC}       ${PROVIDER_NAME}"
@@ -1032,6 +1103,10 @@ if [[ "${SKIP_CONFIG}" == "false" ]]; then
   STEP_NUM=1
   if [[ "${CLAUDE_AUTH_METHOD}" == "subscription" ]]; then
     echo "    ${STEP_NUM}. Run 'claude login' in a separate terminal"
+    STEP_NUM=$((STEP_NUM + 1))
+  fi
+  if [[ "${CLAUDE_AUTH_METHOD}" == "kimi" ]]; then
+    echo "    ${STEP_NUM}. Run 'kimi login' in a separate terminal (https://kimi.com to sign up)"
     STEP_NUM=$((STEP_NUM + 1))
   fi
   if [[ "$SETUP_FEISHU" == "true" ]]; then

--- a/src/skills/metaskill/flows/agent.md
+++ b/src/skills/metaskill/flows/agent.md
@@ -126,3 +126,7 @@ Write the complete agent markdown file to the chosen path. The file structure is
 - Make the agent proactive in seeking clarification when requirements are ambiguous.
 
 After writing the file, confirm the file path and briefly explain how to use the new agent (it will be auto-discovered by Claude Code).
+
+### Engine Compatibility Note
+
+`.claude/agents/*.md` files are discovered only by the **Claude engine**. Under the **Kimi engine**, subagent definitions in this directory are not loaded — Kimi only ships with the builtin `default`/`okabe` subagents. If the target bot uses `engine: "kimi"` in `bots.json`, this agent will have no effect; the main session must handle its role inline. Tell the user this when the bot is Kimi-backed.

--- a/src/skills/metaskill/flows/team.md
+++ b/src/skills/metaskill/flows/team.md
@@ -38,6 +38,25 @@ cd <project-folder>
 git init
 ```
 
+### Engine Compatibility (Claude ↔ Kimi)
+
+MetaBot supports two engines: **Claude Code** and **Kimi**. The scaffolded project should be usable by either engine. Key differences you must account for:
+
+| Feature | Claude | Kimi |
+|---------|--------|------|
+| Orchestration doc | `CLAUDE.md` | `AGENTS.md` (symlink `CLAUDE.md` → `AGENTS.md`) |
+| `.claude/skills/` | ✅ auto-discovered | ✅ auto-discovered (brand fallback) |
+| `.claude/agents/*.md` | ✅ auto-discovered | ❌ not loaded (Kimi has only builtin `default`/`okabe`) |
+| MCP config | `.mcp.json` (project-level) | `~/.kimi/mcp.json` (user-level) |
+
+**What to do at the end of Phase 2 (before verification):**
+```bash
+# Create AGENTS.md symlink so Kimi reads the same CLAUDE.md
+[ -f CLAUDE.md ] && [ ! -e AGENTS.md ] && ln -s CLAUDE.md AGENTS.md
+```
+
+Note in the final summary that subagents under `.claude/agents/` only take effect under the Claude engine. Users who run this team on a Kimi-backed bot should expect the orchestrator (CLAUDE.md/AGENTS.md) to do the work inline rather than delegating.
+
 All subsequent paths in Phase 2-4 are **relative to this project folder**. You MUST `cd` into the project folder before creating any files.
 
 ---
@@ -444,6 +463,7 @@ cat .mcp.json | python3 -m json.tool > /dev/null && echo "Valid JSON" || echo "I
 
 ### Files Created
 - CLAUDE.md (orchestration hub — you are the tech lead)
+- AGENTS.md → CLAUDE.md (symlink, so Kimi engine reads the same doc)
 - .mcp.json (MCP server config — auto-discovered by Claude Code)
 - .claude/agents/[specialist-1].md
 - .claude/agents/[specialist-2].md

--- a/src/workspace/CLAUDE.md
+++ b/src/workspace/CLAUDE.md
@@ -1,6 +1,6 @@
 # MetaBot Workspace
 
-This workspace is managed by **MetaBot** — an AI assistant accessible via Feishu/Telegram that runs Claude Code with full tool access.
+This workspace is managed by **MetaBot** — an AI assistant accessible via Feishu/Telegram that runs the Claude Code or Kimi agent engine with full tool access. The bot's engine is configured per-bot in `bots.json` (`engine: "claude" | "kimi"`).
 
 ## Available Skills
 


### PR DESCRIPTION
## Summary
- **install.sh**: New engine selection step (Claude / Kimi). Kimi path installs `uv` + `kimi-cli`, writes `engine: "kimi"` into the generated `bots.json`, and prints `run kimi login` in the final summary. Also symlinks `AGENTS.md → CLAUDE.md` in the deployed workspace so Kimi bots read the same orchestration doc.
- **metaskill**: `team.md` and `agent.md` flows now emit an `AGENTS.md` symlink alongside `CLAUDE.md`, and call out the fact that `.claude/agents/*.md` subagents only load under Claude (Kimi ships only builtin `default`/`okabe`).
- **Docs**: `README.md` / `README_EN.md` get a new "Kimi engine" section distinguishing the native Kimi executor (via `kimi-cli` subscription) from the existing Anthropic-compatible third-party provider flow, with a per-engine feature matrix (subagents, MCP path, workspace doc, permission mode).

This closes out phases 5, 6, 7, 8 and 9 of the Kimi rollout plan. Phases 2-4 (engine abstraction + KimiExecutor + bots.json flag) landed in #200 and #201.

## Test plan
- [x] `npm run build` — passes (web frontend + TypeScript).
- [x] `npm test` — 183/183 tests pass.
- [x] `npm run lint` — 0 errors (3 pre-existing warnings, unchanged).
- [x] `bash -n install.sh` — syntax OK.
- [x] Manual: `bulma` bot flipped to `engine: "kimi"` in `bots.json` with `AGENTS.md → CLAUDE.md` symlink in its workdir; restarted metabot and verified `/status` reports `Engine: kimi` in Feishu.
- [ ] Fresh-install smoke test of `install.sh` Kimi branch on a clean box (deferred — no CI harness for this yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)