### PR TITLE
fix(codex): mirror skills and avoid bwrap sandbox

### DIFF
--- a/bin/mb
+++ b/bin/mb
@@ -351,7 +351,8 @@ print(json.dumps({'botName': sys.argv[1], 'source': sys.argv[2]}))
 
     echo "==> Updating skills..."
     SKILLS_DIR="$HOME/.claude/skills"
-    mkdir -p "$SKILLS_DIR"
+    CODEX_SKILLS_DIR="$HOME/.codex/skills"
+    mkdir -p "$SKILLS_DIR" "$CODEX_SKILLS_DIR"
     for skill in metaskill metamemory metabot voice phone-call skill-hub; do
       case "$skill" in
         metaskill)   src="$METABOT_SRC/src/skills/metaskill" ;;
@@ -363,8 +364,10 @@ print(json.dumps({'botName': sys.argv[1], 'source': sys.argv[2]}))
         *)           src="" ;;
       esac
       if [[ -n "$src" && -d "$src" ]]; then
-        mkdir -p "$SKILLS_DIR/$skill"
-        cp -r "$src/." "$SKILLS_DIR/$skill/"
+        for dst_root in "$SKILLS_DIR" "$CODEX_SKILLS_DIR"; do
+          mkdir -p "$dst_root/$skill"
+          cp -r "$src/." "$dst_root/$skill/"
+        done
         echo "    Updated: $skill"
       fi
     done
@@ -372,6 +375,9 @@ print(json.dumps({'botName': sys.argv[1], 'source': sys.argv[2]}))
     if [[ -d "$SKILLS_DIR/feishu-doc" ]]; then
       rm -rf "$SKILLS_DIR/feishu-doc"
       echo "    Removed legacy: feishu-doc"
+    fi
+    if [[ -d "$CODEX_SKILLS_DIR/feishu-doc" ]]; then
+      rm -rf "$CODEX_SKILLS_DIR/feishu-doc"
     fi
 
     # Check if lark-cli skills were previously installed (opt-in via install.sh)
@@ -389,19 +395,24 @@ print(json.dumps({'botName': sys.argv[1], 'source': sys.argv[2]}))
       " 2>/dev/null || true)
       if [[ -n "${work_dir:-}" ]]; then
         ws_skills_dir="$work_dir/.claude/skills"
-        mkdir -p "$ws_skills_dir"
+        ws_codex_skills_dir="$work_dir/.codex/skills"
+        mkdir -p "$ws_skills_dir" "$ws_codex_skills_dir"
         for skill in metaskill metamemory metabot voice phone-call skill-hub; do
           if [[ -d "$SKILLS_DIR/$skill" ]]; then
-            mkdir -p "$ws_skills_dir/$skill"
-            cp -r "$SKILLS_DIR/$skill/." "$ws_skills_dir/$skill/"
+            for dst_root in "$ws_skills_dir" "$ws_codex_skills_dir"; do
+              mkdir -p "$dst_root/$skill"
+              cp -r "$SKILLS_DIR/$skill/." "$dst_root/$skill/"
+            done
           fi
         done
         # Copy lark-cli skills if previously installed
         if [[ "${has_lark_skills:-false}" == "true" ]]; then
           for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
             if [[ -d "$SKILLS_DIR/$lark_skill" ]]; then
-              mkdir -p "$ws_skills_dir/$lark_skill"
-              cp -r "$SKILLS_DIR/$lark_skill/." "$ws_skills_dir/$lark_skill/"
+              for dst_root in "$ws_skills_dir" "$ws_codex_skills_dir"; do
+                mkdir -p "$dst_root/$lark_skill"
+                cp -r "$SKILLS_DIR/$lark_skill/." "$dst_root/$lark_skill/"
+              done
             fi
           done
         fi
@@ -409,8 +420,14 @@ print(json.dumps({'botName': sys.argv[1], 'source': sys.argv[2]}))
         if [[ -d "$ws_skills_dir/feishu-doc" ]]; then
           rm -rf "$ws_skills_dir/feishu-doc"
         fi
+        if [[ -d "$ws_codex_skills_dir/feishu-doc" ]]; then
+          rm -rf "$ws_codex_skills_dir/feishu-doc"
+        fi
         if [[ -f "$METABOT_SRC/src/workspace/CLAUDE.md" ]]; then
           cp "$METABOT_SRC/src/workspace/CLAUDE.md" "$work_dir/CLAUDE.md"
