### PR TITLE
fix: propagate Feishu send/update failures so retry + fallback actually run

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -1277,18 +1277,11 @@ export class MessageBridge {
    */
   private async sendFinalCard(messageId: string, state: CardState, chatId?: string): Promise<void> {
     for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
-      try {
-        await this.sender.updateCard(messageId, state);
-        if (attempt > 0) {
-          await new Promise((r) => setTimeout(r, FINAL_CARD_BASE_DELAY_MS));
-          await this.sender.updateCard(messageId, state);
-        }
-        return;
-      } catch {
-        const delay = FINAL_CARD_BASE_DELAY_MS * Math.pow(2, attempt);
-        this.logger.warn({ attempt, delay, messageId }, 'Final card update failed, retrying');
-        await new Promise((r) => setTimeout(r, delay));
-      }
+      const ok = await this.sender.updateCard(messageId, state);
+      if (ok) return;
+      const delay = FINAL_CARD_BASE_DELAY_MS * Math.pow(2, attempt);
+      this.logger.warn({ attempt, delay, messageId }, 'Final card update failed, retrying');
+      await new Promise((r) => setTimeout(r, delay));
     }
     if (chatId) {
       this.logger.error({ messageId, chatId }, 'All final card retries failed, sending text fallback');

--- a/src/bridge/message-sender.interface.ts
+++ b/src/bridge/message-sender.interface.ts
@@ -8,8 +8,8 @@ export interface IMessageSender {
   /** Send a new streaming card/message for a CardState. Returns messageId for subsequent updates. */
   sendCard(chatId: string, state: CardState): Promise<string | undefined>;
 
-  /** Update an existing streaming card/message with new CardState. */
-  updateCard(messageId: string, state: CardState): Promise<void>;
+  /** Update an existing streaming card/message with new CardState. Returns false on failure. */
+  updateCard(messageId: string, state: CardState): Promise<boolean>;
 
   /** Send a simple notice message (for command responses: /help, /reset, /stop, etc.). */
   sendTextNotice(chatId: string, title: string, content: string, color?: string): Promise<void>;

--- a/src/feishu/feishu-sender-adapter.ts
+++ b/src/feishu/feishu-sender-adapter.ts
@@ -16,7 +16,7 @@ export class FeishuSenderAdapter implements IMessageSender {
     return this.sender.sendCard(chatId, buildCard(state));
   }
 
-  async updateCard(messageId: string, state: CardState): Promise<void> {
+  async updateCard(messageId: string, state: CardState): Promise<boolean> {
     return this.sender.updateCard(messageId, buildCard(state));
   }
 

--- a/src/feishu/message-sender.ts
+++ b/src/feishu/message-sender.ts
@@ -30,14 +30,16 @@ export class MessageSender {
     }
   }
 
-  async updateCard(messageId: string, cardContent: string): Promise<void> {
+  async updateCard(messageId: string, cardContent: string): Promise<boolean> {
     try {
       await this.client.im.v1.message.patch({
         path: { message_id: messageId },
         data: { content: cardContent },
       });
+      return true;
     } catch (err) {
       this.logger.error({ err, messageId }, 'Failed to update card');
+      return false;
     }
   }
 
@@ -100,7 +102,7 @@ export class MessageSender {
     }
   }
 
-  async sendImage(chatId: string, imageKey: string): Promise<void> {
+  async sendImage(chatId: string, imageKey: string): Promise<boolean> {
     try {
       await this.client.im.v1.message.create({
         params: { receive_id_type: 'chat_id' },
@@ -110,16 +112,17 @@ export class MessageSender {
           msg_type: 'image',
         },
       });
+      return true;
     } catch (err) {
       this.logger.error({ err, chatId, imageKey }, 'Failed to send image');
+      return false;
     }
   }
 
   async sendImageFile(chatId: string, filePath: string): Promise<boolean> {
     const imageKey = await this.uploadImage(filePath);
     if (!imageKey) return false;
-    await this.sendImage(chatId, imageKey);
-    return true;
+    return this.sendImage(chatId, imageKey);
   }
 
   async uploadFile(filePath: string, fileName: string, fileType: string): Promise<string | undefined> {
@@ -142,7 +145,7 @@ export class MessageSender {
     }
   }
 
-  async sendFile(chatId: string, fileKey: string): Promise<void> {
+  async sendFile(chatId: string, fileKey: string): Promise<boolean> {
     try {
       await this.client.im.v1.message.create({
         params: { receive_id_type: 'chat_id' },
@@ -152,16 +155,17 @@ export class MessageSender {
           msg_type: 'file',
         },
       });
+      return true;
     } catch (err) {
       this.logger.error({ err, chatId, fileKey }, 'Failed to send file');
+      return false;
     }
   }
 
   async sendLocalFile(chatId: string, filePath: string, fileName: string, fileType: string): Promise<boolean> {
     const fileKey = await this.uploadFile(filePath, fileName, fileType);
     if (!fileKey) return false;
-    await this.sendFile(chatId, fileKey);
-    return true;
+    return this.sendFile(chatId, fileKey);
   }
 
   async getChatMemberCount(chatId: string): Promise<number | undefined> {

--- a/src/telegram/telegram-sender.ts
+++ b/src/telegram/telegram-sender.ts
@@ -391,21 +391,23 @@ export class TelegramSender implements IMessageSender {
     }
   }
 
-  async updateCard(messageId: string, state: CardState): Promise<void> {
+  async updateCard(messageId: string, state: CardState): Promise<boolean> {
     const ref = this.messageMap.get(messageId);
     if (!ref) {
       this.logger.warn({ messageId }, 'Cannot update unknown Telegram message');
-      return;
+      return false;
     }
     try {
       const html = renderCardHtml(state);
       await this.bot.api.editMessageText(ref.chatId, ref.messageId, html, { parse_mode: 'HTML' });
+      return true;
     } catch (err: any) {
-      // Telegram returns 400 if message content hasn't changed — ignore
+      // Telegram returns 400 if message content hasn't changed — treat as success (nothing to do)
       if (err?.error_code === 400 && err?.description?.includes('message is not modified')) {
-        return;
+        return true;
       }
       this.logger.error({ err, messageId }, 'Failed to update Telegram message');
+      return false;
     }
   }
 

--- a/src/web/null-sender.ts
+++ b/src/web/null-sender.ts
@@ -9,7 +9,9 @@ export class NullSender implements IMessageSender {
   async sendCard(_chatId: string, _state: CardState): Promise<string | undefined> {
     return undefined;
   }
-  async updateCard(_messageId: string, _state: CardState): Promise<void> {}
+  async updateCard(_messageId: string, _state: CardState): Promise<boolean> {
+    return true;
+  }
   async sendTextNotice(_chatId: string, _title: string, _content: string, _color?: string): Promise<void> {}
   async sendText(_chatId: string, _text: string): Promise<void> {}
   async sendImageFile(_chatId: string, _filePath: string): Promise<boolean> {

--- a/src/wechat/wechat-sender.ts
+++ b/src/wechat/wechat-sender.ts
@@ -39,13 +39,13 @@ export class WechatSender implements IMessageSender {
     return messageId;
   }
 
-  async updateCard(messageId: string, state: CardState): Promise<void> {
+  async updateCard(messageId: string, state: CardState): Promise<boolean> {
     const { chatId } = this.parseMessageId(messageId);
-    if (!chatId) return;
+    if (!chatId) return false;
 
     // Terminal states: send final result as standalone FINISH message
     if (state.status === 'complete' || state.status === 'error') {
-      if (this.finalSentSet.has(messageId)) return; // idempotency
+      if (this.finalSentSet.has(messageId)) return true; // idempotency — already delivered
       this.finalSentSet.add(messageId);
       this.lastProgressSent.delete(messageId);
       this.reportedToolCount.delete(messageId);
@@ -54,7 +54,7 @@ export class WechatSender implements IMessageSender {
       const text = this.renderFinalMessage(state);
       // Use sendText for automatic chunking of long responses
       await this.sendText(chatId, text);
-      return;
+      return true;
     }
 
     // Waiting for input: send question as standalone message
@@ -63,7 +63,7 @@ export class WechatSender implements IMessageSender {
       await this.client.sendTextMessage(chatId, text).catch((err) => {
         this.logger.error({ err, chatId }, 'Failed to send WeChat question');
       });
-      return;
+      return true;
     }
 
     // Intermediate: send tool progress as actual messages (throttled)
@@ -83,6 +83,7 @@ export class WechatSender implements IMessageSender {
         this.logger.debug({ err, chatId }, 'Failed to send WeChat progress (may lack context_token)');
       });
     }
+    return true;
   }
 
   async sendTextNotice(chatId: string, title: string, content: string): Promise<void> {


### PR DESCRIPTION
## Summary

Two open bugs share a single root cause: `MessageSender` in `src/feishu/message-sender.ts` silently swallowed API errors in `updateCard`, `sendImage` and `sendFile` (returned `void`). The retry and fallback logic that depended on those failures being visible was therefore dead code.

- Fixes #186 — long tasks' final card was stuck on an intermediate state (e.g. `⏳ bash`). `sendFinalCard`'s retry + text fallback were guarded by `try/catch` on a function that never throws, so a rate-limited final Feishu patch was lost and the card never updated to the completion state (even though `/status` reported no running task).
- Fixes #190 — group chats didn't receive output files. `sendImageFile` / `sendLocalFile` returned `true` on successful upload regardless of whether the actual `message.create` step succeeded, so `OutputHandler`'s text fallback for failed file sends never triggered.

## Changes

- `MessageSender.updateCard` / `sendImage` / `sendFile` now return `Promise<boolean>` (success/failure).
- `sendImageFile` / `sendLocalFile` propagate the real send result instead of hard-coding `true`.
- `MessageBridge.sendFinalCard` checks the boolean to drive retries and the text-message fallback.
- Interface (`IMessageSender`) and other implementations (Telegram / WeChat / Null) updated to match.

Return-based signalling (not `throw`) keeps the many fire-and-forget call sites inside `RateLimiter.schedule` callbacks safe from unhandled promise rejections.

## Test plan

- [x] `npm run build` (tsc + vite) succeeds.
- [x] `npm test` — all 174 tests pass.
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged).
- [ ] Smoke-test in a 3+ member Feishu group: trigger a task that produces an image/PDF output; confirm the file lands in the group (or a text fallback fires if the send fails).
- [ ] Smoke-test a long-running task in Feishu: card should end up in "complete" state rather than stuck on a tool call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)