### PR TITLE
docs(codex): ship Codex follow-ups to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,13 +211,29 @@ Knowledge persistence is handled by an external **MetaMemory server** (FastAPI +
 Before running the service, ensure:
 
 1. **Node.js 20+** is installed.
-2. **Claude Code CLI is installed and authenticated** — The Agent SDK spawns `claude` as a subprocess; it must be able to run independently.
+2. **At least one engine CLI is installed and authenticated** — MetaBot spawns the selected engine's CLI as a subprocess. Install only the engine(s) you intend to use; each bot picks one via `engine` in its config.
+
+   **Claude Code (default)** — `engine: "claude"`
    - Install: `npm install -g @anthropic-ai/claude-code`
    - Authenticate (one of):
      - **OAuth login (recommended)**: Run `claude login` in a standalone terminal and complete the browser flow.
      - **API Key**: Set `ANTHROPIC_API_KEY=sk-ant-...` in `.env` or your shell environment.
-   - Verify: Run `claude --version` and `claude "hello"` in a standalone terminal to confirm it works.
+   - Verify: Run `claude --version` and `claude "hello"` in a standalone terminal.
    - **Important**: You cannot run `claude login` or `claude auth status` from inside a Claude Code session (nested sessions are blocked). Always use a separate terminal.
+
+   **Kimi Code** — `engine: "kimi"`
+   - Install: `npm install -g @moonshot-ai/kimi-code`
+   - Authenticate: `kimi login` (OAuth, uses your Moonshot subscription) or set `KIMI_API_KEY` in `.env`.
+   - Verify: `kimi --version`.
+
+   **Codex CLI** — `engine: "codex"`
+   - Install the Codex CLI (see the upstream project README for platform-specific binaries).
+   - Authenticate: `codex login` in a standalone terminal, or configure a profile / API key in `~/.codex/config.toml`.
+   - Verify: `codex exec --help`.
+   - Optional per-bot overrides: `codex.model`, `codex.profile`, `codex.approvalPolicy` (`untrusted` | `on-failure` | `on-request` | `never`), `codex.sandbox` (`read-only` | `workspace-write` | `danger-full-access`), `codex.extraArgs` (extra argv passed verbatim to `codex exec`), `codex.env` (extra env vars for the subprocess). `CODEX_EXECUTABLE_PATH` env var overrides auto-detection; `CODEX_APPROVAL_POLICY` / `CODEX_SANDBOX` provide global defaults.
+   - Session continuity uses `codex exec resume <thread_id>` — MetaBot stores the Codex thread id per `chatId` just like Claude sessions.
+   - Interactive tool approvals (`sendAnswer` / `resolveQuestion`) are **not** supported under Codex — use `approvalPolicy: "never"` and a sandbox level you trust, since the bridge cannot surface approval prompts back to Feishu.
+
 3. **Feishu app is configured** — See the setup guide below.
 
 ## HTTPS Setup (Required for Web Voice Mode)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <p>
   <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
   <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
+  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Engine-Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
   <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
   <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
 </p>
@@ -31,7 +32,7 @@
 
 </div>
 
-> 支持 **Claude Code** 和 **Kimi Code** 双引擎 — 两家原生订阅都能直接用，无需 API Key。每个 Bot 可独立选引擎。
+> 支持 **Claude Code**、**Kimi Code** 和 **Codex CLI** 三大引擎 — 订阅 / API Key 任你选，每个 Bot 可独立选引擎。
 
 ![MetaBot Demo](resources/metabot-demo.gif)
 
@@ -39,23 +40,23 @@
 curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash
 ```
 
-安装器引导一切：工作目录 → **引擎选择（Claude / Kimi）** → 订阅登录 → IM 平台 → PM2 自动启动。**5 分钟上手。**
+安装器引导一切：工作目录 → **引擎选择（Claude / Kimi / Codex）** → 订阅登录 → IM 平台 → PM2 自动启动。**5 分钟上手。**
 
 ---
 
-## 双引擎：Claude Code 与 Kimi Code 并列一等支持
+## 三引擎：Claude Code ✕ Kimi Code ✕ Codex CLI 并列一等支持
 
-MetaBot 不是只绑定一家 — 两大顶级 AI 编码 Agent 都内置原生支持，**你的订阅直接用**。
+MetaBot 不是只绑定一家 — 三大顶级 AI 编码 Agent 都内置原生支持，**你的订阅直接用**。
 
-| | **Claude Code**（Anthropic） | **Kimi Code**（Moonshot） |
-|---|---|---|
-| **订阅直连** | ✅ `claude login` OAuth，走 Claude Code 订阅 | ✅ `kimi login`，走 Kimi 订阅 |
-| **API Key 兜底** | ✅ `ANTHROPIC_API_KEY` / 第三方 Anthropic 兼容端 | ✅ Moonshot API Key |
-| **上下文窗口** | 200k（Opus/Sonnet 可选 1M） | 256k（kimi-for-coding） |
-| **工具能力** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | 同上（Kimi CLI 原生 + `.claude/skills/` 自动发现） |
-| **自主运行模式** | `bypassPermissions` | `yoloMode`（等价） |
-| **子 Agent** | `.claude/agents/*.md` 自动加载 | 仅内置 `default` / `okabe` |
-| **工作区说明** | `CLAUDE.md` | `AGENTS.md`（安装器自动建软链） |
+| | **Claude Code**（Anthropic） | **Kimi Code**（Moonshot） | **Codex CLI**（OpenAI） |
+|---|---|---|---|
+| **订阅直连** | ✅ `claude login` OAuth | ✅ `kimi login` | ✅ `codex login`，走 ChatGPT 订阅 |
+| **API Key 兜底** | ✅ `ANTHROPIC_API_KEY` / 第三方 Anthropic 兼容端 | ✅ Moonshot API Key | ✅ `OPENAI_API_KEY` / Codex profile |
+| **上下文窗口** | 200k（Opus/Sonnet 可选 1M） | 256k（kimi-for-coding） | 400k（gpt-5.x-codex） |
+| **工具能力** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | 同上（Kimi CLI 原生 + `.claude/skills/` 自动发现） | Codex CLI 原生 sandbox + shell 工具链 |
+| **自主运行模式** | `bypassPermissions` | `yoloMode`（等价） | `--dangerously-bypass-approvals-and-sandbox` |
+| **子 Agent** | `.claude/agents/*.md` 自动加载 | 仅内置 `default` / `okabe` | 暂不支持子 Agent |
+| **工作区说明** | `CLAUDE.md` | `AGENTS.md`（安装器自动建软链） | `AGENTS.md`（Codex 官方约定） |
 
 **配置只需一行** — 每个 Bot 独立选引擎：
 ```json
@@ -72,7 +73,7 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
 
 ## 你能用它做什么
 
-- **手机写代码** — 地铁上用飞书给 Claude Code / Kimi Code 发消息，它帮你改 bug、提 PR、跑测试
+- **手机写代码** — 地铁上用飞书给 Claude Code / Kimi Code / Codex CLI 发消息，它帮你改 bug、提 PR、跑测试
 - **多 Agent 协作** — 前端 Bot、后端 Bot、运维 Bot，各自独立工作空间（甚至独立引擎），通过 Agent 总线互相委派任务
 - **知识自生长** — Agent 把学到的东西存入 MetaMemory，组织每天都在变聪明，无需重新训练
 - **自动化流水线** — "每天早上9点搜 AI 新闻，总结 Top 5，存档" — 一句话搞定
@@ -81,11 +82,11 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
 
 ## 为什么选 MetaBot
 
-| | MetaBot | 直接用 Claude Code / Kimi Code | Dify / Coze |
+| | MetaBot | 直接用 Claude / Kimi / Codex CLI | Dify / Coze |
 |---|---|---|---|
 | **手机控制** | 飞书/TG/微信随时随地 | 只能在终端 | 有，但不能跑代码 |
-| **引擎选择** | Claude Code ✕ Kimi Code 双引擎 | 各自单一 | 无，只能调 API |
-| **订阅直连** | 两家原生订阅都直接用 | 一次只能登一个 | 不支持订阅 |
+| **引擎选择** | Claude ✕ Kimi ✕ Codex 三引擎 | 各自单一 | 无，只能调 API |
+| **订阅直连** | 三家原生订阅都直接用 | 一次只能登一个 | 不支持订阅 |
 | **代码能力** | 完整 Agent SDK（Read/Write/Edit/Bash/MCP） | 完整 | 无 |
 | **多 Agent** | Agent 总线 + 任务委派 + 运行时创建 | 单会话 | 有，但封闭生态 |
 | **共享记忆** | MetaMemory 全文搜索 + 自动同步飞书知识库 | 无 | 无 |
@@ -99,7 +100,8 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
 
 ```
 飞书/TG/微信 → IM Bridge → Engine Router ──┬─→ Claude Code Agent SDK
-                                            └─→ Kimi Agent SDK（@moonshot-ai/kimi-agent-sdk）
+                                            ├─→ Kimi Agent SDK（@moonshot-ai/kimi-agent-sdk）
+                                            └─→ Codex CLI（codex exec --json 子进程）
                               ↕
                     MetaMemory（共享知识库）
                     MetaSkill（Agent 工厂，产出 CLAUDE.md + AGENTS.md）
@@ -107,7 +109,7 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
                     Agent 总线（跨 Bot 通信，引擎无关）
 ```
 
-引擎层已抽象 —— Kimi 事件流被翻译成 Claude 形状的 `SDKMessage`，流式卡片、工具调用追踪、MetaMemory/调度/Agent 总线在两种引擎下表现一致。
+引擎层已抽象 —— Kimi 事件流和 Codex JSONL 都被翻译成 Claude 形状的 `SDKMessage`，流式卡片、工具调用追踪、MetaMemory/调度/Agent 总线在三种引擎下表现一致。
 
 ## 多端接入
 
@@ -148,7 +150,7 @@ MetaBot 支持 4 种方式与你的 Agent 团队交互：
 
 | 组件 | 一句话说明 |
 |------|-----------|
-| **双引擎内核** | 每个 Bot 独立选 Claude Code 或 Kimi Code — 完整工具链（Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP），自主模式运行 |
+| **三引擎内核** | 每个 Bot 独立选 Claude Code / Kimi Code / Codex CLI — 完整工具链（Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP），自主模式运行 |
 | **MetaSkill** | Agent 工厂。`/metaskill` 一键生成 `.claude/` Agent 团队（orchestrator + 专家 + reviewer） |
 | **MetaMemory** | 内嵌 SQLite 知识库，全文搜索，Web UI，变更自动同步到飞书知识库 |
 | **IM Bridge** | 飞书、Telegram、微信（含手机端）对话任意 Agent，流式卡片 + 工具调用追踪 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -16,6 +16,7 @@
 <p>
   <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
   <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
+  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Engine-Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
   <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
   <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
 </p>
@@ -31,7 +32,7 @@
 
 </div>
 
-> **Claude Code** and **Kimi Code** — both first-class engines. Use either subscription natively, no API key required. Each bot picks its own engine.
+> **Claude Code**, **Kimi Code**, and **Codex CLI** — three first-class engines. Subscription or API key, your choice. Each bot picks its own engine.
 
 ![MetaBot Demo](resources/metabot-demo.gif)
 
@@ -39,23 +40,23 @@
 curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash
 ```
 
-The installer walks you through everything: working directory → **engine choice (Claude / Kimi)** → subscription login → IM platform → auto-start with PM2. **5 minutes to get started.**
+The installer walks you through everything: working directory → **engine choice (Claude / Kimi / Codex)** → subscription login → IM platform → auto-start with PM2. **5 minutes to get started.**
 
 ---
 
 ## Multi-Engine: Claude Code, Kimi Code, and Codex CLI
 
-MetaBot isn't locked to one vendor — both top AI coding agents ship with native support, and **your subscription works directly**.
+MetaBot isn't locked to one vendor — all three top AI coding agents ship with native support, and **your subscription works directly**.
 
-| | **Claude Code** (Anthropic) | **Kimi Code** (Moonshot) |
-|---|---|---|
-| **Subscription login** | ✅ `claude login` OAuth — uses your Claude Code subscription | ✅ `kimi login` — uses your Kimi subscription |
-| **API key fallback** | ✅ `ANTHROPIC_API_KEY` or third-party Anthropic-compat endpoints | ✅ Moonshot API key |
-| **Context window** | 200k (1M optional on Opus/Sonnet) | 256k (kimi-for-coding) |
-| **Tools** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | Same (Kimi CLI builtin + `.claude/skills/` auto-discovery) |
-| **Autonomous mode** | `bypassPermissions` | `yoloMode` (equivalent) |
-| **Subagents** | `.claude/agents/*.md` auto-loaded | Builtin `default` / `okabe` only |
-| **Workspace doc** | `CLAUDE.md` | `AGENTS.md` (installer creates the symlink) |
+| | **Claude Code** (Anthropic) | **Kimi Code** (Moonshot) | **Codex CLI** (OpenAI) |
+|---|---|---|---|
+| **Subscription login** | ✅ `claude login` OAuth | ✅ `kimi login` | ✅ `codex login` — uses your ChatGPT subscription |
+| **API key fallback** | ✅ `ANTHROPIC_API_KEY` or third-party Anthropic-compat endpoints | ✅ Moonshot API key | ✅ `OPENAI_API_KEY` / Codex profile |
+| **Context window** | 200k (1M optional on Opus/Sonnet) | 256k (kimi-for-coding) | 400k (gpt-5.x-codex) |
+| **Tools** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | Same (Kimi CLI builtin + `.claude/skills/` auto-discovery) | Codex CLI native sandbox + shell toolchain |
+| **Autonomous mode** | `bypassPermissions` | `yoloMode` (equivalent) | `--dangerously-bypass-approvals-and-sandbox` |
+| **Subagents** | `.claude/agents/*.md` auto-loaded | Builtin `default` / `okabe` only | Subagents not supported yet |
+| **Workspace doc** | `CLAUDE.md` | `AGENTS.md` (installer creates the symlink) | `AGENTS.md` (Codex convention) |
 
 **One line of config** — each bot picks its engine:
 ```json
@@ -72,7 +73,7 @@ Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The 
 
 ## What You Can Build
 
-- **Code from your phone** — message Claude Code / Kimi Code from Feishu on the subway, it fixes bugs, opens PRs, runs tests
+- **Code from your phone** — message Claude Code / Kimi Code / Codex CLI from Feishu on the subway, it fixes bugs, opens PRs, runs tests
 - **Multi-agent teams** — frontend bot, backend bot, infra bot, each in their own workspace (even their own engine), delegating via Agent Bus
 - **Self-growing knowledge** — agents save what they learn to MetaMemory, the organization gets smarter daily
 - **Automated pipelines** — "Search AI news every morning at 9am, summarize top 5, save to archive" — one sentence
@@ -81,11 +82,11 @@ Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The 
 
 ## Why MetaBot
 
-| | MetaBot | Claude Code / Kimi Code (terminal) | Dify / Coze |
+| | MetaBot | Claude / Kimi / Codex CLI (terminal) | Dify / Coze |
 |---|---|---|---|
 | **Mobile access** | Feishu/TG/WeChat anywhere | Terminal only | Yes, but can't run code |
-| **Engine choice** | Claude Code ✕ Kimi Code dual-engine | One at a time | None, API calls only |
-| **Subscription login** | Both native subscriptions work directly | One at a time | Subscriptions not supported |
+| **Engine choice** | Claude ✕ Kimi ✕ Codex, three engines | One at a time | None, API calls only |
+| **Subscription login** | All three native subscriptions work directly | One at a time | Subscriptions not supported |
 | **Code capabilities** | Full Agent SDK (Read/Write/Edit/Bash/MCP) | Full | None |
 | **Multi-agent** | Agent Bus + task delegation + runtime creation | Single session | Yes, but closed ecosystem |
 | **Shared memory** | MetaMemory with FTS + auto-sync to Wiki | None | None |
@@ -99,7 +100,8 @@ Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The 
 
 ```
 Feishu/TG/WeChat → IM Bridge → Engine Router ──┬─→ Claude Code Agent SDK
-                                                └─→ Kimi Agent SDK (@moonshot-ai/kimi-agent-sdk)
+                                                ├─→ Kimi Agent SDK (@moonshot-ai/kimi-agent-sdk)
+                                                └─→ Codex CLI (codex exec --json subprocess)
                                     ↕
                          MetaMemory (shared knowledge)
                          MetaSkill (agent factory, emits CLAUDE.md + AGENTS.md)
@@ -107,7 +109,7 @@ Feishu/TG/WeChat → IM Bridge → Engine Router ──┬─→ Claude Code Age
                          Agent Bus (cross-bot comms, engine-agnostic)
 ```
 
-The engine layer is abstracted — Kimi's event stream is translated into Claude-shaped `SDKMessage` objects, so streaming cards, tool-call tracking, MetaMemory/Scheduler/Agent Bus behave identically regardless of engine.
+The engine layer is abstracted — Kimi's event stream and Codex's JSONL stream are both translated into Claude-shaped `SDKMessage` objects, so streaming cards, tool-call tracking, MetaMemory/Scheduler/Agent Bus behave identically across all three engines.
 
 | Client | Use Case | Key Features |
 |--------|----------|-------------|
@@ -144,7 +146,7 @@ Full-featured browser-based chat interface. Access at `https://your-server/web/`
 
 | Component | Description |
 |-----------|-------------|
-| **Dual Engine Kernel** | Each bot independently chooses Claude Code or Kimi Code — full tool stack (Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP) in autonomous mode |
+| **Triple Engine Kernel** | Each bot independently chooses Claude Code / Kimi Code / Codex CLI — full tool stack (Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP) in autonomous mode |
 | **MetaSkill** | Agent factory. `/metaskill` generates a complete `.claude/` agent team (orchestrator + specialists + reviewer) |
 | **MetaMemory** | Embedded SQLite knowledge store with full-text search, Web UI, auto-syncs to Feishu Wiki |
 | **IM Bridge** | Chat with any agent from Feishu, Telegram, or WeChat (including mobile). Streaming cards + tool call tracking |

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,19 +39,22 @@ export interface BotConfigBase {
     contextWindow?: number;
   };
   /** Codex-specific overrides. Populated only when engine === 'codex'. */
-  codex?: {
-    executable?: string;
-    model?: string;
-    displayModel?: string;
-    profile?: string;
-    approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
-    sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
-    dangerouslyBypassApprovalsAndSandbox?: boolean;
-    /** Context window size in tokens for display only. */
-    contextWindow?: number;
-    extraArgs?: string[];
-    env?: Record<string, string>;
-  };
+  codex?: CodexBotConfig;
+}
+
+/** Codex-specific overrides. Populated only when engine === 'codex'. */
+export interface CodexBotConfig {
+  executable?: string;
+  model?: string;
+  displayModel?: string;
+  profile?: string;
+  approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+  dangerouslyBypassApprovalsAndSandbox?: boolean;
+  /** Context window size in tokens for display only. */
+  contextWindow?: number;
+  extraArgs?: string[];
+  env?: Record<string, string>;
 }
 
 /** Feishu bot config (extends base with Feishu credentials). */

