### PR TITLE
feat(kimi): engine-aware /model command + multi-bot docs

### DIFF
--- a/docs/configuration/multi-bot.md
+++ b/docs/configuration/multi-bot.md
@@ -37,14 +37,42 @@ Set `BOTS_CONFIG=./bots.json` in `.env` to enable multi-bot mode:
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `name` | Yes | — | Bot identifier |
-| `defaultWorkingDirectory` | Yes | — | Working directory for Claude |
+| `defaultWorkingDirectory` | Yes | — | Working directory for the agent |
+| `engine` | No | `"claude"` | Agent engine — `"claude"` or `"kimi"` |
 | `feishuAppId` / `feishuAppSecret` | Feishu | — | Feishu app credentials |
 | `telegramBotToken` | Telegram | — | Telegram bot token |
 | `maxTurns` | No | unlimited | Max turns per request |
-| `maxBudgetUsd` | No | unlimited | Max cost per request |
-| `model` | No | SDK default | Claude model |
-| `allowedTools` | No | `Read,Edit,Write,Glob,Grep,Bash` | Claude tools whitelist |
+| `maxBudgetUsd` | No | unlimited | Max cost per request (Claude only — Kimi runs on subscription) |
+| `model` | No | SDK default | Default model ID (engine-specific) |
+| `allowedTools` | No | `Read,Edit,Write,Glob,Grep,Bash` | Tool whitelist (Claude only) |
 | `outputsBaseDir` | No | `/tmp/metabot-outputs` | Output files directory |
+| `kimi` | No | — | Kimi-specific options (only when `engine: "kimi"`) — see below |
+
+### Kimi engine options
+
+When `engine: "kimi"`, the `kimi` object configures Kimi CLI behavior:
+
+```json
+{
+  "name": "coding-bot",
+  "engine": "kimi",
+  "feishuAppId": "cli_xxx",
+  "feishuAppSecret": "...",
+  "defaultWorkingDirectory": "/home/user/project",
+  "kimi": {
+    "model": "kimi-for-coding",
+    "thinking": true
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `kimi.model` | `kimi-for-coding` | Kimi model ID |
+| `kimi.thinking` | `false` | Enable thinking mode (shows reasoning tokens) |
+| `kimi.executable` | (auto) | Override path to `kimi` CLI binary |
+
+Kimi requires a one-time `kimi login` (run it in a separate terminal after installing `kimi-cli` via `uv tool install kimi-cli`). Authentication is shared with the Kimi CLI — no API key needed.
 
 ## How It Works
 

--- a/docs/configuration/multi-bot.zh.md
+++ b/docs/configuration/multi-bot.zh.md
@@ -37,14 +37,42 @@
 | 字段 | 必填 | 默认值 | 说明 |
 |------|------|--------|------|
 | `name` | 是 | — | Bot 标识名 |
-| `defaultWorkingDirectory` | 是 | — | Claude 工作目录 |
+| `defaultWorkingDirectory` | 是 | — | Agent 工作目录 |
+| `engine` | 否 | `"claude"` | Agent 引擎 — `"claude"` 或 `"kimi"` |
 | `feishuAppId` / `feishuAppSecret` | 飞书 | — | 飞书应用凭证 |
 | `telegramBotToken` | Telegram | — | Telegram Bot Token |
 | `maxTurns` | 否 | 不限 | 每次请求最大轮次 |
-| `maxBudgetUsd` | 否 | 不限 | 每次请求费用上限 |
-| `model` | 否 | SDK 默认 | Claude 模型 |
-| `allowedTools` | 否 | `Read,Edit,Write,Glob,Grep,Bash` | Claude 工具白名单 |
+| `maxBudgetUsd` | 否 | 不限 | 每次请求费用上限（仅 Claude — Kimi 走订阅） |
+| `model` | 否 | SDK 默认 | 默认模型 ID（引擎相关） |
+| `allowedTools` | 否 | `Read,Edit,Write,Glob,Grep,Bash` | 工具白名单（仅 Claude） |
 | `outputsBaseDir` | 否 | `/tmp/metabot-outputs` | 输出文件目录 |
+| `kimi` | 否 | — | Kimi 专用配置（仅当 `engine: "kimi"` 时） — 见下方 |
+
+### Kimi 引擎选项
+
+当 `engine: "kimi"` 时，`kimi` 对象用于配置 Kimi CLI 行为：
+
+```json
+{
+  "name": "coding-bot",
+  "engine": "kimi",
+  "feishuAppId": "cli_xxx",
+  "feishuAppSecret": "...",
+  "defaultWorkingDirectory": "/home/user/project",
+  "kimi": {
+    "model": "kimi-for-coding",
+    "thinking": true
+  }
+}
+```
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `kimi.model` | `kimi-for-coding` | Kimi 模型 ID |
+| `kimi.thinking` | `false` | 启用思考模式（展示推理过程） |
+| `kimi.executable` | (自动) | 覆盖 `kimi` CLI 二进制路径 |
+
+Kimi 需要先执行一次 `kimi login`（安装 `uv tool install kimi-cli` 后，在另外的终端运行）。授权与 Kimi CLI 共享 — 无需 API Key。
 
 ## 工作原理
 

--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -235,18 +235,25 @@ export class CommandHandler {
 
   private async handleModelCommand(chatId: string, args: string): Promise<void> {
     const session = this.sessionManager.getSession(chatId);
-    const botDefault = this.config.claude.model;
+    const engine = this.config.engine ?? 'claude';
+    const botDefault =
+      engine === 'kimi' ? this.config.kimi?.model : this.config.claude.model;
 
     // No args — show current model
     if (!args) {
       const active = session.model || botDefault || '_default_';
+      const exampleModels =
+        engine === 'kimi'
+          ? '`kimi-for-coding`, `kimi-k2`'
+          : '`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`';
       const lines = [
+        `**Engine:** \`${engine}\``,
         `**Active:** \`${active}\`${session.model ? ' (session override)' : ''}`,
         `**Bot default:** \`${botDefault || '_unset_'}\``,
         '',
         'Usage:',
         '- `/model list` — Show available models',
