### PR TITLE
feat(installer): allow custom install directory via --dir / -Dir flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `install.sh`: `--dir <path>` / `-d <path>` flag to customize the install directory (priority: `--dir` > `METABOT_HOME` env > interactive prompt > `~/metabot`). Non-default paths are persisted to `~/.bashrc` / `~/.zshrc` so the `mb`/`mm`/`metabot` CLIs find the install in new shells.
+- `install.ps1`: matching `-Dir <path>` parameter on Windows; non-default paths persisted via user-level `METABOT_HOME` environment variable.
 - CONTRIBUTING.md with development setup guide
 - GitHub Actions CI workflow (Node.js 20/22 build + type check)
 - Issue templates for bug reports and feature requests

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh
 
 安装器引导一切：工作目录 → **引擎选择（Claude / Kimi / Codex）** → 订阅登录 → IM 平台 → PM2 自动启动。**5 分钟上手。**
 
+> 自定义安装目录(默认 `~/metabot`)：`curl ... | bash -s -- --dir /opt/metabot`,或 `METABOT_HOME=/opt/metabot bash install.sh`。Windows: `.\install.ps1 -Dir C:\opt\metabot`。
+
 ---
 
 ## 三引擎：Claude Code ✕ Kimi Code ✕ Codex CLI 并列一等支持

--- a/README_EN.md
+++ b/README_EN.md
@@ -42,6 +42,8 @@ curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh
 
 The installer walks you through everything: working directory → **engine choice (Claude / Kimi / Codex)** → subscription login → IM platform → auto-start with PM2. **5 minutes to get started.**
 
+> Custom install directory (default `~/metabot`): `curl ... | bash -s -- --dir /opt/metabot`, or `METABOT_HOME=/opt/metabot bash install.sh`. Windows: `.\install.ps1 -Dir C:\opt\metabot`.
+
 ---
 
 ## Multi-Engine: Claude Code, Kimi Code, and Codex CLI

--- a/install.ps1
+++ b/install.ps1
@@ -1,14 +1,49 @@
 # MetaBot Installer for Windows PowerShell
-# Usage: irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
+# Usage:
+#   irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
+#   .\install.ps1 -Dir C:\opt\metabot
+#   $env:METABOT_HOME = "C:\opt\metabot"; irm <url> | iex
 #Requires -Version 5.1
 
+[CmdletBinding()]
+param(
+    [Alias('d', 'InstallDir')]
+    [string]$Dir = "",
+
+    [switch]$Help
+)
+
 $ErrorActionPreference = "Stop"