--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
-import type { BotConfigBase } from '../../config.js';
+import type { BotConfigBase, CodexBotConfig } from '../../config.js';
 import type { Logger } from '../../utils/logger.js';
 import { AsyncQueue } from '../../utils/async-queue.js';
 import type {
@@ -28,6 +28,43 @@ function resolveCodexPath(): string {
 
 const CODEX_EXECUTABLE = resolveCodexPath();
 
+/**
+ * Build the argv array for `codex exec`. Exported for unit testing.
+ * Values are passed as discrete argv entries (never through a shell), so
+ * `extraArgs` / `profile` / `model` cannot introduce shell-injection even
+ * if they contain metacharacters — but they will still be visible to the
+ * Codex CLI as literal arguments.
+ */
+export function buildCodexArgs(
+  codexConfig: CodexBotConfig,
+  cwd: string,
+  prompt: string,
+  sessionId: string | undefined,
+  model: string | undefined,
+): string[] {
+  const args: string[] = [];
+
+  if (codexConfig.dangerouslyBypassApprovalsAndSandbox) {
+    args.push('--dangerously-bypass-approvals-and-sandbox');
+  } else {
+    args.push('-a', codexConfig.approvalPolicy ?? 'never');
+    args.push('--sandbox', codexConfig.sandbox ?? 'workspace-write');
+  }
+
+  args.push('-C', cwd);
+  if (model) args.push('-m', model);
+  if (codexConfig.profile) args.push('-p', codexConfig.profile);
+  for (const extraArg of codexConfig.extraArgs ?? []) args.push(extraArg);
+
+  args.push('exec');
+  if (sessionId) {
+    args.push('resume', '--json', '--skip-git-repo-check', sessionId, prompt);
+  } else {
+    args.push('--json', '--color', 'never', '--skip-git-repo-check', prompt);
+  }
+  return args;
+}
+
 export class CodexExecutor {
   constructor(
     private config: BotConfigBase,
@@ -44,7 +81,7 @@ export class CodexExecutor {
       model: model || codexConfig.displayModel,
       contextWindow: codexConfig.contextWindow,
     });
-    const args = this.buildArgs(cwd, fullPrompt, sessionId, model);
+    const args = buildCodexArgs(codexConfig, cwd, fullPrompt, sessionId, model);
     const startTime = Date.now();
     let child: ChildProcess | undefined;
     let sawResult = false;
@@ -158,31 +195,6 @@ export class CodexExecutor {
     } finally {
       handle.finish();
     }
-  }
-
-  private buildArgs(cwd: string, prompt: string, sessionId: string | undefined, model: string | undefined): string[] {
-    const codexConfig = this.config.codex ?? {};
-    const args: string[] = [];
-
-    if (codexConfig.dangerouslyBypassApprovalsAndSandbox) {
-      args.push('--dangerously-bypass-approvals-and-sandbox');
-    } else {
-      args.push('-a', codexConfig.approvalPolicy ?? 'never');
-      args.push('--sandbox', codexConfig.sandbox ?? 'workspace-write');
-    }
-
-    args.push('-C', cwd);
-    if (model) args.push('-m', model);
-    if (codexConfig.profile) args.push('-p', codexConfig.profile);
-    for (const extraArg of codexConfig.extraArgs ?? []) args.push(extraArg);
-
-    args.push('exec');
-    if (sessionId) {
-      args.push('resume', '--json', '--skip-git-repo-check', sessionId, prompt);
-    } else {
-      args.push('--json', '--color', 'never', '--skip-git-repo-check', prompt);
-    }
-    return args;
   }
 
   private buildPromptWithContext(

--- a/tests/codex-build-args.test.ts
+++ b/tests/codex-build-args.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { buildCodexArgs } from '../src/engines/codex/executor.js';
+import type { CodexBotConfig } from '../src/config.js';
+
+describe('buildCodexArgs', () => {
+  const cwd = '/work/proj';
+  const prompt = 'run pwd';
+
+  it('defaults approval policy to "never" and sandbox to "workspace-write"', () => {
+    const args = buildCodexArgs({}, cwd, prompt, undefined, undefined);
+    expect(args).toEqual([
+      '-a', 'never',
+      '--sandbox', 'workspace-write',
+      '-C', cwd,
+      'exec', '--json', '--color', 'never', '--skip-git-repo-check', prompt,
+    ]);
+  });
+
+  it('honors explicit approvalPolicy and sandbox', () => {
+    const cfg: CodexBotConfig = { approvalPolicy: 'on-failure', sandbox: 'read-only' };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, undefined);
+    expect(args.slice(0, 4)).toEqual(['-a', 'on-failure', '--sandbox', 'read-only']);
+  });
+
+  it('replaces policy/sandbox flags when dangerouslyBypassApprovalsAndSandbox is set', () => {
+    const cfg: CodexBotConfig = {
+      dangerouslyBypassApprovalsAndSandbox: true,
+      approvalPolicy: 'on-failure',
+      sandbox: 'read-only',
+    };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, undefined);
+    expect(args[0]).toBe('--dangerously-bypass-approvals-and-sandbox');
+    expect(args).not.toContain('-a');
+    expect(args).not.toContain('--sandbox');
+  });
+
+  it('passes model and profile when provided', () => {
+    const cfg: CodexBotConfig = { profile: 'staging' };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, 'gpt-5.4-codex');
+    expect(args).toContain('-m');
+    expect(args[args.indexOf('-m') + 1]).toBe('gpt-5.4-codex');
+    expect(args).toContain('-p');
+    expect(args[args.indexOf('-p') + 1]).toBe('staging');
+  });
+
+  it('appends extraArgs verbatim between global flags and the exec subcommand', () => {
+    const cfg: CodexBotConfig = { extraArgs: ['--foo', 'bar baz', '--qux'] };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, undefined);
+    const execIdx = args.indexOf('exec');
+    expect(args.slice(execIdx - 3, execIdx)).toEqual(['--foo', 'bar baz', '--qux']);
+  });
+
+  it('uses `exec resume <sessionId>` when a session id is provided', () => {
+    const args = buildCodexArgs({}, cwd, prompt, 'sess-abc', undefined);
+    const tail = args.slice(args.indexOf('exec'));
+    expect(tail).toEqual(['exec', 'resume', '--json', '--skip-git-repo-check', 'sess-abc', prompt]);
+    // resume path does NOT pass --color never (Codex resume subcommand differs)
+    expect(tail).not.toContain('--color');
+  });
+
+  it('passes `--color never` for fresh executions (no session id)', () => {
+    const args = buildCodexArgs({}, cwd, prompt, undefined, undefined);
+    const tail = args.slice(args.indexOf('exec'));
+    expect(tail).toEqual(['exec', '--json', '--color', 'never', '--skip-git-repo-check', prompt]);
+  });
+
+  it('keeps prompt as a single argv entry even with whitespace / metacharacters', () => {
+    // spawn() receives argv as an array, so shell metacharacters are safe.
+    const evil = 'ignore; rm -rf /\n`whoami`';
+    const args = buildCodexArgs({}, cwd, evil, undefined, undefined);
+    expect(args[args.length - 1]).toBe(evil);
+  });
+});

