### PR TITLE
feat: add /api and /resume commands for remote management

### DIFF
--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -1,15 +1,18 @@
+import * as fs from 'node:fs';
 import type { BotConfigBase } from '../config.js';
 import type { Logger } from '../utils/logger.js';
 import type { IncomingMessage } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
-import { resolveEngineName, SessionManager, getSharedApiConfigManager } from '../engines/index.js';
-import type { EngineName } from '../engines/index.js';
+import { resolveEngineName, SessionManager, ClaudeExecutor, getSharedApiConfigManager } from '../engines/index.js';
+import type { EngineName, SDKSessionInfo } from '../engines/index.js';
 import { MemoryClient } from '../memory/memory-client.js';
 import { AuditLogger } from '../utils/audit-logger.js';
 import type { DocSync } from '../sync/doc-sync.js';
 
 export class CommandHandler {
   private docSync: DocSync | null = null;
+  private pendingResumeSelections = new Map<string, { sessions: SDKSessionInfo[]; timestamp: number }>();
+  private static readonly RESUME_SELECTION_TTL_MS = 5 * 60 * 1000;
 
   constructor(
     private config: BotConfigBase,
@@ -49,6 +52,7 @@ export class CommandHandler {
           '`/model <name>` - Set model for current engine',
           '`/memory` - Memory document commands',
           '`/api` - API configuration management',
+          '`/resume` - Resume a local Claude Code session',
           '`/help` - Show this help message',
           '',
           '**Usage:**',
@@ -122,6 +126,12 @@ export class CommandHandler {
       case '/api': {
         const args = text.slice('/api'.length).trim();
         await this.handleApiCommand(chatId, args);
+        return true;
+      }
+
+      case '/resume': {
+        const args = text.slice('/resume'.length).trim();
+        await this.handleResumeCommand(chatId, args);
         return true;
       }
 
@@ -551,8 +561,169 @@ export class CommandHandler {
       await this.sender.sendTextNotice(chatId, '❌ API Error', err.message, 'red');
     }
   }
+
+  private async handleResumeCommand(chatId: string, args: string): Promise<void> {
+    if (this.getRunningTask(chatId)) {
+      await this.sender.sendTextNotice(chatId, '⏳ Task Running', 'Please wait for the current task to finish or use `/stop` first.', 'orange');
+      return;
+    }
+
+    const trimmed = args.trim();
+
+    if (!trimmed) {
+      await this.listAndShowSessions(chatId);
+      return;
+    }
+
+    const num = parseInt(trimmed, 10);
+    if (!isNaN(num) && num > 0 && String(num) === trimmed) {
+      await this.resumeByIndex(chatId, num);
+      return;
+    }
+
+    if (trimmed.length >= 8) {
+      await this.resumeByPrefix(chatId, trimmed);
+      return;
+    }
+
+    await this.sender.sendTextNotice(chatId, '📋 Resume',
+      'Usage:\n- `/resume` — List local CLI sessions\n- `/resume <n>` — Resume session by index\n- `/resume <id>` — Resume by session ID prefix (8+ chars)');
+  }
+
+  private async listAndShowSessions(chatId: string): Promise<void> {
+    try {
+      const dir = this.config.claude.defaultWorkingDirectory;
+      const sessions = await ClaudeExecutor.listHistorySessions(dir, 10);
+
+      if (sessions.length === 0) {
+        await this.sender.sendTextNotice(chatId, '📋 History Sessions', 'No local CLI sessions found.', 'blue');
+        return;
+      }
+
+      this.pendingResumeSelections.set(chatId, { sessions, timestamp: Date.now() });
+
+      const lines = sessions.map((s, i) => {
+        const branch = s.gitBranch ? `[${s.gitBranch}]` : '';
+        const age = formatRelativeTime(s.lastModified);
+        const size = s.fileSize != null ? formatFileSize(s.fileSize) : '';
+        const title = s.customTitle || s.summary || s.firstPrompt?.slice(0, 50) || '(untitled)';
+        return `**${i + 1}.** ${branch} ${title} — ${age}${size ? ` (${size})` : ''}`;
+      });
+
+      lines.push('', 'Reply `/resume <n>` to restore a session.');
+
+      await this.sender.sendTextNotice(chatId, `📋 History Sessions (${dir})`, lines.join('\n'));
+    } catch (err: any) {
+      this.logger.error({ err, chatId }, 'Failed to list sessions');
+      await this.sender.sendTextNotice(chatId, '❌ List Sessions Failed', err.message, 'red');
+    }
+  }
+
+  private async resumeByIndex(chatId: string, index: number): Promise<void> {
+    const pending = this.pendingResumeSelections.get(chatId);
+
+    if (!pending || Date.now() - pending.timestamp > CommandHandler.RESUME_SELECTION_TTL_MS) {
+      this.pendingResumeSelections.delete(chatId);
+      await this.sender.sendTextNotice(chatId, '📋 Resume', 'Session list expired. Run `/resume` again to refresh.', 'orange');
+      return;
+    }
+
+    if (index < 1 || index > pending.sessions.length) {
+      await this.sender.sendTextNotice(chatId, '❌ Invalid Index',
+        `Please enter a number between 1 and ${pending.sessions.length}.`, 'red');
+      return;
+    }
+
+    const session = pending.sessions[index - 1];
+    this.pendingResumeSelections.delete(chatId);
+    await this.applyResume(chatId, session);
+  }
+
+  private async resumeByPrefix(chatId: string, prefix: string): Promise<void> {
+    try {
+      const dir = this.config.claude.defaultWorkingDirectory;
+      const sessions = await ClaudeExecutor.listHistorySessions(dir, 50);
+      const matches = sessions.filter(s => s.sessionId.startsWith(prefix));
+
+      if (matches.length === 0) {
+        await this.sender.sendTextNotice(chatId, '❌ Not Found',
+          `No session matching "${prefix}".`, 'red');
+        return;
+      }
+
+      if (matches.length > 1) {
+        const lines = matches.slice(0, 5).map(s =>
+          `- \`${s.sessionId.slice(0, 12)}\` ${s.summary || '(untitled)'}`,
+        );
+        await this.sender.sendTextNotice(chatId, '⚠️ Multiple Matches',
+          `Found ${matches.length} sessions. Provide a longer prefix:\n${lines.join('\n')}`, 'orange');
+        return;
+      }
+
+      await this.applyResume(chatId, matches[0]);
+    } catch (err: any) {
+      this.logger.error({ err, chatId }, 'Failed to resume by prefix');
+      await this.sender.sendTextNotice(chatId, '❌ Resume Failed', err.message, 'red');
+    }
+  }
+
+  private async applyResume(chatId: string, sessionInfo: SDKSessionInfo): Promise<void> {
+    const defaultDir = this.config.claude.defaultWorkingDirectory;
+    let cwd = sessionInfo.cwd || defaultDir;
+
+    try {
+      const stat = fs.statSync(cwd);
+      if (!stat.isDirectory()) throw new Error('Not a directory');
+    } catch {
+      if (cwd !== defaultDir) {
+        await this.sender.sendTextNotice(chatId, '⚠️ Directory Missing',
+          `Original directory \`${cwd}\` not found. Using default \`${defaultDir}\`.`, 'orange');
+      }
+      cwd = defaultDir;
+    }
+
+    this.sessionManager.setSession(chatId, sessionInfo.sessionId, cwd);
+
+    const title = sessionInfo.customTitle || sessionInfo.summary || sessionInfo.firstPrompt?.slice(0, 50) || '(untitled)';
+    const parts = [
+      `**Session:** ${title}`,
+      `**ID:** \`${sessionInfo.sessionId.slice(0, 12)}...\``,
+    ];
+    if (sessionInfo.gitBranch) {
+      parts.push(`**Branch:** ${sessionInfo.gitBranch}`);
+    }
+    if (cwd !== defaultDir) {
+      parts.push(`**Working Directory:** \`${cwd}\` _(differs from default)_`);
+    }
+    parts.push('', 'Subsequent messages will continue in this session context.');
+
+    await this.sender.sendTextNotice(chatId, '✅ Session Restored', parts.join('\n'), 'green');
+
+    this.audit.log({
+      event: 'session_resumed',
+      botName: this.config.name,
+      chatId,
+      prompt: `/resume ${sessionInfo.sessionId.slice(0, 8)}`,
+    });
+  }
 }
 
 function isEngineName(value: string): value is EngineName {
   return value === 'claude' || value === 'kimi' || value === 'codex';
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }

--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -2,7 +2,7 @@ import type { BotConfigBase } from '../config.js';
 import type { Logger } from '../utils/logger.js';
 import type { IncomingMessage } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
-import { resolveEngineName, SessionManager } from '../engines/index.js';
+import { resolveEngineName, SessionManager, getSharedApiConfigManager } from '../engines/index.js';
 import type { EngineName } from '../engines/index.js';
 import { MemoryClient } from '../memory/memory-client.js';
 import { AuditLogger } from '../utils/audit-logger.js';
@@ -48,6 +48,7 @@ export class CommandHandler {
           '`/model claude`, `/model kimi`, or `/model codex` - Switch engine (resets session)',
           '`/model <name>` - Set model for current engine',
           '`/memory` - Memory document commands',
+          '`/api` - API configuration management',
           '`/help` - Show this help message',
           '',
           '**Usage:**',
@@ -115,6 +116,12 @@ export class CommandHandler {
       case '/model': {
         const args = text.slice('/model'.length).trim();
         await this.handleModelCommand(chatId, args);
+        return true;
+      }
+
+      case '/api': {
+        const args = text.slice('/api'.length).trim();
+        await this.handleApiCommand(chatId, args);
         return true;
       }
 
@@ -395,6 +402,153 @@ export class CommandHandler {
         return '_Make sure `kimi login` has been completed on this host._';
       case 'codex':
         return '_Make sure Codex CLI is authenticated (`codex login`) or configured with an API key._';
+    }
+  }
+
+  private async handleApiCommand(chatId: string, args: string): Promise<void> {
+    const apiConfigManager = getSharedApiConfigManager(this.logger);
+    const [subCmd, ...rest] = args.split(/\s+/);
+
+    if (!subCmd) {
+      await this.sender.sendTextNotice(
+        chatId,
+        '🔧 API Configuration',
+        'Usage:\n- `/api set <name> <url> <token>` — Add/update API config\n- `/api switch <name>` — Switch to saved config\n- `/api list` — List all saved configs\n- `/api current` — Show current API config\n- `/api delete <name>` — Delete saved config',
+      );
+      return;
+    }
+
+    try {
+      switch (subCmd.toLowerCase()) {
+        case 'set': {
+          const [name, baseUrl, authToken] = rest;
+          if (!name || !baseUrl || !authToken) {
+            await this.sender.sendTextNotice(chatId, '🔧 API Configuration', 'Usage: `/api set <name> <url> <token>`\n\nExample:\n`/api set kimi https://api.moonshot.ai/anthropic sk-xxx`');
+            return;
+          }
+
+          await this.sender.sendTextNotice(chatId, '⏳ Validating API', `Testing connection to ${baseUrl}...`, 'blue');
+
+          const result = await apiConfigManager.setConfig(name, { baseUrl, authToken }, true);
+
+          if (result.success) {
+            await this.sender.sendTextNotice(
+              chatId,
+              '✅ API Config Saved',
+              `Configuration "${name}" has been saved and activated.\n\n**Base URL:** \`${baseUrl}\`\n**Token:** \`${authToken.slice(0, 8)}...${authToken.slice(-4)}\``,
+              'green',
+            );
+          } else {
+            await this.sender.sendTextNotice(chatId, '❌ API Config Failed', result.error || 'Unknown error', 'red');
+          }
+          break;
+        }
+
+        case 'switch': {
+          const [nameOrIndex] = rest;
+          if (!nameOrIndex) {
+            const configs = apiConfigManager.listConfigs();
+            if (configs.length === 0) {
+              await this.sender.sendTextNotice(chatId, '🔧 API Configuration', 'No saved configurations.\n\nUse `/api set <name> <url> <token>` to add one.');
+              return;
+            }
+            const lines = configs.map((c, i) => {
+              const marker = c.isCurrent ? '✓' : ' ';
+              return `${marker} **${i + 1}.** ${c.name} — \`${c.baseUrl}\``;
+            });
+            lines.push('', 'Usage: `/api switch <name or index>`');
+            await this.sender.sendTextNotice(chatId, '🔧 Switch API', lines.join('\n'));
+            return;
+          }
+
+          let name = nameOrIndex;
+          const index = parseInt(nameOrIndex, 10);
+          if (!isNaN(index)) {
+            const configs = apiConfigManager.listConfigs();
+            if (index < 1 || index > configs.length) {
+              await this.sender.sendTextNotice(chatId, '❌ Switch Failed', `Index ${index} out of range (1-${configs.length})`, 'red');
+              return;
+            }
+            name = configs[index - 1].name;
+          }
+
+          await this.sender.sendTextNotice(chatId, '⏳ Switching API', `Validating "${name}"...`, 'blue');
+
+          const result = await apiConfigManager.switchConfig(name, true);
+
+          if (result.success) {
+            const current = apiConfigManager.getCurrentConfig();
+            await this.sender.sendTextNotice(
+              chatId,
+              '✅ API Switched',
+              `Now using configuration "${name}".\n\n**Base URL:** \`${current?.config.baseUrl}\``,
+              'green',
+            );
+          } else {
+            await this.sender.sendTextNotice(chatId, '❌ Switch Failed', result.error || 'Unknown error', 'red');
+          }
+          break;
+        }
+
+        case 'list': {
+          const configs = apiConfigManager.listConfigs();
+          if (configs.length === 0) {
+            await this.sender.sendTextNotice(chatId, '📋 API Configurations', 'No saved configurations.\n\nUse `/api set <name> <url> <token>` to add one.');
+            return;
+          }
+
+          const lines = configs.map((c, i) => {
+            const marker = c.isCurrent ? '✓' : ' ';
+            return `${marker} **${i + 1}.** ${c.name} — \`${c.baseUrl}\``;
+          });
+
+          await this.sender.sendTextNotice(chatId, '📋 API Configurations', lines.join('\n'));
+          break;
+        }
+
+        case 'current': {
+          const current = apiConfigManager.getCurrentConfig();
+          if (!current) {
+            await this.sender.sendTextNotice(chatId, 'ℹ️ No Active API', 'No API configuration is currently active.\n\nUse `/api set` or `/api switch` to activate one.');
+            return;
+          }
+
+          await this.sender.sendTextNotice(
+            chatId,
+            '🔧 Current API Configuration',
+            [
+              `**Name:** ${current.name}`,
+              `**Base URL:** \`${current.config.baseUrl}\``,
+              `**Token:** \`${current.config.authToken.slice(0, 8)}...${current.config.authToken.slice(-4)}\``,
+            ].join('\n'),
+            'blue',
+          );
+          break;
+        }
+
+        case 'delete': {
+          const [name] = rest;
+          if (!name) {
+            await this.sender.sendTextNotice(chatId, '🔧 API Configuration', 'Usage: `/api delete <name>`');
+            return;
+          }
+
+          const result = await apiConfigManager.deleteConfig(name);
+
+          if (result.success) {
+            await this.sender.sendTextNotice(chatId, '✅ Config Deleted', `Configuration "${name}" has been removed.`, 'green');
+          } else {
+            await this.sender.sendTextNotice(chatId, '❌ Delete Failed', result.error || 'Unknown error', 'red');
+          }
+          break;
+        }
+
+        default:
+          await this.sender.sendTextNotice(chatId, '🔧 API Configuration', `Unknown sub-command: \`${subCmd}\`\nUse \`/api\` for help.`, 'orange');
+      }
+    } catch (err: any) {
+      this.logger.error({ err, chatId }, 'API command error');
+      await this.sender.sendTextNotice(chatId, '❌ API Error', err.message, 'red');
     }
   }
 }

--- a/src/engines/claude/api-config-manager.ts
+++ b/src/engines/claude/api-config-manager.ts
@@ -1,0 +1,219 @@
+import * as fs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { Logger } from '../../utils/logger.js';
+
+export interface ApiConfig {
+  baseUrl: string;
+  authToken: string;
+}
+
+interface ConfigFile {
+  configs: Record<string, ApiConfig>;
+  current?: string;
+}
+
+export class ApiConfigManager {
+  private configPath: string;
+  private settingsPath: string;
+  private configs: Map<string, ApiConfig> = new Map();
+  private currentName?: string;
+
+  constructor(private logger: Logger) {
+    const claudeDir = path.join(os.homedir(), '.claude');
+    this.configPath = path.join(claudeDir, 'metabot-apis.json');
+    this.settingsPath = path.join(claudeDir, 'settings.json');
+    this.loadConfigs();
+  }
+
+  private loadConfigs(): void {
+    try {
+      if (!fs.existsSync(this.configPath)) {
+        this.logger.info('API config file not found, starting with empty config');
+        return;
+      }
+
+      const content = fs.readFileSync(this.configPath, 'utf-8');
+      const data: ConfigFile = JSON.parse(content);
+
+      this.configs.clear();
+      for (const [name, config] of Object.entries(data.configs || {})) {
+        this.configs.set(name, config);
+      }
+      this.currentName = data.current;
+
+      this.logger.info({ count: this.configs.size, current: this.currentName }, 'Loaded API configs');
+    } catch (err: any) {
+      this.logger.error({ err, path: this.configPath }, 'Failed to load API configs');
+    }
+  }
+
+  private async saveConfigs(): Promise<void> {
+    const data: ConfigFile = {
+      configs: Object.fromEntries(this.configs),
+      current: this.currentName,
+    };
+
+    const dir = path.dirname(this.configPath);
+    await fsPromises.mkdir(dir, { recursive: true });
+
+    const tmpPath = `${this.configPath}.tmp`;
+    await fsPromises.writeFile(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+    await fsPromises.rename(tmpPath, this.configPath);
+
+    this.logger.info({ path: this.configPath }, 'Saved API configs');
+  }
+
+  private async syncToSettings(config: ApiConfig): Promise<void> {
+    try {
+      let settings: Record<string, unknown> = {};
+
+      if (fs.existsSync(this.settingsPath)) {
+        const content = fs.readFileSync(this.settingsPath, 'utf-8');
+        settings = JSON.parse(content);
+      }
+
+      const env = (settings.env as Record<string, string>) || {};
+      env.ANTHROPIC_BASE_URL = config.baseUrl;
+      env.ANTHROPIC_AUTH_TOKEN = config.authToken;
+      settings.env = env;
+
+      const tmpPath = `${this.settingsPath}.tmp`;
+      await fsPromises.writeFile(tmpPath, JSON.stringify(settings, null, 2), 'utf-8');
+      await fsPromises.rename(tmpPath, this.settingsPath);
+
+      this.logger.info({ baseUrl: config.baseUrl }, 'Synced API config to settings.json');
+    } catch (err: any) {
+      this.logger.error({ err }, 'Failed to sync API config to settings.json');
+      throw new Error(`Failed to update settings.json: ${err.message}`, { cause: err });
+    }
+  }
+
+  async validateConfig(config: ApiConfig): Promise<{ valid: boolean; error?: string }> {
+    const url = `${config.baseUrl}/v1/messages`;
+    const maxRetries = 2;
+    let lastError = '';
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 8000);
+
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': config.authToken,
+            'anthropic-version': '2023-06-01',
+          },
+          body: JSON.stringify({}),
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (response.status === 401 || response.status === 403) {
+          return { valid: false, error: `Authentication failed (HTTP ${response.status})` };
+        }
+
+        return { valid: true };
+      } catch (err: any) {
+        lastError = err.name === 'AbortError' ? 'Request timeout (8s)' : (err.message || String(err));
+        this.logger.warn({ attempt: attempt + 1, maxRetries: maxRetries + 1, error: lastError }, 'API validation attempt failed, retrying...');
+
+        if (attempt < maxRetries) {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+      }
+    }
+
+    return { valid: false, error: lastError };
+  }
+
+  async setConfig(name: string, config: ApiConfig, validate = true): Promise<{ success: boolean; error?: string }> {
+    if (!name || !config.baseUrl || !config.authToken) {
+      return { success: false, error: 'Invalid config: name, baseUrl, and authToken are required' };
+    }
+
+    if (validate) {
+      this.logger.info({ name, baseUrl: config.baseUrl }, 'Validating API config');
+      const result = await this.validateConfig(config);
+      if (!result.valid) {
+        return { success: false, error: `Validation failed: ${result.error}` };
+      }
+    }
+
+    this.configs.set(name, config);
+    this.currentName = name;
+    await this.saveConfigs();
+    await this.syncToSettings(config);
+
+    this.logger.info({ name, baseUrl: config.baseUrl }, 'API config set and activated');
+    return { success: true };
+  }
+
+  async switchConfig(name: string, validate = true): Promise<{ success: boolean; error?: string }> {
+    const config = this.configs.get(name);
+    if (!config) {
+      return { success: false, error: `Config "${name}" not found` };
+    }
+
+    if (validate) {
+      this.logger.info({ name, baseUrl: config.baseUrl }, 'Validating API config before switch');
+      const result = await this.validateConfig(config);
+      if (!result.valid) {
+        return { success: false, error: `Validation failed: ${result.error}` };
+      }
+    }
+
+    this.currentName = name;
+    await this.saveConfigs();
+    await this.syncToSettings(config);
+
+    this.logger.info({ name, baseUrl: config.baseUrl }, 'Switched to API config');
+    return { success: true };
+  }
+
+  async deleteConfig(name: string): Promise<{ success: boolean; error?: string }> {
+    if (!this.configs.has(name)) {
+      return { success: false, error: `Config "${name}" not found` };
+    }
+
+    this.configs.delete(name);
+
+    if (this.currentName === name) {
+      this.currentName = undefined;
+    }
+
+    await this.saveConfigs();
+
+    this.logger.info({ name }, 'Deleted API config');
+    return { success: true };
+  }
+
+  listConfigs(): Array<{ name: string; baseUrl: string; isCurrent: boolean }> {
+    return Array.from(this.configs.entries()).map(([name, config]) => ({
+      name,
+      baseUrl: config.baseUrl,
+      isCurrent: name === this.currentName,
+    }));
+  }
+
+  getCurrentConfig(): { name: string; config: ApiConfig } | null {
+    if (!this.currentName) return null;
+    const config = this.configs.get(this.currentName);
+    if (!config) return null;
+    return { name: this.currentName, config };
+  }
+
+  getCurrentEnv(): Record<string, string> | null {
+    const current = this.getCurrentConfig();
+    if (!current) return null;
+
+    return {
+      ANTHROPIC_BASE_URL: current.config.baseUrl,
+      ANTHROPIC_AUTH_TOKEN: current.config.authToken,
+    };
+  }
+}