+
+if ($Help) {
+    @"
+MetaBot Installer (Windows)
+
+Usage:
+  .\install.ps1 [-Dir <path>]
+  irm <url> | iex                        # uses default ($env:USERPROFILE\metabot) or $env:METABOT_HOME
+
+Parameters:
+  -Dir, -d <path>     Install MetaBot to <path>.
+                      Priority: -Dir > `$env:METABOT_HOME > interactive prompt.
+                      Default: `$env:USERPROFILE\metabot
+  -Help               Show this help and exit.
+
+Examples:
+  .\install.ps1
+  .\install.ps1 -Dir C:\opt\metabot
+  `$env:METABOT_HOME = "C:\opt\metabot"; irm <url> | iex
+"@ | Write-Host
+    exit 0
+}
 
 # ============================================================================
 # Configuration defaults
 # ============================================================================
 $MetabotRepo = if ($env:METABOT_REPO) { $env:METABOT_REPO } else { "https://github.com/xvirobotics/metabot.git" }
-$MetabotHome = if ($env:METABOT_HOME) { $env:METABOT_HOME } else { Join-Path $env:USERPROFILE "metabot" }
+# $MetabotHome is resolved later (Phase 0.5) — priority: -Dir > env > prompt > default.
+$DefaultMetabotHome = Join-Path $env:USERPROFILE "metabot"
+$MetabotHome = $null
 
 # ============================================================================
 # Helper functions (colors via Write-Host -ForegroundColor)
@@ -103,6 +138,51 @@ if ($PSVer.Major -lt 5 -or ($PSVer.Major -eq 5 -and $PSVer.Minor -lt 1)) {
     Write-Err "PowerShell 5.1+ is required. Current: $PSVer"
     exit 1
 }
+
+# ============================================================================
+# Phase 0.5: Resolve install directory
+# Priority: -Dir parameter > $env:METABOT_HOME > interactive prompt > default.
+# ============================================================================
+Write-Step "Phase 0.5: Choose install directory"
+
+if ($Dir) {
+    $MetabotHome = $Dir
+    Write-Info "Using install directory from -Dir: $MetabotHome"
+} elseif ($env:METABOT_HOME) {
+    $MetabotHome = $env:METABOT_HOME
+    Write-Info "Using install directory from `$env:METABOT_HOME: $MetabotHome"
+} else {
+    Write-Host ""
+    Write-Host "Where should MetaBot be installed?" -ForegroundColor White
+    Write-Host "  (Override later with -Dir or `$env:METABOT_HOME.)"
+    $MetabotHome = Read-Input "Install directory" $DefaultMetabotHome
+}
+
+# Expand a leading ~ to $env:USERPROFILE.
+if ($MetabotHome.StartsWith("~")) {
+    $MetabotHome = Join-Path $env:USERPROFILE ($MetabotHome.Substring(1).TrimStart('\','/'))
+}
+
+# Require a rooted path so all later $MetabotHome references are unambiguous.
+if (-not [System.IO.Path]::IsPathRooted($MetabotHome)) {
+    Write-Err "Install path must be absolute, got: $MetabotHome"
+    exit 1
+}
+
+# Refuse a few obviously-bad targets that would clobber the user's profile or a system root.
+$normalized = $MetabotHome.TrimEnd('\','/')
+$forbidden = @(
+    $env:USERPROFILE.TrimEnd('\','/'),
+    $env:SystemDrive,                          # e.g. "C:"
+    (Join-Path $env:SystemDrive 'Users').TrimEnd('\','/'),
+    (Join-Path $env:SystemDrive 'Windows').TrimEnd('\','/')
+) | ForEach-Object { $_.TrimEnd('\','/') }
+if ($forbidden -contains $normalized -or $normalized -eq '') {
+    Write-Err "Refusing to install directly into $MetabotHome — pick a dedicated subdirectory."
+    exit 1
+}
+
+Write-Success "Install directory: $MetabotHome"
 
 # ============================================================================
 # Phase 1: Check prerequisites
@@ -631,6 +711,15 @@ if ($HasBash) {
 } else {
     Write-Warn "Git Bash not found. CLI tools (mm, mb, metabot) require bash."
     Write-Warn "Install Git for Windows (https://git-scm.com) to enable CLI tools."
+}
+
+# Persist METABOT_HOME for non-default install paths so the CLI tools
+# (mm/mb/metabot) can find the install in new shell sessions. The CLIs all
+# fall back to ~/metabot, so we only need to persist when it differs.
+if ($MetabotHome -ne $DefaultMetabotHome) {
+    [System.Environment]::SetEnvironmentVariable("METABOT_HOME", $MetabotHome, "User")
+    $env:METABOT_HOME = $MetabotHome
+    Write-Info "Persisted METABOT_HOME=$MetabotHome to user environment"
 }
 
 # ============================================================================

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # MetaBot Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash -s -- --dir /opt/metabot
+#   METABOT_HOME=/opt/metabot bash install.sh
 set -euo pipefail
 
 # ============================================================================
@@ -14,9 +17,58 @@ else
 fi
 
 # ============================================================================
+# Parse CLI arguments
+# ============================================================================
+INSTALL_DIR_ARG=""
+print_usage() {
+  cat <<'USAGE'
+MetaBot Installer
+
+Usage:
+  bash install.sh [OPTIONS]
+  curl -fsSL <url> | bash -s -- [OPTIONS]
+
+Options:
+  -d, --dir <path>     Install MetaBot to <path>.
+                       Priority: --dir > METABOT_HOME env var > interactive prompt.
+                       Default: $HOME/metabot
+  -h, --help           Show this help and exit.
+
+Examples:
+  bash install.sh
+  bash install.sh --dir /opt/metabot
+  bash install.sh -d ~/projects/metabot
+  METABOT_HOME=/opt/metabot bash install.sh
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--dir)
+      [[ $# -ge 2 ]] || { echo "Error: $1 requires a path argument" >&2; exit 1; }
+      INSTALL_DIR_ARG="$2"
+      shift 2
+      ;;
+    --dir=*)
+      INSTALL_DIR_ARG="${1#--dir=}"
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Warning: unknown argument '$1'" >&2
+      shift
+      ;;
+  esac
+done
+
+# ============================================================================
 # Configuration defaults
 # ============================================================================
-METABOT_HOME="${METABOT_HOME:-$HOME/metabot}"
+# METABOT_HOME is resolved later (Phase 0.5) — priority: --dir > env var > prompt > default.
+DEFAULT_METABOT_HOME="$HOME/metabot"
 METABOT_REPO="${METABOT_REPO:-https://github.com/xvirobotics/metabot.git}"
 
 # ============================================================================
@@ -130,6 +182,43 @@ sed_i() {
     sed -i "$@"
   fi
 }
+
+# ============================================================================
+# Phase 0.5: Resolve install directory
+# Priority: --dir CLI arg > METABOT_HOME env var > interactive prompt > default.
+# ============================================================================
+step "Phase 0.5: Choose install directory"
+
+if [[ -n "$INSTALL_DIR_ARG" ]]; then
+  METABOT_HOME="$INSTALL_DIR_ARG"
+  info "Using install directory from --dir: $METABOT_HOME"
+elif [[ -n "${METABOT_HOME:-}" ]]; then
+  info "Using install directory from METABOT_HOME env: $METABOT_HOME"
+else
+  echo ""
+  echo -e "${BOLD}Where should MetaBot be installed?${NC}"
+  echo "  (You can override later with the METABOT_HOME env var or --dir flag.)"
+  prompt_input METABOT_HOME "Install directory" "$DEFAULT_METABOT_HOME"
+fi
+
+# Expand a leading ~ to $HOME (avoids eval; safe with spaces).
+METABOT_HOME="${METABOT_HOME/#\~/$HOME}"
+
+# Require an absolute path so all later $METABOT_HOME references are unambiguous.
+if [[ "$METABOT_HOME" != /* ]]; then
+  error "Install path must be absolute, got: $METABOT_HOME"
+  exit 1
+fi
+
+# Refuse a few obviously-bad targets that would clobber the user's home or root.
+case "$METABOT_HOME" in
+  /|/root|/home|/Users|"$HOME")
+    error "Refusing to install directly into $METABOT_HOME — pick a dedicated subdirectory."
+    exit 1
+    ;;
+esac
+
+success "Install directory: $METABOT_HOME"
 
 # ============================================================================
 # Phase 1: Check prerequisites
@@ -1000,6 +1089,24 @@ if ! echo "$PATH" | grep -q "$LOCAL_BIN"; then
   info "Added ~/.local/bin to PATH in ~/.bashrc"
 fi
 success "mm/mb/metabot CLI tools installed to $LOCAL_BIN"
+
+# Persist METABOT_HOME for non-default install paths so the CLI tools
+# (mm/mb/metabot) can find the install in new shell sessions. The CLIs all
+# fall back to $HOME/metabot, so we only need to export when it differs.
+if [[ "$METABOT_HOME" != "$DEFAULT_METABOT_HOME" ]]; then
+  for rc_file in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+    [[ -f "$rc_file" ]] || continue
+    # Drop any prior export to keep this idempotent across re-runs.
+    if grep -q '^export METABOT_HOME=' "$rc_file" 2>/dev/null; then
+      sed_i '/^export METABOT_HOME=/d' "$rc_file"
+    fi
+  done
+  echo "export METABOT_HOME=\"$METABOT_HOME\"" >> "$HOME/.bashrc"
+  if [[ -f "$HOME/.zshrc" ]]; then
+    echo "export METABOT_HOME=\"$METABOT_HOME\"" >> "$HOME/.zshrc"
+  fi
+  info "Persisted METABOT_HOME=$METABOT_HOME to shell rc files"
+fi
 
 # ============================================================================
 # Phase 8: Build + Start MetaBot with PM2


### PR DESCRIPTION
## Summary
- `install.sh` and `install.ps1` previously hardcoded `$HOME/metabot` as the install path. Adds a CLI flag (`--dir <path>` / `-d <path>` on Linux/macOS, `-Dir <path>` on Windows) and an interactive fallback prompt so users can install MetaBot anywhere.
- Resolution priority: CLI flag > `METABOT_HOME` env var > interactive prompt > `~/metabot` default. Tilde expansion + absolute-path validation; refuses to clobber `$HOME` or system roots.
- Persists `METABOT_HOME` to `~/.bashrc` / `~/.zshrc` / `~/.profile` (Linux/macOS) or to a user-level environment variable (Windows) when the chosen path is non-default — ensures the `mb`/`mm`/`metabot` CLIs in `~/.local/bin` find the install in new shell sessions (they all fall back to `~/metabot` otherwise).
- Docs: README.md, README_EN.md, CHANGELOG.md updated with the new flag.

## Test plan
- [x] `bash -n install.sh` — syntax OK
- [x] `bash install.sh --help` — prints usage
- [x] `npm run lint` — 0 errors (3 pre-existing warnings, unrelated)
- [x] `npm test` — 211/211 pass
- [x] `npm run build` — TS + web build succeeds
- [ ] Manual smoke test on a fresh box with `bash install.sh --dir /tmp/metabot-test` (left for the maintainer to verify, since this CI environment already has MetaBot installed)