--- a/tests/codex-jsonl-translator.test.ts
+++ b/tests/codex-jsonl-translator.test.ts
@@ -75,4 +75,61 @@ describe('Codex JSONL translator', () => {
     expect(cardState.status).toBe('error');
     expect(cardState.errorMessage).toBe('network failed');
   });
+
+  it('captures session id from thread.started and leaves state empty otherwise', () => {
+    const state = createCodexTranslatorState();
+    expect(state.sessionId).toBeUndefined();
+
+    const messages = translateCodexJsonEvent({ type: 'thread.started', thread_id: 'sid-1' }, state);
+    expect(state.sessionId).toBe('sid-1');
+    expect(messages).toEqual([{ type: 'system', subtype: 'init', session_id: 'sid-1' }]);
+  });
+
+  it('ignores thread.started without a thread_id (defensive)', () => {
+    const state = createCodexTranslatorState();
+    const messages = translateCodexJsonEvent({ type: 'thread.started' } as CodexJsonEvent, state);
+    expect(messages).toEqual([]);
+    expect(state.sessionId).toBeUndefined();
+  });
+
+  it('returns [] for unknown / unhandled event types', () => {
+    const state = createCodexTranslatorState();
+    expect(translateCodexJsonEvent({ type: 'turn.started' }, state)).toEqual([]);
+    expect(translateCodexJsonEvent({ type: 'something.new' } as CodexJsonEvent, state)).toEqual([]);
+  });
+
+  it('emits a task_notification message for top-level Codex error events with a message', () => {
+    const state = createCodexTranslatorState();
+    state.sessionId = 'sid-err';
+    const messages = translateCodexJsonEvent({ type: 'error', message: 'ratelimited' }, state);
+    expect(messages).toEqual([
+      { type: 'task_notification', session_id: 'sid-err', result: 'ratelimited' },
+    ]);
+  });
+
+  it('drops error events that carry no message', () => {
+    const state = createCodexTranslatorState();
+    expect(translateCodexJsonEvent({ type: 'error' }, state)).toEqual([]);
+  });
+
+  it('tolerates item.completed agent_message with missing text', () => {
+    const state = createCodexTranslatorState();
+    const messages = translateCodexJsonEvent(
+      { type: 'item.completed', item: { id: 'x', type: 'agent_message' } } as CodexJsonEvent,
+      state,
+    );
+    expect(state.lastAgentText).toBe('');
+    expect(messages[0]).toMatchObject({ type: 'assistant' });
+  });
+
+  it('falls back to a generic failure message when turn.failed has no error detail', () => {
+    const state = createCodexTranslatorState();
+    const [msg] = translateCodexJsonEvent({ type: 'turn.failed' }, state);
+    expect(msg).toMatchObject({
+      type: 'result',
+      is_error: true,
+      subtype: 'error_during_execution',
+      errors: ['Codex execution failed'],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Ship the follow-up to #214 — Codex docs + tests that were queued on dev.

- Triple-engine framing across README.md / README_EN.md (table, badges, architecture diagram, config example)
- CLAUDE.md Prerequisites rewritten for all three engines
- New unit tests: \`tests/codex-build-args.test.ts\` and extended \`tests/codex-jsonl-translator.test.ts\` edge-case coverage
- \`buildCodexArgs\` extracted as an exported pure function; \`CodexBotConfig\` interface named in \`config.ts\`

## Test plan

- [x] Already green on dev via #215 (200 tests, 0 lint errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)