### PR TITLE
feat(installer): add Codex CLI engine option to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -373,9 +373,14 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     if command -v codex &>/dev/null; then
       success "Codex CLI found: $(command -v codex)"
     else
-      warn "Codex CLI not found on PATH."
-      warn "Install it from https://github.com/openai/codex (see the project README for your platform)."
-      warn "MetaBot will still be configured — install Codex + run 'codex login' before starting."
+      info "Installing Codex CLI..."
+      npm_install_global @openai/codex
+      if command -v codex &>/dev/null; then
+        success "Codex CLI installed: $(command -v codex)"
+      else
+        warn "Codex CLI install failed. Install manually: sudo npm install -g @openai/codex"
+        warn "MetaBot will still be configured — install Codex + run 'codex login' before starting."
+      fi
     fi
     info "After install, run 'codex login' in a separate terminal to authenticate (or set OPENAI_API_KEY / configure a profile in ~/.codex/config.toml)."
     info "Note: Codex runs with approvalPolicy='never' and sandbox='workspace-write' by default — interactive tool approvals are not surfaced to IM."
@@ -1137,7 +1142,7 @@ if [[ "${SKIP_CONFIG}" == "false" ]]; then
   fi
   if [[ "${CLAUDE_AUTH_METHOD}" == "codex" ]]; then
     if ! command -v codex &>/dev/null; then
-      echo "    ${STEP_NUM}. Install Codex CLI — see https://github.com/openai/codex"
+      echo "    ${STEP_NUM}. Install Codex CLI: sudo npm install -g @openai/codex"
       STEP_NUM=$((STEP_NUM + 1))
     fi
     echo "    ${STEP_NUM}. Run 'codex login' in a separate terminal (or set OPENAI_API_KEY / configure ~/.codex/config.toml)"

--- a/install.sh
+++ b/install.sh
@@ -350,6 +350,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
   echo -e "${BOLD}Agent Engine:${NC}"
   echo "  1) Claude Code (Anthropic)"
   echo "  2) Kimi (Moonshot AI — requires kimi-cli login, uses your subscription)"
+  echo "  3) Codex CLI (OpenAI — requires codex login, uses your ChatGPT subscription)"
   prompt_choice ENGINE_CHOICE "1"
 
   BOT_ENGINE="claude"
@@ -365,6 +366,21 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     info "After install, run 'kimi login' in a separate terminal to authenticate."
     # Skip the Claude provider prompt entirely for Kimi — it has its own auth.
     AUTH_CHOICE="kimi"
+  elif [[ "$ENGINE_CHOICE" == "3" ]]; then
+    BOT_ENGINE="codex"
+    CLAUDE_AUTH_METHOD="codex"
+    echo ""
+    if command -v codex &>/dev/null; then
+      success "Codex CLI found: $(command -v codex)"
+    else
+      warn "Codex CLI not found on PATH."
+      warn "Install it from https://github.com/openai/codex (see the project README for your platform)."
+      warn "MetaBot will still be configured — install Codex + run 'codex login' before starting."
+    fi
+    info "After install, run 'codex login' in a separate terminal to authenticate (or set OPENAI_API_KEY / configure a profile in ~/.codex/config.toml)."
+    info "Note: Codex runs with approvalPolicy='never' and sandbox='workspace-write' by default — interactive tool approvals are not surfaced to IM."
+    # Skip the Claude provider prompt entirely for Codex — it has its own auth.
+    AUTH_CHOICE="codex"
   else
     # ------ 4b-claude: Claude AI authentication ------
     echo ""
@@ -376,7 +392,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
   fi
 
   case "$AUTH_CHOICE" in
-    kimi)
+    kimi|codex)
       : # handled above
       ;;
     1)
@@ -525,9 +541,16 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     echo "API_PORT=${API_PORT}"
     echo "API_SECRET=${API_SECRET}"
     echo ""
-    echo "# Claude AI Authentication"
+    echo "# Agent Engine Authentication"
     if [[ "$CLAUDE_AUTH_METHOD" == "subscription" ]]; then
       echo "# Using Claude Code Subscription (OAuth). Run 'claude login' to authenticate."
