### PR TITLE
docs: redesigned README header — centered + badge rows for engines/platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
-# MetaBot
+<div align="center">
 
-**在飞书 / Telegram / 微信上用手机控制 Claude Code 或 Kimi Code — 写代码、管 Agent、自动化一切。**
+# 🤖 MetaBot
 
-[![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
-[![GitHub stars](https://img.shields.io/github/stars/xvirobotics/metabot?style=flat-square)](https://github.com/xvirobotics/metabot)
+### 在飞书 / Telegram / 微信上用手机控制 Claude Code 或 Kimi Code
 
-中文 | [English](README_EN.md) | [文档站](https://xvirobotics.com/metabot/zh/)
+*写代码 · 管 Agent · 自动化一切*
+
+<p>
+  <a href="https://github.com/xvirobotics/metabot/actions"><img src="https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=for-the-badge&label=CI&logo=github" alt="CI"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="License"></a>
+  <a href="https://github.com/xvirobotics/metabot"><img src="https://img.shields.io/github/stars/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Stars"></a>
+  <a href="https://github.com/xvirobotics/metabot/network/members"><img src="https://img.shields.io/github/forks/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Forks"></a>
+</p>
+
+<p>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
+  <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
+  <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
+  <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
+</p>
+
+<p>
+  <a href="https://feishu.cn"><img src="https://img.shields.io/badge/飞书_/_Lark-00D6B9?style=for-the-badge&logo=lark&logoColor=white" alt="Feishu/Lark"></a>
+  <a href="https://telegram.org"><img src="https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram"></a>
+  <a href="https://ilinkai.weixin.qq.com"><img src="https://img.shields.io/badge/微信_ClawBot-07C160?style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <img src="https://img.shields.io/badge/Web_UI-61DAFB?style=for-the-badge&logo=react&logoColor=white" alt="Web UI">
+</p>
+
+**中文** · [English](README_EN.md) · [📚 文档站](https://xvirobotics.com/metabot/zh/)
+
+</div>
 
 > 支持 **Claude Code** 和 **Kimi Code** 双引擎 — 两家原生订阅都能直接用，无需 API Key。每个 Bot 可独立选引擎。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,12 +1,35 @@
-# MetaBot
+<div align="center">
 
-**Control Claude Code or Kimi Code from your phone via Feishu / Telegram / WeChat — write code, manage agents, automate everything.**
+# 🤖 MetaBot
 
-[![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
-[![GitHub stars](https://img.shields.io/github/stars/xvirobotics/metabot?style=flat-square)](https://github.com/xvirobotics/metabot)
+### Control Claude Code or Kimi Code from your phone via Feishu / Telegram / WeChat
 
-[中文](README.md) | English | [Docs](https://xvirobotics.com/metabot/)
+*Write code · Manage agents · Automate everything*
+
+<p>
+  <a href="https://github.com/xvirobotics/metabot/actions"><img src="https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=for-the-badge&label=CI&logo=github" alt="CI"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="License"></a>
+  <a href="https://github.com/xvirobotics/metabot"><img src="https://img.shields.io/github/stars/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Stars"></a>
+  <a href="https://github.com/xvirobotics/metabot/network/members"><img src="https://img.shields.io/github/forks/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Forks"></a>
+</p>
+
+<p>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
+  <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
+  <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
+  <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
+</p>
+
+<p>
+  <a href="https://feishu.cn"><img src="https://img.shields.io/badge/Feishu_/_Lark-00D6B9?style=for-the-badge&logo=lark&logoColor=white" alt="Feishu/Lark"></a>
+  <a href="https://telegram.org"><img src="https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram"></a>
+  <a href="https://ilinkai.weixin.qq.com"><img src="https://img.shields.io/badge/WeChat_ClawBot-07C160?style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <img src="https://img.shields.io/badge/Web_UI-61DAFB?style=for-the-badge&logo=react&logoColor=white" alt="Web UI">
+</p>
+
+[中文](README.md) · **English** · [📚 Docs](https://xvirobotics.com/metabot/)
+
+</div>
 
 > **Claude Code** and **Kimi Code** — both first-class engines. Use either subscription natively, no API key required. Each bot picks its own engine.
 


### PR DESCRIPTION
## What

You asked the README top to feel more designed / professional. This is a focused header redesign:

- **Centered hero block** with emoji title, H3 tagline, and italic one-liner.
- **3 rows of \`for-the-badge\` badges** for scannability:
  1. Status — CI / License / Stars / Forks
  2. Engines — **Claude Code / Kimi Code / Native Subscription** / Node.js (the engine + subscription badges are now the headline, matching our dual-engine positioning)
  3. Platforms — Feishu/Lark / Telegram / WeChat ClawBot / Web UI
- Language switcher as inline text beneath the rows.

Same treatment applied to \`README.md\` (zh) and \`README_EN.md\`.

## Test plan
- [x] Local markdown preview shows centered block + the three badge rows without awkward wrapping.
- [ ] Post-merge: check GitHub-rendered README looks clean on desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)