--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -3,8 +3,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { query } from '@anthropic-ai/claude-agent-sdk';
-import type { SDKUserMessage, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
+import { query, listSessions } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKUserMessage, SDKSessionInfo, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
+
+export type { SDKSessionInfo };
 import type { BotConfigBase } from '../../config.js';
 import type { Logger } from '../../utils/logger.js';
 import { AsyncQueue } from '../../utils/async-queue.js';
@@ -202,6 +204,11 @@ export class ClaudeExecutor {
     private config: BotConfigBase,
     private logger: Logger,
   ) {}
+
+  /** List local Claude Code CLI history sessions for a given directory. */
+  static async listHistorySessions(dir: string, limit: number = 20): Promise<SDKSessionInfo[]> {
+    return listSessions({ dir, limit });
+  }
 
   private buildQueryOptions(cwd: string, sessionId: string | undefined, abortController: AbortController, outputsDir?: string, apiContext?: ApiContext): Record<string, unknown> {
     const queryOptions: Record<string, unknown> = {

--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -8,6 +8,7 @@ import type { SDKUserMessage, SpawnOptions, SpawnedProcess } from '@anthropic-ai
 import type { BotConfigBase } from '../../config.js';
 import type { Logger } from '../../utils/logger.js';
 import { AsyncQueue } from '../../utils/async-queue.js';
+import { ApiConfigManager } from './api-config-manager.js';
 
 const isWindows = process.platform === 'win32';
 
@@ -58,8 +59,9 @@ function hasCredentialsFile(): boolean {
  *   or credentials.json exists (so env-var-only users can still authenticate).
  * - Merges process.env so child inherits system PATH, TEMP, etc.
  * - Optionally injects an explicit ANTHROPIC_API_KEY from bots.json config.
+ * - Optionally injects extra env vars (e.g. from ApiConfigManager).
  */
-function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => SpawnedProcess {
+function createSpawnFn(explicitApiKey?: string, extraEnv?: Record<string, string>): (options: SpawnOptions) => SpawnedProcess {
   // Decide once whether to filter auth env vars
   const filterAuthVars = !!(explicitApiKey || hasCredentialsFile());
 
@@ -85,6 +87,11 @@ function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => Spaw
       env.ANTHROPIC_API_KEY = explicitApiKey;
     }
 
+    // Inject extra env vars (e.g. ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN from ApiConfigManager)
+    if (extraEnv) {
+      Object.assign(env, extraEnv);
+    }
+
     const child = spawn(nodePath, options.args, {
       cwd: options.cwd,
       env,
@@ -94,6 +101,21 @@ function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => Spaw
 
     return child as unknown as SpawnedProcess;
   };
+}
+
+/** Singleton ApiConfigManager — shared across all ClaudeExecutor instances. */
+let _apiConfigManager: ApiConfigManager | null = null;
+
+function getApiConfigManager(logger: Logger): ApiConfigManager {
+  if (!_apiConfigManager) {
+    _apiConfigManager = new ApiConfigManager(logger);
+  }
+  return _apiConfigManager;
+}
+
+/** Expose the singleton for use by CommandHandler (/api command). */
+export function getSharedApiConfigManager(logger: Logger): ApiConfigManager {
+  return getApiConfigManager(logger);
 }
 
 export interface ApiContext {
@@ -193,7 +215,7 @@ export class ClaudeExecutor {
       // Cross-platform spawn: custom spawn filters CLAUDE* env vars and uses
       // process.execPath to avoid PATH issues on Windows; fileURLToPath converts
       // file:// URLs to native paths for the SDK CLI entrypoint.
-      spawnClaudeCodeProcess: createSpawnFn(this.config.claude.apiKey),
+      spawnClaudeCodeProcess: createSpawnFn(this.config.claude.apiKey, getApiConfigManager(this.logger).getCurrentEnv() ?? undefined),
       executableArgs: [path.join(path.dirname(fileURLToPath(import.meta.resolve('@anthropic-ai/claude-agent-sdk'))), 'cli.js')],
       pathToClaudeCodeExecutable: CLAUDE_EXECUTABLE,
     };

--- a/src/engines/claude/index.ts
+++ b/src/engines/claude/index.ts
@@ -28,6 +28,7 @@ export { ApiConfigManager } from './api-config-manager.js';
 export type { UserSession } from './session-manager.js';
 export type {
   SDKMessage,
+  SDKSessionInfo,
   ExecutionHandle,
   ExecutorOptions,
   ApiContext,

--- a/src/engines/claude/index.ts
+++ b/src/engines/claude/index.ts
@@ -21,9 +21,10 @@ export class ClaudeEngine implements Engine {
   }
 }
 
-export { ClaudeExecutor } from './executor.js';
+export { ClaudeExecutor, getSharedApiConfigManager } from './executor.js';
 export { StreamProcessor, extractImagePaths } from './stream-processor.js';
 export { SessionManager } from './session-manager.js';
+export { ApiConfigManager } from './api-config-manager.js';
 export type { UserSession } from './session-manager.js';
 export type {
   SDKMessage,
@@ -32,3 +33,4 @@ export type {
   ApiContext,
 } from './executor.js';
 export type { DetectedTool } from './stream-processor.js';
+export type { ApiConfig } from './api-config-manager.js';

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -99,6 +99,20 @@ export class SessionManager {
     this.saveToDisk();
   }
 
+  /** Restore a CLI history session: set sessionId and optionally workingDirectory. */
+  setSession(chatId: string, sessionId: string, workingDirectory?: string): void {
+    const session = this.getSession(chatId);
+    session.sessionId = sessionId;
+    if (workingDirectory) {
+      session.workingDirectory = workingDirectory;
+    }
+    this.logger.info(
+      { chatId, sessionId: sessionId.slice(0, 8), workingDirectory },
+      'Session restored from CLI history',
+    );
+    this.saveToDisk();
+  }
+
   /** Set per-session model override. Pass undefined to clear. */
   setSessionModel(chatId: string, model: string | undefined): void {
     const session = this.getSession(chatId);

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -60,6 +60,7 @@ export {
 export type {
   UserSession,
   SDKMessage,
+  SDKSessionInfo,
   ExecutionHandle,
   ExecutorOptions,
   ApiContext,

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -54,6 +54,8 @@ export {
   StreamProcessor,
   SessionManager,
   extractImagePaths,
+  ApiConfigManager,
+  getSharedApiConfigManager,
 } from './claude/index.js';
 export type {
   UserSession,
@@ -62,4 +64,5 @@ export type {
   ExecutorOptions,
   ApiContext,
   DetectedTool,
+  ApiConfig,
 } from './claude/index.js';

--- a/src/utils/audit-logger.ts
+++ b/src/utils/audit-logger.ts
@@ -11,7 +11,8 @@ export type AuditEvent =
   | 'command'
   | 'auth_denied'
   | 'api_task_start'
-  | 'api_task_complete';
+  | 'api_task_complete'
+  | 'session_resumed';
 
 export interface AuditEntry {
   event: AuditEvent;


### PR DESCRIPTION
## Summary

- **`/api` command**: remotely switch Claude API endpoints from Feishu when quota is exhausted. Supports multiple saved configurations with connectivity validation and persistence (`~/.claude/metabot-apis.json`).
- **`/resume` command**: enumerate and resume local Claude Code CLI sessions from Feishu, continuing unfinished tasks with full conversation context via the Agent SDK's `listSessions()` API.

## Changes

- New `src/engines/claude/api-config-manager.ts` — CRUD, validation, persistence for API configs
- Modified `src/engines/claude/executor.ts` — inject API config env vars into subprocess + `listHistorySessions()` static method
- Modified `src/engines/claude/session-manager.ts` — `setSession()` for restoring CLI sessions
- Modified `src/bridge/command-handler.ts` — `/api` and `/resume` command handlers
- Modified `src/engines/claude/index.ts` + `src/engines/index.ts` — re-exports
- Modified `src/utils/audit-logger.ts` — `session_resumed` event type

## Test plan

- [x] `/api set test https://api.example.com sk-xxx` — validates and saves
- [x] `/api list` — shows saved configs with index
- [x] `/api switch 1` — switches by index
- [x] `/api current` — displays active config
- [x] `/api delete test` — removes config
- [x] `/resume` — lists local CLI sessions
- [x] `/resume 1` — resumes first session
- [x] `npm run build` passes (excluding pre-existing kimi SDK issue)
- [x] `npm test` — 207 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)