+          if [[ ! -e "$work_dir/AGENTS.md" ]]; then
+            cp "$METABOT_SRC/src/workspace/CLAUDE.md" "$work_dir/AGENTS.md"
+          fi
         fi
       fi
     fi

--- a/bin/metabot
+++ b/bin/metabot
@@ -62,9 +62,10 @@ cmd_update() {
     success "CLI tools updated"
   fi
 
-  # Update skills in ~/.claude/skills
+  # Update skills in ~/.claude/skills and ~/.codex/skills
   SKILLS_DIR="$HOME/.claude/skills"
-  mkdir -p "$SKILLS_DIR"
+  CODEX_SKILLS_DIR="$HOME/.codex/skills"
+  mkdir -p "$SKILLS_DIR" "$CODEX_SKILLS_DIR"
   info "Updating skills..."
   local src=""
   for skill in metaskill metamemory metabot voice skill-hub; do
@@ -77,14 +78,19 @@ cmd_update() {
       *)          src="" ;;
     esac
     if [[ -n "$src" && -d "$src" ]]; then
-      mkdir -p "$SKILLS_DIR/$skill"
-      cp -r "$src/." "$SKILLS_DIR/$skill/"
+      for dst_root in "$SKILLS_DIR" "$CODEX_SKILLS_DIR"; do
+        mkdir -p "$dst_root/$skill"
+        cp -r "$src/." "$dst_root/$skill/"
+      done
     fi
   done
   # Clean up legacy feishu-doc skill
   if [[ -d "$SKILLS_DIR/feishu-doc" ]]; then
     rm -rf "$SKILLS_DIR/feishu-doc"
     info "Removed legacy feishu-doc skill"
+  fi
+  if [[ -d "$CODEX_SKILLS_DIR/feishu-doc" ]]; then
+    rm -rf "$CODEX_SKILLS_DIR/feishu-doc"
   fi
 
   # Update lark-cli skills only if previously installed (opt-in via install.sh)
@@ -104,21 +110,26 @@ cmd_update() {
     " 2>/dev/null || true)
     if [[ -n "$work_dir" ]]; then
       local ws_skills_dir="$work_dir/.claude/skills"
-      mkdir -p "$ws_skills_dir"
+      local ws_codex_skills_dir="$work_dir/.codex/skills"
+      mkdir -p "$ws_skills_dir" "$ws_codex_skills_dir"
 
       # Copy common skills
       for skill in metaskill metamemory metabot voice skill-hub; do
         if [[ -d "$SKILLS_DIR/$skill" ]]; then
-          mkdir -p "$ws_skills_dir/$skill"
-          cp -r "$SKILLS_DIR/$skill/." "$ws_skills_dir/$skill/"
+          for dst_root in "$ws_skills_dir" "$ws_codex_skills_dir"; do
+            mkdir -p "$dst_root/$skill"
+            cp -r "$SKILLS_DIR/$skill/." "$dst_root/$skill/"
+          done
         fi
       done
       # Copy lark-cli skills if previously installed
       if [[ "$has_lark_skills" == "true" ]]; then
         for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
           if [[ -d "$SKILLS_DIR/$lark_skill" ]]; then
-            mkdir -p "$ws_skills_dir/$lark_skill"
-            cp -r "$SKILLS_DIR/$lark_skill/." "$ws_skills_dir/$lark_skill/"
+            for dst_root in "$ws_skills_dir" "$ws_codex_skills_dir"; do
+              mkdir -p "$dst_root/$lark_skill"
+              cp -r "$SKILLS_DIR/$lark_skill/." "$dst_root/$lark_skill/"
+            done
           fi
         done
       fi
@@ -126,9 +137,15 @@ cmd_update() {
       if [[ -d "$ws_skills_dir/feishu-doc" ]]; then
         rm -rf "$ws_skills_dir/feishu-doc"
       fi
+      if [[ -d "$ws_codex_skills_dir/feishu-doc" ]]; then
+        rm -rf "$ws_codex_skills_dir/feishu-doc"
+      fi
       # Update CLAUDE.md
       if [[ -f "$METABOT_HOME/src/workspace/CLAUDE.md" ]]; then
         cp "$METABOT_HOME/src/workspace/CLAUDE.md" "$work_dir/CLAUDE.md"
+        if [[ ! -e "$work_dir/AGENTS.md" ]]; then
+          cp "$METABOT_HOME/src/workspace/CLAUDE.md" "$work_dir/AGENTS.md"
+        fi
       fi
       success "Workspace skills updated"
     fi

--- a/src/api/routes/skill-hub-routes.ts
+++ b/src/api/routes/skill-hub-routes.ts
@@ -56,7 +56,11 @@ export async function handleSkillHubRoutes(
       return true;
     }
 
-    const skillDir = path.join(bot.config.claude.defaultWorkingDirectory, '.claude', 'skills', skillName);
+    const skillDir = [
+      path.join(bot.config.claude.defaultWorkingDirectory, '.claude', 'skills', skillName),
+      path.join(bot.config.claude.defaultWorkingDirectory, '.codex', 'skills', skillName),
+    ].find((candidate) => fs.existsSync(path.join(candidate, 'SKILL.md')))
+      ?? path.join(bot.config.claude.defaultWorkingDirectory, '.claude', 'skills', skillName);
     const skillMdPath = path.join(skillDir, 'SKILL.md');
     if (!fs.existsSync(skillMdPath)) {
       jsonResponse(res, 404, { error: `Skill not found at ${skillMdPath}` });

--- a/src/api/skills-installer.ts
+++ b/src/api/skills-installer.ts
@@ -29,7 +29,10 @@ export interface InstallSkillsOptions {
 
 export function installSkillsToWorkDir(workDir: string, logger: Logger, options?: InstallSkillsOptions): void {
   const userSkillsDir = path.join(os.homedir(), '.claude', 'skills');
-  const destSkillsDir = path.join(workDir, '.claude', 'skills');
+  const destSkillDirs = [
+    path.join(workDir, '.claude', 'skills'),
+    path.join(workDir, '.codex', 'skills'),
+  ];
 
   const skillNames = options?.platform === 'feishu'
     ? [...COMMON_SKILLS, ...LARK_CLI_SKILLS]
@@ -43,10 +46,12 @@ export function installSkillsToWorkDir(workDir: string, logger: Logger, options?
       continue;
     }
 
-    const dest = path.join(destSkillsDir, skill);
-    fs.mkdirSync(dest, { recursive: true });
-    fs.cpSync(src, dest, { recursive: true });
-    logger.info({ skill, src, dest }, 'Skill installed to working directory');
+    for (const destSkillsDir of destSkillDirs) {
+      const dest = path.join(destSkillsDir, skill);
+      fs.mkdirSync(dest, { recursive: true });
+      fs.cpSync(src, dest, { recursive: true });
+      logger.info({ skill, src, dest }, 'Skill installed to working directory');
+    }
   }
 
   // For Feishu bots, ensure lark-cli is configured
@@ -54,23 +59,7 @@ export function installSkillsToWorkDir(workDir: string, logger: Logger, options?
     ensureLarkCliConfig(options.feishuAppId, options.feishuAppSecret, logger);
   }
 
-  // Deploy workspace CLAUDE.md if not already present
-  const destClaudeMd = path.join(workDir, 'CLAUDE.md');
-  if (!fs.existsSync(destClaudeMd)) {
-    const thisFile = url.fileURLToPath(import.meta.url);
-    const thisDir = path.dirname(thisFile);
-    // Try src/workspace/CLAUDE.md (tsx) or dist/workspace/CLAUDE.md (compiled)
-    for (const candidate of [
-      path.join(thisDir, '..', 'workspace', 'CLAUDE.md'),
-      path.join(thisDir, '..', '..', 'src', 'workspace', 'CLAUDE.md'),
-    ]) {
-      if (fs.existsSync(candidate)) {
-        fs.copyFileSync(candidate, destClaudeMd);
-        logger.info({ dest: destClaudeMd }, 'CLAUDE.md deployed to working directory');
-        break;
-      }
-    }
-  }
+  deployWorkspaceInstructions(workDir, logger);
 }
 
 /**
@@ -114,19 +103,44 @@ export function installSkillFromHub(
   referencesTar: Buffer | undefined,
   logger: Logger,
 ): void {
-  const destDir = path.join(workDir, '.claude', 'skills', skillName);
-  fs.mkdirSync(destDir, { recursive: true });
-  fs.writeFileSync(path.join(destDir, 'SKILL.md'), skillMd, 'utf-8');
+  const destDirs = [
+    path.join(workDir, '.claude', 'skills', skillName),
+    path.join(workDir, '.codex', 'skills', skillName),
+  ];
 
-  if (referencesTar && referencesTar.length > 0) {
-    try {
-      execSync(`tar xf - -C "${destDir}"`, { input: referencesTar, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30_000 });
-    } catch (err: any) {
-      logger.warn({ err: err.message, skillName }, 'Failed to extract references tar');
+  for (const destDir of destDirs) {
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(path.join(destDir, 'SKILL.md'), skillMd, 'utf-8');
+
+    if (referencesTar && referencesTar.length > 0) {
+      try {
+        execSync(`tar xf - -C "${destDir}"`, { input: referencesTar, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30_000 });
+      } catch (err: any) {
+        logger.warn({ err: err.message, skillName, destDir }, 'Failed to extract references tar');
+      }
     }
-  }
 
-  logger.info({ skillName, dest: destDir }, 'Skill installed from Hub');
+    logger.info({ skillName, dest: destDir }, 'Skill installed from Hub');
+  }
+}
+
+function deployWorkspaceInstructions(workDir: string, logger: Logger): void {
+  const thisFile = url.fileURLToPath(import.meta.url);
+  const thisDir = path.dirname(thisFile);
+  for (const candidate of [
+    path.join(thisDir, '..', 'workspace', 'CLAUDE.md'),
+    path.join(thisDir, '..', '..', 'src', 'workspace', 'CLAUDE.md'),
+  ]) {
+    if (!fs.existsSync(candidate)) continue;
+
+    for (const fileName of ['CLAUDE.md', 'AGENTS.md']) {
+      const dest = path.join(workDir, fileName);
+      if (fs.existsSync(dest)) continue;
+      fs.copyFileSync(candidate, dest);
+      logger.info({ dest }, `${fileName} deployed to working directory`);
+    }
+    break;
+  }
 }
 
 /** Locate the lark-cli executable. */

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -591,22 +591,24 @@ export class MessageBridge {
     const session = this.sessionManager.getSession(chatId);
     const cwd = session.workingDirectory;
     const abortController = new AbortController();
+    const activeEngine = session.engine ?? resolveEngineName(this.config);
+    const enginePromptText = normalizePromptForEngine(text, activeEngine);
 
     // Prepare downloads directory (bot-isolated)
     const downloadsDir = this.config.claude.downloadsDir;
     fs.mkdirSync(downloadsDir, { recursive: true });
 
     // Handle image download if present
-    let prompt = text;
+    let prompt = enginePromptText;
     let imagePath: string | undefined;
     let filePath: string | undefined;
     if (imageKey) {
       imagePath = path.join(downloadsDir, `${imageKey}.png`);
       const ok = await this.sender.downloadImage(msgId, imageKey, imagePath);
       if (ok) {
-        prompt = `${text}\n\n[Image saved at: ${imagePath}]\nPlease use the Read tool to read and analyze this image file.`;
+        prompt = `${enginePromptText}\n\n[Image saved at: ${imagePath}]\nPlease use the Read tool to read and analyze this image file.`;
       } else {
-        prompt = `${text}\n\n(Note: Failed to download the image)`;
+        prompt = `${enginePromptText}\n\n(Note: Failed to download the image)`;
       }
     }
 
@@ -615,9 +617,9 @@ export class MessageBridge {
       filePath = path.join(downloadsDir, `${fileKey}_${fileName}`);
       const ok = await this.sender.downloadFile(msgId, fileKey, filePath);
       if (ok) {
-        prompt = `${text}\n\n[File saved at: ${filePath}]\nPlease use the Read tool (for text/code files, images, PDFs) or Bash tool (for other formats) to read and analyze this file.`;
+        prompt = `${enginePromptText}\n\n[File saved at: ${filePath}]\nPlease use the Read tool (for text/code files, images, PDFs) or Bash tool (for other formats) to read and analyze this file.`;
       } else {
-        prompt = `${text}\n\n(Note: Failed to download the file)`;
+        prompt = `${enginePromptText}\n\n(Note: Failed to download the file)`;
       }
     }
 
@@ -1517,8 +1519,16 @@ export function isStaleSessionError(errorMessage?: string): boolean {
   return /no conversation found|conversation not found|session id|invalid session|multiple.*tool_result.*blocks|each tool_use must have a single result/i.test(errorMessage);
 }
 
+export function normalizePromptForEngine(text: string, engine: EngineName): string {
+  if (engine !== 'codex') return text;
+  const match = text.match(/^\/([A-Za-z0-9][A-Za-z0-9_-]*)([\s\S]*)$/);
+  if (!match) return text;
+  const suffix = match[2] ?? '';
+  if (suffix && !/^\s/.test(suffix)) return text;
+  return `$${match[1]}${suffix}`;
+}
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) return false;
   return /context.window.exceeds.limit|context.length.exceeded|context.too.long|max.context.length|token.limit.exceeded|maximum.context/i.test(errorMessage);
 }
-

--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -144,7 +144,7 @@ export function buildCodexArgs(
     args.push('--dangerously-bypass-approvals-and-sandbox');
   } else {
     args.push('-a', codexConfig.approvalPolicy ?? 'never');
-    args.push('--sandbox', codexConfig.sandbox ?? 'workspace-write');
+    args.push('--sandbox', codexConfig.sandbox ?? 'danger-full-access');
   }
 
   args.push('-C', cwd);

--- a/src/skills/metaskill/SKILL.md
+++ b/src/skills/metaskill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metaskill
-description: "The meta-skill: create AI agent teams, individual agents, or custom skills for any project. Use when the user wants to generate a complete .claude/ agent team, create a single agent, or create a single skill."
+description: "The meta-skill: create AI agent teams, individual agents, or custom skills for any project. Use when the user wants to generate a complete agent team, create a single agent, or create a single skill for Claude Code, Kimi, or Codex."
 user-invocable: true
 disable-model-invocation: false
 context: fork
@@ -17,7 +17,7 @@ You are an elite AI agent architect. You can create complete agent teams, indivi
 
 Working directory: !`pwd`
 Existing subdirectories: !`ls -d */ 2>/dev/null | head -20 || echo "empty directory"`
-Skill base: !`for d in "$HOME/.claude/skills/metaskill" ".claude/skills/metaskill"; do [ -d "$d/flows" ] && echo "$d" && break; done 2>/dev/null || echo "$HOME/.claude/skills/metaskill"`
+Skill base: !`for d in ".codex/skills/metaskill" ".claude/skills/metaskill" "$HOME/.codex/skills/metaskill" "$HOME/.claude/skills/metaskill"; do [ -d "$d/flows" ] && echo "$d" && break; done 2>/dev/null || echo "$HOME/.codex/skills/metaskill"`
 
 ## Step 1: Detect Intent
 

--- a/src/skills/metaskill/flows/agent.md
+++ b/src/skills/metaskill/flows/agent.md
@@ -1,6 +1,6 @@
 # Flow: Create Single Agent
 
-You are an elite AI agent architect specializing in crafting high-performance Claude Code subagent configurations. Your task is to create a well-designed agent based on the user's request.
+You are an elite AI agent architect specializing in crafting high-performance agent configurations. Your task is to create a well-designed agent based on the user's request.
 
 ## Process
 
@@ -19,6 +19,7 @@ Also check for existing agents to avoid conflicts:
 ```
 Glob(".claude/agents/*.md")
 Glob("~/.claude/agents/*.md")
+Read("AGENTS.md") — if it exists
 ```
 
 ### Step 2: Determine Scope
@@ -129,4 +130,4 @@ After writing the file, confirm the file path and briefly explain how to use the
 
 ### Engine Compatibility Note
 
-`.claude/agents/*.md` files are discovered only by the **Claude engine**. Under the **Kimi engine**, subagent definitions in this directory are not loaded — Kimi only ships with the builtin `default`/`okabe` subagents. If the target bot uses `engine: "kimi"` in `bots.json`, this agent will have no effect; the main session must handle its role inline. Tell the user this when the bot is Kimi-backed.
+`.claude/agents/*.md` files are discovered only by the **Claude engine**. Under the **Kimi** and **Codex** engines, subagent definitions in this directory are not loaded. For Codex compatibility, also add or update an `AGENTS.md` section that describes when the main Codex session should assume this role inline. Tell the user that the standalone agent file only takes effect under Claude, while `AGENTS.md` carries the guidance for Codex/Kimi.

--- a/src/skills/metaskill/flows/skill.md
+++ b/src/skills/metaskill/flows/skill.md
@@ -1,6 +1,6 @@
 # Flow: Create Single Skill
 
-You are a Claude Code skill designer. Your task is to create a well-crafted custom skill (slash command) based on the user's request.
+You are an AI agent skill designer. Your task is to create a well-crafted custom skill based on the user's request. The skill should work in Claude Code/Kimi (`.claude/skills`) and Codex (`.codex/skills`) when possible.
 
 ## Process
 
@@ -19,6 +19,8 @@ Also check for existing skills to avoid naming conflicts:
 ```
 Glob(".claude/skills/*/SKILL.md")
 Glob("~/.claude/skills/*/SKILL.md")
+Glob(".codex/skills/*/SKILL.md")
+Glob("~/.codex/skills/*/SKILL.md")
 ```
 
 ### Step 2: Determine Scope and Behavior
@@ -26,8 +28,8 @@ Glob("~/.claude/skills/*/SKILL.md")
 Ask the user (if not clear from their request):
 
 1. **Where to save:**
-   - **Project-level** (`.claude/skills/<name>/SKILL.md`) — specific to this project
-   - **User-level** (`~/.claude/skills/<name>/SKILL.md`) — available across all projects
+   - **Project-level** (`.claude/skills/<name>/SKILL.md` and `.codex/skills/<name>/SKILL.md`) — specific to this project, compatible with Claude/Kimi/Codex
+   - **User-level** (`~/.claude/skills/<name>/SKILL.md` and `~/.codex/skills/<name>/SKILL.md`) — available across all projects for both engines
 
 2. **Invocation model:**
    - **User-invocable + auto-invocable** (default) — appears in `/` menu AND Claude can auto-trigger it
@@ -105,12 +107,16 @@ Provide a structured report with severity levels.
 
 ### Step 6: Write the File
 
-Create the directory and write the SKILL.md file to the chosen path:
+Create the directory and write the SKILL.md file to the chosen paths:
 
 ```
-~/.claude/skills/<name>/SKILL.md     (user-level)
-.claude/skills/<name>/SKILL.md       (project-level)
+~/.claude/skills/<name>/SKILL.md     (user-level, Claude/Kimi)
+~/.codex/skills/<name>/SKILL.md      (user-level, Codex)
+.claude/skills/<name>/SKILL.md       (project-level, Claude/Kimi)
+.codex/skills/<name>/SKILL.md        (project-level, Codex)
 ```
+
+For Codex, keep `name` and `description` accurate; Codex uses those fields for discovery and may ignore Claude-specific fields like `allowed-tools`, `context`, or `user-invocable`. Prefer portable instructions in the Markdown body over engine-specific frontmatter.
 
 ### Key Principles
 

--- a/src/skills/metaskill/flows/team.md
+++ b/src/skills/metaskill/flows/team.md
@@ -17,7 +17,8 @@ If the user's request is empty or unclear, use `AskUserQuestion` to ask the user
 **All files are created inside this project folder:**
 ```
 <project-folder>/
-├── CLAUDE.md                          # Orchestration hub (YOU are the tech lead)
+├── CLAUDE.md                          # Claude/Kimi orchestration hub (YOU are the tech lead)
+├── AGENTS.md                          # Codex orchestration hub (same content or symlink)
 ├── .mcp.json                          # MCP server config
 └── .claude/
     ├── agents/
@@ -38,24 +39,26 @@ cd <project-folder>
 git init
 ```
 
-### Engine Compatibility (Claude ↔ Kimi)
+### Engine Compatibility (Claude ↔ Kimi ↔ Codex)
 
-MetaBot supports two engines: **Claude Code** and **Kimi**. The scaffolded project should be usable by either engine. Key differences you must account for:
+MetaBot supports three engines: **Claude Code**, **Kimi**, and **Codex**. The scaffolded project should be usable by any engine. Key differences you must account for:
 
-| Feature | Claude | Kimi |
-|---------|--------|------|
-| Orchestration doc | `CLAUDE.md` | `AGENTS.md` (symlink `CLAUDE.md` → `AGENTS.md`) |
-| `.claude/skills/` | ✅ auto-discovered | ✅ auto-discovered (brand fallback) |
-| `.claude/agents/*.md` | ✅ auto-discovered | ❌ not loaded (Kimi has only builtin `default`/`okabe`) |
-| MCP config | `.mcp.json` (project-level) | `~/.kimi/mcp.json` (user-level) |
+| Feature | Claude | Kimi | Codex |
+|---------|--------|------|-------|
+| Orchestration doc | `CLAUDE.md` | `AGENTS.md` (symlink or copy from `CLAUDE.md`) | `AGENTS.md` |
+| Skills | `.claude/skills/` | `.claude/skills/` | `.codex/skills/` |
+| `.claude/agents/*.md` | ✅ auto-discovered | ❌ not loaded (builtin agents only) | ❌ not loaded |
+| MCP config | `.mcp.json` (project-level) | `~/.kimi/mcp.json` (user-level) | Codex config / MCP setup |
 
 **What to do at the end of Phase 2 (before verification):**
 ```bash
-# Create AGENTS.md symlink so Kimi reads the same CLAUDE.md
+# Create AGENTS.md symlink so Kimi/Codex read the same orchestration guide
 [ -f CLAUDE.md ] && [ ! -e AGENTS.md ] && ln -s CLAUDE.md AGENTS.md
+# Mirror project skills for Codex
+if [ -d .claude/skills ]; then mkdir -p .codex && cp -R .claude/skills .codex/skills; fi
 ```
 
-Note in the final summary that subagents under `.claude/agents/` only take effect under the Claude engine. Users who run this team on a Kimi-backed bot should expect the orchestrator (CLAUDE.md/AGENTS.md) to do the work inline rather than delegating.
+Note in the final summary that subagents under `.claude/agents/` only take effect under the Claude engine. Users who run this team on a Kimi- or Codex-backed bot should expect the orchestrator (`AGENTS.md`) to do the work inline rather than delegating to project subagents.
 
 All subsequent paths in Phase 2-4 are **relative to this project folder**. You MUST `cd` into the project folder before creating any files.
 
@@ -127,9 +130,9 @@ After all searches, write a structured summary (in your thinking, not as a file)
 
 Based on your research findings combined with the embedded patterns below, create all files **inside the project folder** created in Step 0. Make sure you are `cd`'d into the project folder before writing any files. Create them in this order.
 
-### File 1: `<project-folder>/CLAUDE.md`
+### File 1: `<project-folder>/CLAUDE.md` and `<project-folder>/AGENTS.md`
 
-Write a comprehensive `CLAUDE.md` that serves as the orchestration hub. Structure:
+Write a comprehensive `CLAUDE.md` that serves as the orchestration hub. Then create `AGENTS.md` as a symlink or copy of the same content so Codex reads it. Structure:
 
 ```markdown
 # CLAUDE.md

--- a/src/workspace/CLAUDE.md
+++ b/src/workspace/CLAUDE.md
@@ -1,6 +1,6 @@
 # MetaBot Workspace
 
-This workspace is managed by **MetaBot** — an AI assistant accessible via Feishu/Telegram that runs the Claude Code or Kimi agent engine with full tool access. The bot's engine is configured per-bot in `bots.json` (`engine: "claude" | "kimi"`).
+This workspace is managed by **MetaBot** — an AI assistant accessible via Feishu/Telegram that runs the Claude Code, Kimi, or Codex agent engine with full tool access. The bot's engine is configured per-bot in `bots.json` (`engine: "claude" | "kimi" | "codex"`).
 
 ## Available Skills
 
@@ -8,9 +8,9 @@ This workspace is managed by **MetaBot** — an AI assistant accessible via Feis
 Create AI agent teams, individual agents, or custom skills for any project.
 
 ```
-/metaskill ios app          → generates full .claude/ agent team
+/metaskill ios app          → generates a portable agent team
 /metaskill a security agent → creates a single agent
-/metaskill a deploy skill   → creates a custom slash command
+/metaskill a deploy skill   → creates a custom skill
 ```
 
 ### /metamemory — Shared Knowledge Store
@@ -50,7 +50,7 @@ lark-cli calendar +agenda --as user                      # View calendar
 lark-cli base records list ...                           # Query bitable
 ```
 
-19 AI Agent Skills are installed (lark-doc, lark-im, lark-calendar, lark-sheets, lark-base, lark-task, lark-drive, lark-mail, lark-wiki, etc.) providing structured guidance for each domain.
+19 AI Agent Skills are installed (lark-doc, lark-im, lark-calendar, lark-sheets, lark-base, lark-task, lark-drive, lark-mail, lark-wiki, etc.) providing structured guidance for each domain. Claude/Kimi discover these under `.claude/skills`; Codex discovers the mirrored copies under `.codex/skills`.
 
 ## Guidelines
 

--- a/tests/codex-build-args.test.ts
+++ b/tests/codex-build-args.test.ts
@@ -9,11 +9,11 @@ describe('buildCodexArgs', () => {
   const cwd = '/work/proj';
   const prompt = 'run pwd';
 
-  it('defaults approval policy to "never" and sandbox to "workspace-write"', () => {
+  it('defaults approval policy to "never" and sandbox to "danger-full-access"', () => {
     const args = buildCodexArgs({}, cwd, prompt, undefined, undefined);
     expect(args).toEqual([
       '-a', 'never',
-      '--sandbox', 'workspace-write',
+      '--sandbox', 'danger-full-access',
       '-C', cwd,
       'exec', '--json', '--color', 'never', '--skip-git-repo-check', prompt,
     ]);

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isStaleSessionError } from '../src/bridge/message-bridge.js';
+import { isStaleSessionError, normalizePromptForEngine } from '../src/bridge/message-bridge.js';
 
 describe('isStaleSessionError', () => {
   it('matches the GitHub issue error text', () => {
@@ -29,5 +29,19 @@ describe('isStaleSessionError', () => {
     expect(isStaleSessionError('Task timed out (24 hour limit)')).toBe(false);
     expect(isStaleSessionError('permission denied')).toBe(false);
     expect(isStaleSessionError(undefined)).toBe(false);
+  });
+});
+
+describe('normalizePromptForEngine', () => {
+  it('converts slash skill invocations to Codex explicit skill syntax', () => {
+    expect(normalizePromptForEngine('/metaskill ios app', 'codex')).toBe('$metaskill ios app');
+    expect(normalizePromptForEngine('/skill-name', 'codex')).toBe('$skill-name');
+  });
+
+  it('leaves non-Codex and non-skill prompts unchanged', () => {
+    expect(normalizePromptForEngine('/metaskill ios app', 'claude')).toBe('/metaskill ios app');
+    expect(normalizePromptForEngine('/metaskill ios app', 'kimi')).toBe('/metaskill ios app');
+    expect(normalizePromptForEngine('hello /metaskill', 'codex')).toBe('hello /metaskill');
+    expect(normalizePromptForEngine('/bad/path', 'codex')).toBe('/bad/path');
   });
 });

--- a/tests/skills-installer.test.ts
+++ b/tests/skills-installer.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { installSkillFromHub, installSkillsToWorkDir } from '../src/api/skills-installer.js';
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+} as any;
+
+let cleanupDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of cleanupDirs) rmSync(dir, { recursive: true, force: true });
+  cleanupDirs = [];
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+describe('skills installer', () => {
+  it('installs hub skills to both Claude and Codex project skill directories', () => {
+    const workDir = tempDir('metabot-work-');
+    installSkillFromHub(workDir, 'demo-skill', '---\nname: demo-skill\ndescription: Demo\n---\n', undefined, logger);
+
+    expect(readFileSync(join(workDir, '.claude/skills/demo-skill/SKILL.md'), 'utf-8')).toContain('demo-skill');
+    expect(readFileSync(join(workDir, '.codex/skills/demo-skill/SKILL.md'), 'utf-8')).toContain('demo-skill');
+  });
+
+  it('mirrors user skills into Claude and Codex project directories and deploys AGENTS.md', () => {
+    const priorHome = process.env.HOME;
+    const home = tempDir('metabot-home-');
+    const workDir = tempDir('metabot-work-');
+    try {
+      process.env.HOME = home;
+      mkdirSync(join(home, '.claude/skills/metaskill'), { recursive: true });
+      writeFileSync(join(home, '.claude/skills/metaskill/SKILL.md'), '---\nname: metaskill\ndescription: Meta\n---\n');
+
+      installSkillsToWorkDir(workDir, logger);
+
+      expect(readFileSync(join(workDir, '.claude/skills/metaskill/SKILL.md'), 'utf-8')).toContain('metaskill');
+      expect(readFileSync(join(workDir, '.codex/skills/metaskill/SKILL.md'), 'utf-8')).toContain('metaskill');
+      expect(readFileSync(join(workDir, 'AGENTS.md'), 'utf-8')).toContain('MetaBot Workspace');
+    } finally {
+      if (priorHome === undefined) delete process.env.HOME;
+      else process.env.HOME = priorHome;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- mirror MetaBot/Skill Hub skills into both .claude/skills and .codex/skills so Codex can discover the same skills
- deploy AGENTS.md alongside CLAUDE.md and update MetaSkill flows for Claude/Kimi/Codex compatibility
- translate Feishu /skill invocations to Codex explicit  syntax
- default Codex sandbox to danger-full-access to avoid bubblewrap failures on hosts without unprivileged user namespaces; CODEX_SANDBOX/codex.sandbox can still override

## Tests
- npm test -- --run tests/message-bridge.test.ts tests/skills-installer.test.ts tests/codex-build-args.test.ts tests/codex-jsonl-translator.test.ts
- npm run lint (passes with existing warnings)
- npm run build