### PR TITLE
feat(feishu): surface Monitor / background task events on the live card

### DIFF
--- a/src/engines/claude/stream-processor.ts
+++ b/src/engines/claude/stream-processor.ts
@@ -1,5 +1,11 @@
 import type { SDKMessage } from './executor.js';
-import type { CardState, ToolCall, PendingQuestion } from '../../feishu/card-builder.js';
+import type {
+  BackgroundEvent,
+  BackgroundTaskStatus,
+  CardState,
+  ToolCall,
+  PendingQuestion,
+} from '../../feishu/card-builder.js';
 
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.tiff']);
 
@@ -33,6 +39,8 @@ export class StreamProcessor {
   // Track per-API-call usage from stream events for accurate context window display
   private _lastInputTokens: number | undefined;
   private _lastOutputTokens: number | undefined;
+  // Live background tasks (Monitor, etc.) — task_id → latest rollup.
+  private _backgroundEvents: Map<string, BackgroundEvent> = new Map();
 
   constructor(private userPrompt: string) {}
 
@@ -44,7 +52,10 @@ export class StreamProcessor {
 
     switch (message.type) {
       case 'system':
-        // Init message, session captured above
+        // SDK emits task_started / task_progress / task_notification / task_updated
+        // as type='system' with a specific subtype. Surface them so Feishu can
+        // show background task (e.g. Monitor) progress mid-turn.
+        this.processSystemMessage(message);
         break;
 
       case 'assistant':
@@ -59,8 +70,11 @@ export class StreamProcessor {
         break;
 
       case 'task_notification':
+        // Codex translator synthesizes this shape for top-level error events.
+        this.recordCodexTaskNotification(message);
+        break;
+
       case 'tool_use_summary':
-        // SDK 0.2 message types — no action needed for card display
         break;
     }
 
@@ -78,7 +92,77 @@ export class StreamProcessor {
       costUsd: this.costUsd,
       durationMs: this.durationMs,
       pendingQuestion: this._pendingQuestions[0] || undefined,
+      backgroundEvents: this._backgroundEvents.size > 0
+        ? [...this._backgroundEvents.values()]
+        : undefined,
     };
+  }
+
+  private processSystemMessage(message: SDKMessage): void {
+    const subtype = (message as { subtype?: string }).subtype;
+    if (!subtype) return;
+    switch (subtype) {
+      case 'task_started':
+      case 'task_progress':
+      case 'task_notification':
+      case 'task_updated':
+        this.recordTaskEvent(message, subtype);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private recordTaskEvent(message: SDKMessage, subtype: string): void {
+    const m = message as Record<string, unknown>;
+    const taskId = typeof m.task_id === 'string' ? m.task_id : undefined;
+    if (!taskId) return;
+
+    // Ambient/housekeeping tasks (skip_transcript=true) stay hidden from the card.
+    if (m.skip_transcript === true) return;
+
+    const prior = this._backgroundEvents.get(taskId);
+    const patch = (m.patch as Record<string, unknown> | undefined) ?? undefined;
+    const description = typeof m.description === 'string'
+      ? m.description
+      : (typeof patch?.description === 'string' ? patch.description as string : prior?.description);
+
+    let status: BackgroundTaskStatus = prior?.status ?? 'running';
+    if (subtype === 'task_notification') {
+      const s = typeof m.status === 'string' ? m.status : undefined;
+      if (s === 'completed' || s === 'failed' || s === 'stopped') status = s;
+    } else if (subtype === 'task_updated') {
+      const s = typeof patch?.status === 'string' ? patch.status as string : undefined;
+      if (s === 'completed') status = 'completed';
+      else if (s === 'failed' || s === 'killed') status = 'failed';
+      else if (s === 'running') status = 'running';
+    }
+
+    // SDKTaskNotificationMessage.summary carries the last-line event text for Monitor
+    // and the final message for one-shot background tasks. SDKTaskProgressMessage
+    // also exposes an optional summary for in-flight updates.
+    const summary = typeof m.summary === 'string' ? m.summary : undefined;
+    const lastEvent = summary ?? prior?.lastEvent;
+
+    this._backgroundEvents.set(taskId, {
+      taskId,
+      description: description ?? prior?.description ?? 'background task',
+      status,
+      lastEvent,
+    });
+  }
+
+  private recordCodexTaskNotification(message: SDKMessage): void {
+    const m = message as Record<string, unknown>;
+    const result = typeof m.result === 'string' ? m.result : undefined;
+    if (!result) return;
+    const taskId = typeof m.session_id === 'string' ? m.session_id : 'codex';
+    this._backgroundEvents.set(taskId, {
+      taskId,
+      description: 'Codex notification',
+      status: 'running',
+      lastEvent: result,
+    });
   }
 
   private processAssistantMessage(message: SDKMessage): void {
@@ -204,6 +288,9 @@ export class StreamProcessor {
       model: this._model,
       totalTokens: this._totalTokens,
       contextWindow: this._contextWindow,
+      backgroundEvents: this._backgroundEvents.size > 0
+        ? [...this._backgroundEvents.values()]
+        : undefined,
     };
   }
 
@@ -298,6 +385,9 @@ export class StreamProcessor {
       costUsd: this.costUsd,
       durationMs: this.durationMs,
       pendingQuestion: this._pendingQuestions[0] || undefined,
+      backgroundEvents: this._backgroundEvents.size > 0
+        ? [...this._backgroundEvents.values()]
+        : undefined,
     };
   }
 

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -1,5 +1,12 @@
 // Re-export shared types so existing imports from this module continue to work
-export type { CardStatus, ToolCall, PendingQuestion, CardState } from '../types.js';
+export type {
+  CardStatus,
+  ToolCall,
+  PendingQuestion,
+  CardState,
+  BackgroundEvent,
+  BackgroundTaskStatus,
+} from '../types.js';
 import type { CardState, CardStatus } from '../types.js';
 
 const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: string }> = {
@@ -9,6 +16,18 @@ const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: st
   error: { color: 'red', title: 'Error', icon: '🔴' },
   waiting_for_input: { color: 'yellow', title: 'Waiting for Input', icon: '🟡' },
 };
+
+const BG_ICON: Record<'running' | 'completed' | 'failed' | 'stopped', string> = {
+  running: '⏳',
+  completed: '✅',
+  failed: '❌',
+  stopped: '⏹️',
+};
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + '…';
+}
 
 const MAX_CONTENT_LENGTH = 28000;
 
@@ -35,6 +54,22 @@ export function buildCard(state: CardState): string {
     elements.push({
       tag: 'markdown',
       content: toolLines.join('\n'),
+    });
+    elements.push({ tag: 'hr' });
+  }
+
+  // Background tasks (Monitor, etc.) — show live stdout events / final status
+  if (state.backgroundEvents && state.backgroundEvents.length > 0) {
+    const lines = state.backgroundEvents.map((ev) => {
+      const icon = BG_ICON[ev.status];
+      const shortId = ev.taskId.slice(0, 6);
+      const desc = truncate(ev.description, 60);
+      const last = ev.lastEvent ? ` — _${truncate(ev.lastEvent, 140)}_` : '';
+      return `${icon} **${desc}** \`${shortId}\`${last}`;
+    });
+    elements.push({
+      tag: 'markdown',
+      content: '📡 **Background**\n' + lines.join('\n'),
     });
     elements.push({ tag: 'hr' });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,16 @@ export interface PendingQuestion {
   }>;
 }
 
+export type BackgroundTaskStatus = 'running' | 'completed' | 'failed' | 'stopped';
+
+export interface BackgroundEvent {
+  taskId: string;
+  description: string;
+  status: BackgroundTaskStatus;
+  /** Latest stdout event line from the task, if any. */
+  lastEvent?: string;
+}
+
 export interface CardState {
   status: CardStatus;
   userPrompt: string;
@@ -35,6 +45,8 @@ export interface CardState {
   contextWindow?: number;
   /** Cumulative session cost (USD), accumulated across queries until /reset */
   sessionCostUsd?: number;
+  /** Background tasks (e.g. Monitor) the agent has spawned during this turn. */
+  backgroundEvents?: BackgroundEvent[];
 }
 
 export interface IncomingMessage {

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -117,6 +117,40 @@ describe('buildCard', () => {
     const md = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('truncated'));
     expect(md).toBeDefined();
   });
+
+  it('renders a background task section with status icon + last event', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'watch ci',
+      responseText: 'watching…',
+      toolCalls: [],
+      backgroundEvents: [
+        { taskId: 'bheol4172', description: 'Watching CI for PR #215', status: 'running', lastEvent: 'check (20) running' },
+        { taskId: 'bmkr16j6f', description: 'Watching deploy', status: 'completed', lastEvent: 'CI done: success' },
+      ],
+    };
+    const json = JSON.parse(buildCard(state));
+    const bg = json.elements.find((e: any) => e.tag === 'markdown' && /Background/.test(e.content));
+    expect(bg).toBeDefined();
+    expect(bg.content).toContain('⏳');
+    expect(bg.content).toContain('✅');
+    expect(bg.content).toContain('Watching CI for PR #215');
+    expect(bg.content).toContain('check (20) running');
+    expect(bg.content).toContain('CI done: success');
+    expect(bg.content).toContain('bheol4'); // short task id
+  });
+
+  it('omits background section when no events', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'x',
+      responseText: 'y',
+      toolCalls: [],
+    };
+    const json = JSON.parse(buildCard(state));
+    const bg = json.elements.find((e: any) => e.tag === 'markdown' && /Background/.test(e.content));
+    expect(bg).toBeUndefined();
+  });
 });
 
 describe('buildHelpCard', () => {

--- a/tests/stream-processor.test.ts
+++ b/tests/stream-processor.test.ts
@@ -207,6 +207,116 @@ describe('StreamProcessor', () => {
   });
 });
 
