### PR TITLE
fix(codex): install bundled skills when user cache is empty

### DIFF
--- a/src/api/skills-installer.ts
+++ b/src/api/skills-installer.ts
@@ -39,9 +39,11 @@ export function installSkillsToWorkDir(workDir: string, logger: Logger, options?
     : COMMON_SKILLS;
 
   for (const skill of skillNames) {
-    const src = path.join(userSkillsDir, skill);
+    const src = fs.existsSync(path.join(userSkillsDir, skill))
+      ? path.join(userSkillsDir, skill)
+      : bundledSkillSource(skill);
 
-    if (!fs.existsSync(src)) {
+    if (!src || !fs.existsSync(src)) {
       logger.debug({ skill }, 'Skill source not found, skipping');
       continue;
     }
@@ -138,6 +140,34 @@ function deployWorkspaceInstructions(workDir: string, logger: Logger): void {
     copyInstructionFile(fs.existsSync(existingClaudeMd) ? existingClaudeMd : candidate, path.join(workDir, 'AGENTS.md'), 'AGENTS.md', logger);
     break;
   }
+}
+
+function bundledSkillSource(skill: string): string | undefined {
+  const thisFile = url.fileURLToPath(import.meta.url);
+  const thisDir = path.dirname(thisFile);
+  const candidatesBySkill: Record<string, string[]> = {
+    metaskill: [
+      path.join(thisDir, '..', 'skills', 'metaskill'),
+      path.join(thisDir, '..', '..', 'src', 'skills', 'metaskill'),
+    ],
+    metamemory: [
+      path.join(thisDir, '..', 'memory', 'skill'),
+      path.join(thisDir, '..', '..', 'src', 'memory', 'skill'),
+    ],
+    metabot: [
+      path.join(thisDir, '..', 'skills', 'metabot'),
+      path.join(thisDir, '..', '..', 'src', 'skills', 'metabot'),
+    ],
+    voice: [
+      path.join(thisDir, '..', 'skills', 'voice'),
+      path.join(thisDir, '..', '..', 'src', 'skills', 'voice'),
+    ],
+    'skill-hub': [
+      path.join(thisDir, '..', 'skills', 'skill-hub'),
+      path.join(thisDir, '..', '..', 'src', 'skills', 'skill-hub'),
+    ],
+  };
+  return candidatesBySkill[skill]?.find((candidate) => fs.existsSync(candidate));
 }
 
 function copyInstructionFile(src: string, dest: string, fileName: string, logger: Logger): void {

--- a/tests/skills-installer.test.ts
+++ b/tests/skills-installer.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -33,14 +33,13 @@ describe('skills installer', () => {
     expect(readFileSync(join(workDir, '.codex/skills/demo-skill/SKILL.md'), 'utf-8')).toContain('demo-skill');
   });
 
-  it('mirrors user skills into Claude and Codex project directories and deploys AGENTS.md', () => {
+  it('mirrors bundled skills into Claude and Codex project directories and deploys AGENTS.md', () => {
     const priorHome = process.env.HOME;
     const home = tempDir('metabot-home-');
     const workDir = tempDir('metabot-work-');
     try {
       process.env.HOME = home;
-      mkdirSync(join(home, '.claude/skills/metaskill'), { recursive: true });
-      writeFileSync(join(home, '.claude/skills/metaskill/SKILL.md'), '---\nname: metaskill\ndescription: Meta\n---\n');
+      mkdirSync(join(home, '.claude/skills'), { recursive: true });
 
       installSkillsToWorkDir(workDir, logger);
 


### PR DESCRIPTION
## Summary
- fall back to bundled MetaBot skill sources when ~/.claude/skills is empty or missing
- keep Codex .codex/skills mirroring reliable on fresh installs and current server state

## Tests
- npm test -- --run tests/skills-installer.test.ts tests/message-bridge.test.ts tests/codex-build-args.test.ts
- npm run lint (passes with existing warnings)
- npm run build