### PR TITLE
fix(kimi): card thinking text + model/context stats footer

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,8 @@ export interface BotConfigBase {
     model?: string;
     thinking?: boolean;
     apiKey?: string;
+    /** Context window size in tokens (defaults to 262144 — Kimi for Coding default). */
+    contextWindow?: number;
   };
 }
 
@@ -123,6 +125,8 @@ export interface KimiJsonConfig {
   model?: string;
   thinking?: boolean;
   apiKey?: string;
+  /** Context window size in tokens (defaults to 262144 — Kimi for Coding default). */
+  contextWindow?: number;
 }
 
 /** Fields shared across all bot JSON entries (engine selection, Kimi overrides). */

--- a/src/engines/kimi/executor.ts
+++ b/src/engines/kimi/executor.ts
@@ -89,11 +89,16 @@ export class KimiExecutor {
     }
 
     // Local state used when accumulating deltas for the final assistant message
+    const kimiOpts = this.config.kimi ?? {};
     const state: TurnState = {
       sessionId: session.sessionId,
       accumulatedText: '',
       openToolCalls: new Map(),
       startTime: Date.now(),
+      model: session.model ?? options.model ?? kimiOpts.model ?? 'kimi-for-coding',
+      // Kimi for Coding ships with a 256k context window. Override per-bot via
+      // `kimi.contextWindow` in bots.json if you're on a different model.
+      contextWindow: kimiOpts.contextWindow ?? 262144,
     };
 
     const logger = this.logger;
@@ -235,6 +240,13 @@ interface TurnState {
   /** Kimi streams tool arguments across ToolCall + ToolCallPart events. */
   openToolCalls: Map<string, { name: string; argsBuffer: string }>;
   startTime: number;
+  /** Model ID used by the Kimi session (surfaced to the card's stats footer). */
+  model: string;
+  /** Context window size (tokens) — used when emitting modelUsage. */
+  contextWindow: number;
+  /** Last seen StatusUpdate token breakdown (summed into totalTokens). */
+  lastInputTokens?: number;
+  lastOutputTokens?: number;
 }
 
 function translateEvent(event: StreamEvent, state: TurnState, logger: Logger): SDKMessage[] {
@@ -313,7 +325,29 @@ function translateEvent(event: StreamEvent, state: TurnState, logger: Logger): S
     }
 
     case 'StatusUpdate': {
-      // Token usage is tracked but we don't emit until RunResult.
+      // Kimi emits cumulative token usage and context usage on each step.
+      // We cache the latest values so the result message can report them as
+      // modelUsage (which the StreamProcessor reads to populate context/model
+      // stats on the Feishu card).
+      const payload = event.payload as {
+        context_usage?: number | null;
+        token_usage?: {
+          input_other: number;
+          output: number;
+          input_cache_read: number;
+          input_cache_creation: number;
+        } | null;
+      };
+      if (payload.token_usage) {
+        state.lastInputTokens = payload.token_usage.input_other
+          + payload.token_usage.input_cache_read
+          + payload.token_usage.input_cache_creation;
+        state.lastOutputTokens = payload.token_usage.output;
+      } else if (typeof payload.context_usage === 'number') {
+        // Fallback: only a single cumulative number is available.
+        state.lastInputTokens = payload.context_usage;
+        state.lastOutputTokens = 0;
+      }
       return [];
     }
 