+    elif [[ "$CLAUDE_AUTH_METHOD" == "kimi" ]]; then
+      echo "# Using Kimi CLI. Run 'kimi login' to authenticate."
+    elif [[ "$CLAUDE_AUTH_METHOD" == "codex" ]]; then
+      echo "# Using Codex CLI. Run 'codex login' to authenticate (or set OPENAI_API_KEY / configure ~/.codex/config.toml)."
+      echo "# CODEX_EXECUTABLE_PATH="
+      echo "# CODEX_APPROVAL_POLICY=never"
+      echo "# CODEX_SANDBOX=workspace-write"
     elif [[ -n "${CLAUDE_AUTH_ENV_LINES:-}" ]]; then
       echo "$CLAUDE_AUTH_ENV_LINES"
     fi
@@ -563,6 +586,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         defaultWorkingDirectory: process.argv[4],
       };
       if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$BOT_NAME" "$FEISHU_APP_ID" "$FEISHU_APP_SECRET" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -578,6 +602,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         defaultWorkingDirectory: process.argv[3],
       };
       if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$TG_NAME" "$TELEGRAM_BOT_TOKEN" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -593,6 +618,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         defaultWorkingDirectory: process.argv[2],
       };
       if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$WX_NAME" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -1107,6 +1133,14 @@ if [[ "${SKIP_CONFIG}" == "false" ]]; then
   fi
   if [[ "${CLAUDE_AUTH_METHOD}" == "kimi" ]]; then
     echo "    ${STEP_NUM}. Run 'kimi login' in a separate terminal (https://kimi.com to sign up)"
+    STEP_NUM=$((STEP_NUM + 1))
+  fi
+  if [[ "${CLAUDE_AUTH_METHOD}" == "codex" ]]; then
+    if ! command -v codex &>/dev/null; then
+      echo "    ${STEP_NUM}. Install Codex CLI — see https://github.com/openai/codex"
+      STEP_NUM=$((STEP_NUM + 1))
+    fi
+    echo "    ${STEP_NUM}. Run 'codex login' in a separate terminal (or set OPENAI_API_KEY / configure ~/.codex/config.toml)"
     STEP_NUM=$((STEP_NUM + 1))
   fi
   if [[ "$SETUP_FEISHU" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Add **option 3) Codex CLI** to the installer's Agent Engine menu so it matches the README's "三引擎 (Claude / Kimi / Codex)" promise.
- Detect `codex` on PATH during install and print install/login hints when missing — MetaBot still gets fully configured so users can install Codex after.
- When `engine=codex` is picked, generate `bots.json` entries with `engine: "codex"` and `codex: { approvalPolicy: "never", sandbox: "workspace-write" }` for Feishu / Telegram / WeChat bots. Matches `bots.example.json` and honors the CLAUDE.md note that interactive approvals can't be surfaced back to IM under Codex.
- `.env` now emits a Codex auth comment block with `CODEX_EXECUTABLE_PATH` / `CODEX_APPROVAL_POLICY` / `CODEX_SANDBOX` placeholders instead of forcing a Claude/Kimi header.
- "Next Steps" suggests `codex login` (and the Codex CLI install link if the binary is missing).

Before this PR, users who wanted Codex had to finish the installer with Claude and then hand-edit `bots.json` — the runtime already supported it, the installer just didn't expose it.

## Context

Reported by a user running `install.sh` who saw only Claude / Kimi in the menu despite CLAUDE.md and README promising Codex support. Runtime side (`src/engines/codex/executor.ts`, `bots.example.json`, README) was already in place — this patch is installer-only.

## Test plan

- [x] `bash -n install.sh` — syntax OK
- [x] Smoke-tested the `node -e` JSON generator with `engine=codex` — produces valid JSON matching `bots.example.json`
- [ ] End-to-end installer run picking option 3 on a clean machine (recommend a reviewer spot-check)
- [ ] `codex login` flow works after install on a machine with Codex CLI present

🤖 Generated with [Claude Code](https://claude.com/claude-code)