### PR TITLE
fix(kimi): keep full model name in card footer

### DIFF
--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -111,8 +111,9 @@ export function buildCard(state: CardState): string {
         parts.push(`$${state.sessionCostUsd.toFixed(2)}`);
       }
       if (state.model) {
-        // Strip common vendor prefixes to keep the badge short
-        parts.push(state.model.replace(/^(claude-|kimi-)/, ''));
+        // Strip the claude- prefix (claude-opus-4-7 → opus-4-7) but keep the
+        // full Kimi model name since e.g. `for-coding` loses too much context.
+        parts.push(state.model.replace(/^claude-/, ''));
       }
       if (state.durationMs !== undefined) {
         parts.push(`${(state.durationMs / 1000).toFixed(1)}s`);


### PR DESCRIPTION
## Summary
Stripping \`kimi-\` left \`kimi-for-coding\` rendering as \`for-coding\` in the card stats footer, which is confusing. Revert to stripping only \`claude-\` so the full Kimi model name survives.

## Test plan
- [x] \`npm test\` — 183/183 pass.
- [x] \`npm run build\` — clean.
- [ ] Post-merge: restart metabot, send message to bulma, footer shows \`kimi-for-coding\` (not \`for-coding\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)