@@ -362,6 +396,26 @@ function buildResultMessage(result: RunResult, state: TurnState): SDKMessage {
     : result.status === 'cancelled'
       ? 'error_cancelled'
       : 'error_max_steps';
+
+  // Mimic Claude's `modelUsage` shape so StreamProcessor can extract model,
+  // contextWindow, and totalTokens without any engine-specific branching.
+  // Kimi runs on a subscription — leave costUSD at 0 (the card omits $0).
+  const inputTokens = state.lastInputTokens ?? 0;
+  const outputTokens = state.lastOutputTokens ?? 0;
+  const modelUsage: Record<string, {
+    contextWindow: number;
+    inputTokens: number;
+    outputTokens: number;
+    costUSD: number;
+  }> = {
+    [state.model]: {
+      contextWindow: state.contextWindow,
+      inputTokens,
+      outputTokens,
+      costUSD: 0,
+    },
+  };
+
   return {
     type: 'result',
     subtype,
@@ -370,8 +424,9 @@ function buildResultMessage(result: RunResult, state: TurnState): SDKMessage {
     result: state.accumulatedText,
     is_error: isError,
     num_turns: result.steps,
+    modelUsage,
     // Cost is unknown for Kimi (subscription model, no per-call price emitted).
-    // Leave undefined — the card will omit the cost line.
+    // Leave total_cost_usd undefined — the card will omit the cost line.
   };
 }
 

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -48,7 +48,7 @@ export function buildCard(state: CardState): string {
   } else if (state.status === 'thinking') {
     elements.push({
       tag: 'markdown',
-      content: '_Claude is thinking..._',
+      content: '_Thinking..._',
     });
   }
 
@@ -111,7 +111,8 @@ export function buildCard(state: CardState): string {
         parts.push(`$${state.sessionCostUsd.toFixed(2)}`);
       }
       if (state.model) {
-        parts.push(state.model.replace(/^claude-/, ''));
+        // Strip common vendor prefixes to keep the badge short
+        parts.push(state.model.replace(/^(claude-|kimi-)/, ''));
       }
       if (state.durationMs !== undefined) {
         parts.push(`${(state.durationMs / 1000).toFixed(1)}s`);

--- a/src/telegram/telegram-sender.ts
+++ b/src/telegram/telegram-sender.ts
@@ -52,7 +52,7 @@ function renderCardHtml(state: CardState): string {
   if (state.responseText) {
     parts.push(markdownToTelegramHtml(state.responseText));
   } else if (state.status === 'thinking') {
-    parts.push('<i>Claude is thinking...</i>');
+    parts.push('<i>Thinking...</i>');
   }
 
   // Pending question

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -13,7 +13,7 @@ describe('buildCard', () => {
     const json = JSON.parse(buildCard(state));
     expect(json.header.template).toBe('blue');
     expect(json.header.title.content).toContain('Thinking');
-    expect(json.elements.some((e: any) => e.tag === 'markdown' && e.content.includes('thinking'))).toBe(true);
+    expect(json.elements.some((e: any) => e.tag === 'markdown' && /thinking/i.test(e.content))).toBe(true);
   });
 
   it('builds running card with tool calls', () => {


### PR DESCRIPTION
## Summary

Fixes two visible bugs on Kimi-backed Feishu bots, reported by live test on \`bulma\`:

1. **\"Claude is thinking...\" hardcoded** in both Feishu \`card-builder.ts\` and \`telegram-sender.ts\`. Replaced with engine-neutral \`Thinking...\`.

2. **Kimi cards never show model name or context usage.** The synthesized result message from \`KimiExecutor\` didn't carry a Claude-shaped \`modelUsage\` map, so \`StreamProcessor\` couldn't populate \`_model\`/\`_totalTokens\`/\`_contextWindow\`. Fixed by:
   - Tracking \`session.model\` + latest \`StatusUpdate\` token breakdown (input_other + cache_read + cache_creation + output) in \`TurnState\`.
   - Emitting \`modelUsage: { [model]: { contextWindow, inputTokens, outputTokens, costUSD: 0 } }\` in the result message.
   - Default context window 262144 (Kimi for Coding), overridable per-bot via new \`kimi.contextWindow\` field.
   - Card-builder now also strips the \`kimi-\` prefix on the model badge (same treatment as \`claude-\`).

## Test plan

- [x] \`npm run build\` — passes.
- [x] \`npm test\` — 183/183 pass (one card-builder thinking assertion relaxed to case-insensitive).
- [x] \`npm run lint\` — 0 errors.
- [ ] Post-merge: restart metabot, send a message to bulma, verify footer shows \`ctx: X/256k (Y%) | for-coding | Ns\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)