+describe('StreamProcessor background task events', () => {
+  it('surfaces task_started as a running background event', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'system',
+      subtype: 'task_started',
+      task_id: 't-1',
+      description: 'Watching CI for PR #215',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents).toEqual([
+      { taskId: 't-1', description: 'Watching CI for PR #215', status: 'running', lastEvent: undefined },
+    ]);
+  });
+
+  it('updates description + lastEvent on task_progress', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 't-1', description: 'Watching CI',
+    } as unknown as SDKMessage));
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_progress', task_id: 't-1',
+      description: 'Watching CI', summary: 'check (20) running',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0]).toEqual({
+      taskId: 't-1', description: 'Watching CI', status: 'running', lastEvent: 'check (20) running',
+    });
+  });
+
+  it('marks a task completed with its final summary on task_notification', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 't-1', description: 'Watch build',
+    } as unknown as SDKMessage));
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-1',
+      status: 'completed', summary: 'CI done: success',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0]).toMatchObject({
+      taskId: 't-1', status: 'completed', lastEvent: 'CI done: success',
+    });
+  });
+
+  it('picks up failed / stopped statuses from task_notification', () => {
+    const p = new StreamProcessor('hi');
+    const failed = p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-fail',
+      status: 'failed', summary: 'crashed',
+    } as unknown as SDKMessage));
+    expect(failed.backgroundEvents?.[0].status).toBe('failed');
+
+    const stopped = p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-stop',
+      status: 'stopped',
+    } as unknown as SDKMessage));
+    expect(stopped.backgroundEvents?.find(e => e.taskId === 't-stop')?.status).toBe('stopped');
+  });
+
+  it('applies status patches from task_updated', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 't-1', description: 'Watch build',
+    } as unknown as SDKMessage));
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_updated', task_id: 't-1',
+      patch: { status: 'killed' },
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0].status).toBe('failed');
+  });
+
+  it('hides ambient / skip_transcript tasks from the card', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 'housekeeping',
+      description: 'Ambient thing', skip_transcript: true,
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents).toBeUndefined();
+  });
+
+  it('ignores task events without a task_id', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_started', description: 'no id',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents).toBeUndefined();
+  });
+
+  it('renders Codex translator task_notification events too', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'task_notification', session_id: 'codex-sess', result: 'rate limited',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0]).toMatchObject({
+      taskId: 'codex-sess', lastEvent: 'rate limited',
+    });
+  });
+
+  it('propagates backgroundEvents through the result message', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-1',
+      status: 'completed', summary: 'done',
+    } as unknown as SDKMessage));
+    const result = p.processMessage(msg({
+      type: 'result', subtype: 'success', result: 'all set', total_cost_usd: 0, duration_ms: 10,
+    }));
+    expect(result.status).toBe('complete');
+    expect(result.backgroundEvents?.[0]).toMatchObject({ taskId: 't-1', status: 'completed' });
+  });
+});
+
 describe('extractImagePaths', () => {
   it('extracts image paths from text', () => {
     const text = 'Created file at /tmp/img/chart.png and /home/user/photo.jpg';


### PR DESCRIPTION
## Summary

Fixes the "bot goes silent when Claude calls Monitor" problem on Feishu.

When the agent kicks off a background task (Monitor, long-running Task, etc.), the Agent SDK emits \`type:'system'\` messages with subtypes \`task_started\` / \`task_progress\` / \`task_notification\` / \`task_updated\` during the same turn. Before this PR, StreamProcessor dropped all of them — so the Feishu interactive card stopped updating and the user had no visibility into the live events coming back from the background task.

### What's on the card now

A new **📡 Background** section right below tool calls, one line per spawned background task:

\`\`\`
📡 Background
⏳ **Watching CI for PR #215** \`bheol4\` — _check (20) running_
✅ **Watching deploy** \`bmkr16\` — _CI done: success_
\`\`\`

Status icons: ⏳ running, ✅ completed, ❌ failed, ⏹️ stopped.

### Changes

- **\`src/types.ts\`** — new \`BackgroundEvent\` / \`BackgroundTaskStatus\` types, \`CardState.backgroundEvents?\` field.
- **\`src/engines/claude/stream-processor.ts\`** — \`processSystemMessage()\` now inspects \`subtype\` and routes task_* events into a \`_backgroundEvents\` map keyed by \`task_id\`. Ambient tasks (\`skip_transcript: true\`) stay hidden. The Codex translator's \`type:'task_notification'\` shape is also handled so Codex error notifications surface the same way.
- **\`src/feishu/card-builder.ts\`** — renders the new section with status icons, a short task id, description, and the latest event line.
- **Tests** — +9 cases in \`stream-processor.test.ts\` (started / progress / notification statuses / task_updated patches / skip_transcript / missing task_id / codex shape / result propagation), +2 in \`card-builder.test.ts\` for the rendered section.

Since updates flow through the existing 1.5s \`RateLimiter\`, there's zero extra polling or heartbeat load — we only re-render when the SDK actually emits an event.

## Test plan

- [x] \`npm run build\` — green
- [x] \`npm test\` — 211 passing (was 200, +11 new)
- [x] \`npm run lint\` — 0 errors (3 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)