### PR TITLE
feat(model): /model claude | /model kimi — per-chat engine switching

### DIFF
--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -43,7 +43,9 @@ export class CommandHandler {
           '`/reset` - Clear session, start fresh',
           '`/stop` - Abort current running task',
           '`/status` - Show current session info',
-          '`/model` - Show current model; `/model list` - Available models; `/model <name>` - Switch',
+          '`/model` - Show current engine/model; `/model list` - Available options',
+          '`/model claude` or `/model kimi` - Switch engine (resets session)',
+          '`/model <name>` - Set model for current engine',
           '`/memory` - Memory document commands',
           '`/help` - Show this help message',
           '',
@@ -82,14 +84,15 @@ export class CommandHandler {
       case '/status': {
         const session = this.sessionManager.getSession(chatId);
         const isRunning = !!this.getRunningTask(chatId);
-        const engine = this.config.engine ?? 'claude';
-        const defaultModel = engine === 'kimi'
+        const botEngine = this.config.engine ?? 'claude';
+        const activeEngine = session.engine ?? botEngine;
+        const defaultModel = activeEngine === 'kimi'
           ? (this.config.kimi?.model || '_default_')
           : (this.config.claude.model || '_default_');
         const activeModel = session.model || defaultModel;
         await this.sender.sendTextNotice(chatId, '📊 Status', [
           `**User:** \`${userId}\``,
-          `**Engine:** \`${engine}\``,
+          `**Engine:** \`${activeEngine}\`${session.engine ? ' (session override)' : ''}`,
           `**Working Directory:** \`${session.workingDirectory}\``,
           `**Session:** ${session.sessionId ? `\`${session.sessionId.slice(0, 8)}...\`` : '_None_'}`,
           `**Model:** \`${activeModel}\`${session.model ? ' (session override)' : ''}`,
@@ -235,33 +238,65 @@ export class CommandHandler {
 
   private async handleModelCommand(chatId: string, args: string): Promise<void> {
     const session = this.sessionManager.getSession(chatId);
-    const engine = this.config.engine ?? 'claude';
+    const botEngine = this.config.engine ?? 'claude';
+    const activeEngine = session.engine ?? botEngine;
     const botDefault =
-      engine === 'kimi' ? this.config.kimi?.model : this.config.claude.model;
+      activeEngine === 'kimi' ? this.config.kimi?.model : this.config.claude.model;
 
     // No args — show current model
     if (!args) {
       const active = session.model || botDefault || '_default_';
       const exampleModels =
-        engine === 'kimi'
+        activeEngine === 'kimi'
           ? '`kimi-for-coding`, `kimi-k2`'
           : '`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`';
       const lines = [
-        `**Engine:** \`${engine}\``,
+        `**Engine:** \`${activeEngine}\`${session.engine ? ' (session override)' : ''}`,
         `**Active:** \`${active}\`${session.model ? ' (session override)' : ''}`,
         `**Bot default:** \`${botDefault || '_unset_'}\``,
         '',
         'Usage:',
-        '- `/model list` — Show available models',
+        '- `/model list` — Show available engines + models',
+        '- `/model claude` or `/model kimi` — Switch engine (resets session)',
         `- \`/model <name>\` — Set session model (e.g. ${exampleModels})`,
-        '- `/model reset` — Clear override, use bot default',
+        '- `/model reset` — Clear overrides, use bot defaults',
       ];
       await this.sender.sendTextNotice(chatId, '🤖 Model', lines.join('\n'));
       return;
     }
 
+    const normalized = args.toLowerCase();
+
+    // Engine switch — /model claude or /model kimi
+    if (normalized === 'claude' || normalized === 'kimi') {
+      if (activeEngine === normalized) {
+        await this.sender.sendTextNotice(
+          chatId,
+          'ℹ️ Already using ' + normalized,
+          `This chat is already on the \`${normalized}\` engine.`,
+          'blue',
+        );
+        return;
+      }
+      this.sessionManager.setSessionEngine(chatId, normalized);
+      await this.sender.sendTextNotice(
+        chatId,
+        `✅ Engine switched to ${normalized}`,
+        [
+          `Next message will run on the **${normalized}** engine.`,
+          '',
+          '_Session ID and model override cleared — a fresh conversation starts on the next turn._',
+          normalized === 'kimi'
+            ? '_Make sure `kimi login` has been completed on this host._'
+            : '_Make sure Claude Code is authenticated (`claude login`)._',
+        ].join('\n'),
+        'green',
+      );
+      return;
+    }
+
     // List available models
-    if (args.toLowerCase() === 'list' || args.toLowerCase() === 'ls') {
+    if (normalized === 'list' || normalized === 'ls') {
       const active = session.model || botDefault;
       const claudeModels = [
         { id: 'claude-opus-4-7', label: 'Opus 4.7', note: 'Most capable · 200k context' },
@@ -276,32 +311,40 @@ export class CommandHandler {
         { id: 'kimi-for-coding', label: 'Kimi for Coding', note: 'Subscription default · 256k context · thinking' },
         { id: 'kimi-k2', label: 'Kimi K2', note: 'Legacy coding model' },
       ];
-      const models = engine === 'kimi' ? kimiModels : claudeModels;
-      const header = engine === 'kimi' ? '**Available Kimi models:**' : '**Available Claude models:**';
-      const lines = [header, ''];
+      const models = activeEngine === 'kimi' ? kimiModels : claudeModels;
+      const header = activeEngine === 'kimi' ? '**Available Kimi models:**' : '**Available Claude models:**';
+      const lines = [
+        `**Current engine:** \`${activeEngine}\`${session.engine ? ' (session override)' : ''}`,
+        '',
+        '**Engines:** `/model claude` or `/model kimi` to switch.',
+        '',
+        header,
+        '',
+      ];
       for (const m of models) {
         const marker = m.id === active ? ' ✅' : '';
         lines.push(`- \`${m.id}\` — ${m.label} · ${m.note}${marker}`);
       }
       lines.push('');
-      if (engine === 'claude') {
+      if (activeEngine === 'claude') {
         lines.push('_Tip: append `[1m]` to a model name to enable the 1M context window. Only Opus 4.7/4.6 and Sonnet 4.6 support it._');
       } else {
         lines.push('_Tip: leave unset to use the kimi-cli default (recommended for subscription users — the server picks the best available)._');
       }
-      lines.push('Use `/model <name>` to switch.');
+      lines.push('Use `/model <name>` to set the model for the current engine.');
       await this.sender.sendTextNotice(chatId, '🤖 Available Models', lines.join('\n'));
       return;
     }
 
-    // Reset — clear the override
-    if (args.toLowerCase() === 'reset' || args.toLowerCase() === 'clear' || args.toLowerCase() === 'default') {
+    // Reset — clear overrides (both engine AND model)
+    if (normalized === 'reset' || normalized === 'clear' || normalized === 'default') {
       this.sessionManager.setSessionModel(chatId, undefined);
+      this.sessionManager.setSessionEngine(chatId, undefined);
       const fallback = botDefault || '_default_';
       await this.sender.sendTextNotice(
         chatId,
-        '✅ Model Reset',
-        `Session override cleared. Using bot default: \`${fallback}\``,
+        '✅ Overrides Cleared',
+        `Session engine and model overrides cleared. Using bot defaults: engine \`${botEngine}\`, model \`${fallback}\`.`,
         'green',
       );
       return;
@@ -313,7 +356,7 @@ export class CommandHandler {
     await this.sender.sendTextNotice(
       chatId,
       '✅ Model Set',
-      `Session model set to \`${newModel}\`. It will take effect on the next message.`,
+      `Session model set to \`${newModel}\` on engine \`${activeEngine}\`. It will take effect on the next message.`,
       'green',
     );
   }

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -6,8 +6,8 @@ import type { Logger } from '../utils/logger.js';
 import type { IncomingMessage, CardState, PendingQuestion } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
 import type { DocSync } from '../sync/doc-sync.js';
-import type { Engine, Executor, ExecutionHandle } from '../engines/index.js';
-import { createEngine, StreamProcessor, SessionManager } from '../engines/index.js';
+import type { Engine, Executor, ExecutionHandle, EngineName } from '../engines/index.js';
+import { createEngine, resolveEngineName, StreamProcessor, SessionManager } from '../engines/index.js';
 import { RateLimiter } from './rate-limiter.js';
 import { OutputsManager } from './outputs-manager.js';
 import { MemoryClient } from '../memory/memory-client.js';
@@ -99,6 +99,8 @@ export interface ActivityEventData {
 export class MessageBridge {
   private engine: Engine;
   private executor: Executor;
+  /** Lazy per-engine cache so a session override doesn't pay instantiation cost each turn. */
+  private engineCache = new Map<EngineName, { engine: Engine; executor: Executor }>();
   private sessionManager: SessionManager;
   private outputsManager: OutputsManager;
   private audit: AuditLogger;
@@ -121,6 +123,8 @@ export class MessageBridge {
   ) {
     this.engine = createEngine(config, logger);
     this.executor = this.engine.createExecutor();
+    const defaultEngineName = resolveEngineName(config);
+    this.engineCache.set(defaultEngineName, { engine: this.engine, executor: this.executor });
     this.sessionManager = new SessionManager(config.claude.defaultWorkingDirectory, logger, config.name);
     this.outputsManager = new OutputsManager(config.claude.outputsBaseDir, logger);
     this.audit = new AuditLogger(logger);
@@ -140,6 +144,26 @@ export class MessageBridge {
   /** Emit an activity event if a listener is registered. */
   private emitActivity(event: ActivityEventData): void {
     try { this.onActivityEvent?.(event); } catch { /* ignore */ }
+  }
+
+  /**
+   * Pick the executor for a chat based on its session engine override
+   * (set via `/model claude` or `/model kimi`), falling back to the bot's
+   * configured engine. Executors are cached per-engine so repeated turns
+   * on the same engine don't re-instantiate the SDK wrapper.
+   */
+  private executorForChat(chatId: string): Executor {
+    const session = this.sessionManager.getSession(chatId);
+    const name: EngineName = session.engine ?? resolveEngineName(this.config);
+    let entry = this.engineCache.get(name);
+    if (!entry) {
+      const engine = createEngine(this.config, this.logger, name);
+      const executor = engine.createExecutor();
+      entry = { engine, executor };
+      this.engineCache.set(name, entry);
+      this.logger.info({ engine: name, chatId }, 'Instantiated engine on demand for session override');
+    }
+    return entry.executor;
   }
 
   /** Inject the doc sync service for /sync commands. */
@@ -650,7 +674,7 @@ export class MessageBridge {
     const apiContext = { botName: this.config.name, chatId };
 
     // Start multi-turn execution
-    const executionHandle = this.executor.startExecution({
+    const executionHandle = this.executorForChat(chatId).startExecution({
       prompt,
       cwd,
       sessionId: session.sessionId,
@@ -822,7 +846,7 @@ export class MessageBridge {
         await this.sender.updateCard(messageId, { ...lastState, responseText: '_Session expired, retrying..._' });
 
         // Retry execution without sessionId
-        const retryHandle = this.executor.startExecution({
+        const retryHandle = this.executorForChat(chatId).startExecution({
           prompt, cwd, sessionId: undefined, abortController, outputsDir, apiContext, model: session.model,
         });
         executionHandle.finish();
@@ -848,7 +872,7 @@ export class MessageBridge {
         lastState = { ...lastState, status: 'running', errorMessage: undefined };
         await this.sender.updateCard(messageId, { ...lastState, responseText: '_Context limit reached, starting fresh session..._' });
 
-        const retryHandle = this.executor.startExecution({
+        const retryHandle = this.executorForChat(chatId).startExecution({
           prompt, cwd, sessionId: undefined, abortController, outputsDir, apiContext, model: session.model,
         });
         executionHandle.finish();
@@ -914,7 +938,7 @@ export class MessageBridge {
         await this.sender.updateCard(messageId, { ...lastState, status: 'running', responseText: retryMsg });
 
         try {
-          const retryHandle = this.executor.startExecution({
+          const retryHandle = this.executorForChat(chatId).startExecution({
             prompt, cwd, sessionId: undefined, abortController, outputsDir, apiContext, model: session.model,
           });
           executionHandle.finish();
@@ -1043,7 +1067,7 @@ export class MessageBridge {
 
     const apiContext = { botName: this.config.name, chatId, groupMembers: options.groupMembers, groupId: options.groupId };
 
-    const executionHandle = this.executor.startExecution({
+    const executionHandle = this.executorForChat(chatId).startExecution({
       prompt,
       cwd,
       sessionId: session.sessionId,
@@ -1187,7 +1211,7 @@ export class MessageBridge {
           await this.sender.updateCard(messageId, { ...lastState, status: 'running', responseText: retryMsg });
         }
 
-        const retryHandle = this.executor.startExecution({
+        const retryHandle = this.executorForChat(chatId).startExecution({
           prompt, cwd, sessionId: undefined, abortController, outputsDir, apiContext, model: options.model ?? session.model,
         });
         executionHandle.finish();
@@ -1265,7 +1289,7 @@ export class MessageBridge {
         }
 
         try {
-          const retryHandle = this.executor.startExecution({
+          const retryHandle = this.executorForChat(chatId).startExecution({
             prompt, cwd, sessionId: undefined, abortController, outputsDir, apiContext, model: options.model ?? session.model,
           });
           executionHandle.finish();

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import type { Logger } from '../../utils/logger.js';
+import type { EngineName } from '../types.js';
 
 export interface UserSession {
   sessionId: string | undefined;
@@ -15,6 +16,8 @@ export interface UserSession {
   cumulativeDurationMs: number;
   /** Per-session model override (e.g. "claude-opus-4-7"). Falls back to bot default when undefined. */
   model?: string;
+  /** Per-session engine override ("claude" | "kimi"). Falls back to bot default when undefined. */
+  engine?: EngineName;
 }
 
 interface PersistedSession {
@@ -25,6 +28,7 @@ interface PersistedSession {
   cumulativeCostUsd?: number;
   cumulativeDurationMs?: number;
   model?: string;
+  engine?: EngineName;
 }
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -103,6 +107,22 @@ export class SessionManager {
     this.saveToDisk();
   }
 
+  /**
+   * Set per-session engine override. Pass undefined to clear and fall back
+   * to the bot's configured engine. Switching engines also clears the prior
+   * `sessionId` (engines track conversation state in different stores) and
+   * any stale model override, so the next turn starts a fresh session.
+   */
+  setSessionEngine(chatId: string, engine: EngineName | undefined): void {
+    const session = this.getSession(chatId);
+    if (session.engine === engine) return;
+    session.engine = engine;
+    session.sessionId = undefined;
+    session.model = undefined;
+    this.logger.info({ chatId, engine }, 'Session engine override updated (session reset)');
+    this.saveToDisk();
+  }
+
   /** Accumulate token/cost/duration from a completed query into the session totals. */
   addUsage(chatId: string, tokens: number, costUsd: number, durationMs: number): void {
     const session = this.getSession(chatId);
@@ -144,8 +164,8 @@ export class SessionManager {
     try {
       const data: Record<string, PersistedSession> = {};
       for (const [chatId, session] of this.sessions) {
-        // Persist sessions that have either a sessionId or a model override
-        if (session.sessionId || session.model) {
+        // Persist sessions that have a sessionId, model, or engine override
+        if (session.sessionId || session.model || session.engine) {
           data[chatId] = {
             sessionId: session.sessionId || '',
             workingDirectory: session.workingDirectory,
@@ -154,6 +174,7 @@ export class SessionManager {
             cumulativeCostUsd: session.cumulativeCostUsd,
             cumulativeDurationMs: session.cumulativeDurationMs,
             model: session.model,
+            engine: session.engine,
           };
         }
       }
@@ -181,6 +202,7 @@ export class SessionManager {
           cumulativeCostUsd: persisted.cumulativeCostUsd ?? 0,
           cumulativeDurationMs: persisted.cumulativeDurationMs ?? 0,
           model: persisted.model,
+          engine: persisted.engine,
         });
         loaded++;
       }

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -12,8 +12,12 @@ import { KimiEngine } from './kimi/index.js';
  *   2. `METABOT_ENGINE` env var (global default)
  *   3. `'claude'` (fallback)
  */
-export function createEngine(config: BotConfigBase, logger: Logger): Engine {
-  const name = resolveEngineName(config);
+export function createEngine(
+  config: BotConfigBase,
+  logger: Logger,
+  override?: EngineName,
+): Engine {
+  const name = override ?? resolveEngineName(config);
   switch (name) {
     case 'claude':
       return new ClaudeEngine(config, logger);
@@ -26,7 +30,8 @@ export function createEngine(config: BotConfigBase, logger: Logger): Engine {
   }
 }
 
-function resolveEngineName(config: BotConfigBase): EngineName {
+/** Resolve the default engine for a bot config (no session override). */
+export function resolveEngineName(config: BotConfigBase): EngineName {
   const explicit = config.engine;
   if (explicit) return explicit;
   const envDefault = process.env.METABOT_ENGINE as EngineName | undefined;


### PR DESCRIPTION
## Summary

You asked: *\"can /model switch between kimi and claude?\"*. Yes — this PR wires it up so you can flip engines per chat at runtime, no restart or config edit needed.

## What works now

- \`/model claude\` / \`/model kimi\` — switches the engine for this chat on the next turn, resets session ID + model override (engine state doesn't cross over), and hints at the required login.
- \`/model\` — the current-view now shows whether the active engine is a session override.
- \`/model list\` — lists both engines + the catalogue for the currently-active engine.
- \`/model reset\` — clears both engine and model overrides.
- \`/status\` + \`/help\` — updated to mention the new sub-commands.

## Implementation

- \`UserSession\` gains \`engine?: EngineName\`, persisted next to \`model?\`.
- \`SessionManager.setSessionEngine()\` also clears \`sessionId\` + \`model\` since engine-level state (session IDs, model ids) doesn't port.
- \`MessageBridge\` holds a lazy \`Map<EngineName, { engine, executor }>\`; \`executorForChat(chatId)\` routes each turn by \`session.engine ?? resolveEngineName(config)\`. Default engine is pre-populated in the constructor so non-override sessions pay nothing extra.
- \`resolveEngineName\` is now exported from \`src/engines/index.ts\` so the bridge shares the same config → env → claude fallback chain.
- All 7 \`this.executor.startExecution(...)\` call sites in \`message-bridge.ts\` switched to \`this.executorForChat(chatId).startExecution(...)\`.

## Test plan

- [x] \`npm run build\` — passes.
- [x] \`npm test\` — 183/183 pass.
- [x] \`npm run lint\` — 0 errors (3 pre-existing warnings).
- [ ] Post-merge on running metabot: \`/model kimi\` on a Claude-backed chat, send a message, \`/status\` shows \`Engine: kimi (session override)\` and footer shows \`Kimi-k2.6\`. \`/model reset\` flips back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)