-        '- `/model <name>` — Set session model (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`)',
+        `- \`/model <name>\` — Set session model (e.g. ${exampleModels})`,
         '- `/model reset` — Clear override, use bot default',
       ];
       await this.sender.sendTextNotice(chatId, '🤖 Model', lines.join('\n'));
@@ -256,7 +263,7 @@ export class CommandHandler {
     // List available models
     if (args.toLowerCase() === 'list' || args.toLowerCase() === 'ls') {
       const active = session.model || botDefault;
-      const models = [
+      const claudeModels = [
         { id: 'claude-opus-4-7', label: 'Opus 4.7', note: 'Most capable · 200k context' },
         { id: 'claude-opus-4-7[1m]', label: 'Opus 4.7 (1M)', note: '1M context window' },
         { id: 'claude-opus-4-6', label: 'Opus 4.6', note: '200k context' },
@@ -265,13 +272,23 @@ export class CommandHandler {
         { id: 'claude-sonnet-4-6[1m]', label: 'Sonnet 4.6 (1M)', note: '1M context window' },
         { id: 'claude-haiku-4-5', label: 'Haiku 4.5', note: 'Fastest · 200k context' },
       ];
-      const lines = ['**Available Claude models:**', ''];
+      const kimiModels = [
+        { id: 'kimi-for-coding', label: 'Kimi for Coding', note: 'Subscription default · 256k context · thinking' },
+        { id: 'kimi-k2', label: 'Kimi K2', note: 'Legacy coding model' },
+      ];
+      const models = engine === 'kimi' ? kimiModels : claudeModels;
+      const header = engine === 'kimi' ? '**Available Kimi models:**' : '**Available Claude models:**';
+      const lines = [header, ''];
       for (const m of models) {
         const marker = m.id === active ? ' ✅' : '';
         lines.push(`- \`${m.id}\` — ${m.label} · ${m.note}${marker}`);
       }
       lines.push('');
-      lines.push('_Tip: append `[1m]` to a model name to enable the 1M context window. Only Opus 4.7/4.6 and Sonnet 4.6 support it._');
+      if (engine === 'claude') {
+        lines.push('_Tip: append `[1m]` to a model name to enable the 1M context window. Only Opus 4.7/4.6 and Sonnet 4.6 support it._');
+      } else {
+        lines.push('_Tip: leave unset to use the kimi-cli default (recommended for subscription users — the server picks the best available)._');
+      }
       lines.push('Use `/model <name>` to switch.');
       await this.sender.sendTextNotice(chatId, '🤖 Available Models', lines.join('\n'));
       return;


### PR DESCRIPTION
## Summary
- **`/model` is now engine-aware.** Kimi bots see Kimi models (`kimi-for-coding`, `kimi-k2`) and the subscription-centric tip; Claude bots see the existing Claude list. The current-model panel also displays the engine so users can tell which one they're talking to.
- **Session model override already works for Kimi** — `options.model` was already plumbed into `createKimiSession()`, so `/model <name>` takes effect on the next message.
- **`docs/configuration/multi-bot.md` (EN + zh)** now document the `engine` field and the nested `kimi.{ model, thinking, executable }` block, and flag `maxBudgetUsd`/`allowedTools` as Claude-only.

## Test plan
- [x] `npm run build` — passes.
- [x] `npm test` — 183/183 pass.
- [x] `npm run lint` — 0 errors (3 pre-existing warnings).
- [x] `/model` on `bulma` (Kimi bot) shows Kimi models and engine label — verified by reading the updated command-handler.ts path; will confirm in Feishu after merge + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)