### PR TITLE
fix(docs): restore gh-pages deploy (pin mkdocs-material 9.x + swap i18n default to en)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           python-version: '3.x'
 
-      - run: pip install mkdocs-material mkdocs-static-i18n
+      # Pin mkdocs-material to the 9.x line — 2.0 removed the plugin system
+      # and has no migration path. mkdocs-static-i18n is pinned against
+      # its latest 1.x which requires the default locale to own unsuffixed files.
+      - run: pip install 'mkdocs-material>=9,<10' 'mkdocs-static-i18n>=1.3,<2'
 
       - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,103 +50,105 @@ markdown_extensions:
 plugins:
   - search
   - i18n:
-      default_language: zh
+      # Files with no language suffix (index.md, about.md, …) are English —
+      # set en as the default locale to match that convention. Chinese
+      # translations use the `.zh.md` suffix and override per file.
       languages:
-        - locale: zh
-          default: true
-          name: 中文
-          build: true
         - locale: en
+          default: true
           name: English
           build: true
+        - locale: zh
+          name: 中文
+          build: true
           nav:
-            - Home: index.md
-            - Getting Started:
-              - Installation: getting-started/installation.md
-              - Quick Setup: getting-started/quick-setup.md
-              - Feishu App Setup: getting-started/feishu-app-setup.md
-            - Concepts:
-              - Architecture: concepts/architecture.md
-              - Session Isolation: concepts/session-isolation.md
-              - Security: concepts/security.md
-            - Features:
+            - 首页: index.md
+            - 快速开始:
+              - 安装: getting-started/installation.md
+              - 快速配置: getting-started/quick-setup.md
+              - 飞书应用配置: getting-started/feishu-app-setup.md
+            - 核心概念:
+              - 架构: concepts/architecture.md
+              - 会话隔离: concepts/session-isolation.md
+              - 安全: concepts/security.md
+            - 功能:
               - MetaSkill: features/metaskill.md
               - MetaMemory: features/metamemory.md
               - Web UI: features/web-ui.md
-              - Peers Federation: features/peers.md
-              - Task Scheduler: features/scheduler.md
-              - Wiki Sync: features/wiki-sync.md
-              - WeChat: features/wechat.md
-              - Voice Assistant: features/voice-jarvis.md
-              - Output Files: features/outputs.md
-            - Configuration:
-              - Environment Variables: configuration/environment-variables.md
-              - Multi-Bot Mode: configuration/multi-bot.md
-            - Usage:
-              - Chat Commands: usage/chat-commands.md
-              - Example Prompts: usage/example-prompts.md
-              - Use Cases: usage/use-cases.md
-            - Reference:
+              - Peers 联邦: features/peers.md
+              - 任务调度: features/scheduler.md
+              - Wiki 同步: features/wiki-sync.md
+              - 微信接入: features/wechat.md
+              - 语音助手: features/voice-jarvis.md
+              - 输出文件: features/outputs.md
+            - 配置:
+              - 环境变量: configuration/environment-variables.md
+              - 多 Bot 模式: configuration/multi-bot.md
+            - 使用:
+              - 聊天命令: usage/chat-commands.md
+              - 示例提示词: usage/example-prompts.md
+              - 使用场景: usage/use-cases.md
+            - 参考:
               - REST API: reference/api.md
               - mb CLI (Agent Bus): reference/cli-mb.md
               - mm CLI (MetaMemory): reference/cli-mm.md
               - metabot CLI: reference/cli-metabot.md
-            - Deployment:
-              - Production: deployment/production.md
-            - Development:
-              - Contributing: development/contributing.md
-              - Project Structure: development/project-structure.md
-            - Troubleshooting: troubleshooting.md
-            - About: about.md
+            - 部署:
+              - 生产部署: deployment/production.md
+            - 开发:
+              - 贡献指南: development/contributing.md
+              - 项目结构: development/project-structure.md
+            - 故障排除: troubleshooting.md
+            - 关于: about.md
 
 extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/xvirobotics/metabot
   alternate:
-    - name: 中文
-      link: /metabot/
-      lang: zh
     - name: English
-      link: /metabot/en/
+      link: /metabot/
       lang: en
+    - name: 中文
+      link: /metabot/zh/
+      lang: zh
 
 nav:
-  - 首页: index.md
-  - 快速开始:
-    - 安装: getting-started/installation.md
-    - 快速配置: getting-started/quick-setup.md
-    - 飞书应用配置: getting-started/feishu-app-setup.md
-  - 核心概念:
-    - 架构: concepts/architecture.md
-    - 会话隔离: concepts/session-isolation.md
-    - 安全: concepts/security.md
-  - 功能:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Quick Setup: getting-started/quick-setup.md
+    - Feishu App Setup: getting-started/feishu-app-setup.md
+  - Concepts:
+    - Architecture: concepts/architecture.md
+    - Session Isolation: concepts/session-isolation.md
+    - Security: concepts/security.md
+  - Features:
     - MetaSkill: features/metaskill.md
     - MetaMemory: features/metamemory.md
     - Web UI: features/web-ui.md
-    - Peers 联邦: features/peers.md
-    - 任务调度: features/scheduler.md
-    - Wiki 同步: features/wiki-sync.md
-    - 微信接入: features/wechat.md
-    - 语音助手: features/voice-jarvis.md
-    - 输出文件: features/outputs.md
-  - 配置:
-    - 环境变量: configuration/environment-variables.md
-    - 多 Bot 模式: configuration/multi-bot.md
-  - 使用:
-    - 聊天命令: usage/chat-commands.md
-    - 示例提示词: usage/example-prompts.md
-    - 使用场景: usage/use-cases.md
-  - 参考:
+    - Peers Federation: features/peers.md
+    - Task Scheduler: features/scheduler.md
+    - Wiki Sync: features/wiki-sync.md
+    - WeChat: features/wechat.md
+    - Voice Assistant: features/voice-jarvis.md
+    - Output Files: features/outputs.md
+  - Configuration:
+    - Environment Variables: configuration/environment-variables.md
+    - Multi-Bot Mode: configuration/multi-bot.md
+  - Usage:
+    - Chat Commands: usage/chat-commands.md
+    - Example Prompts: usage/example-prompts.md
+    - Use Cases: usage/use-cases.md
+  - Reference:
     - REST API: reference/api.md
     - mb CLI (Agent Bus): reference/cli-mb.md
     - mm CLI (MetaMemory): reference/cli-mm.md
     - metabot CLI: reference/cli-metabot.md
-  - 部署:
-    - 生产部署: deployment/production.md
-  - 开发:
-    - 贡献指南: development/contributing.md
-    - 项目结构: development/project-structure.md
-  - 故障排除: troubleshooting.md
-  - 关于: about.md
+  - Deployment:
+    - Production: deployment/production.md
+  - Development:
+    - Contributing: development/contributing.md
+    - Project Structure: development/project-structure.md
+  - Troubleshooting: troubleshooting.md
+  - About: about.md


### PR DESCRIPTION
## Context

You asked me to bring the \`gh-pages\` docs up to date. Investigation: \`gh-pages\` is **not** a separate source branch — it's the built HTML artifact that MkDocs pushes via the \`Docs\` GitHub Action. The **source** lives in \`docs/\` on main. Problem: that Action has been **failing on every push since 2026-03-29**, so the new dual-engine content from PR #206 never reached the live site. This PR unblocks the deploy.

## Two compounding failures

### 1. \`mkdocs-material\` 2.0 broke everything

\`pip install mkdocs-material\` started resolving to the just-released 2.0, which removed the plugin system. Build fails before it reads config. **Fix**: pin \`mkdocs-material>=9,<10\` and \`mkdocs-static-i18n>=1.3,<2\` in the workflow.

### 2. \`mkdocs-static-i18n\` 1.x refuses conflicting-locale files

Our config declared \`default_language: zh\`, but our files use English-without-suffix + \`.zh.md\` for Chinese. The plugin sees \`about.md\` (no suffix → defaults to zh) AND \`about.zh.md\` (explicit zh) both mapping to the same zh URL and errors out:

\`\`\`
Exception: Conflicting files for the default language 'zh':
choose either 'about.md' or 'about.md' but not both
\`\`\`

**Fix**: flip the config to match the actual file naming — drop the deprecated \`default_language:\` key, move \`default: true\` from zh to en, swap the two \`nav:\` blocks (default English at the top, Chinese override inside the plugin entry).

**URL shape changes**: from \`/metabot/\` (zh) + \`/metabot/en/\` (en) to \`/metabot/\` (en) + \`/metabot/zh/\` (zh) — this also matches the new English-first README.

## Test plan
- [x] \`pip install 'mkdocs-material>=9,<10' 'mkdocs-static-i18n>=1.3,<2' && mkdocs build\` — succeeds locally.
- [x] \`grep -c \"Dual Engine\\|双引擎\\|Kimi Code\" site/index.html site/zh/index.html\` → 8 matches in each, so PR #206's dual-engine content is present.
- [ ] Post-merge: Docs workflow turns green, https://xvirobotics.com/metabot/ serves the new content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)