### PR TITLE
feat(feishu): add Card Schema 2.0 with native table + lark_md headings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "grammy": "^1.40.0",
         "https-proxy-agent": "^7.0.6",
         "mammoth": "^1.12.0",
+        "marked": "^18.0.3",
         "node-edge-tts": "^1.2.10",
         "openai": "^6.29.0",
         "pino": "^9.0.0",
@@ -4159,6 +4160,18 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grammy": "^1.40.0",
     "https-proxy-agent": "^7.0.6",
     "mammoth": "^1.12.0",
+    "marked": "^18.0.3",
     "node-edge-tts": "^1.2.10",
     "openai": "^6.29.0",
     "pino": "^9.0.0",

--- a/src/feishu/card-builder-v2.ts
+++ b/src/feishu/card-builder-v2.ts
@@ -1,0 +1,353 @@
+/**
+ * Feishu Card 2.0 schema builder
+ *
+ * Coexists with card-builder.ts (v1), switched via CARD_SCHEMA_V2 env var.
+ *
+ * Key improvements over v1:
+ *   - Markdown headings → div + lark_md for proper heading rendering
+ *   - Markdown tables  → native tag: 'table' (scrollable, aligned, styled)
+ *   - Footer stats     → column_set with grey background panel
+ *   - Code blocks      → markdown ``` fences (Feishu v2 doesn't support
+ *     tag: 'code' / 'code_block' — returns 400 "not support tag")
+ *
+ * What doesn't work in Feishu v2 (documented for future reference):
+ *   - text_size on markdown element: silently ignored
+ *   - <font size="N"> in markdown: ignored
+ *   - tag: 'code' / 'code_block': 400 error
+ *   - tag: 'note': deprecated in v2
+ */
+import type { CardState, CardStatus } from '../types.js';
+import { parseMarkdownToBlocks, type Block } from './markdown-parser.js';
+
+const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: string }> = {
+  thinking:           { color: 'blue',   title: 'Thinking...',       icon: '🔵' },
+  running:            { color: 'blue',   title: 'Running...',        icon: '🔵' },
+  complete:           { color: 'green',  title: 'Complete',          icon: '🟢' },
+  error:              { color: 'red',    title: 'Error',             icon: '🔴' },
+  waiting_for_input:  { color: 'yellow', title: 'Waiting for Input', icon: '🟡' },
+};
+
+const BG_ICON: Record<'running' | 'completed' | 'failed' | 'stopped', string> = {
+  running:   '⏳',
+  completed: '✅',
+  failed:    '❌',
+  stopped:   '⏹️',
+};
+
+const MAX_CONTENT_LENGTH = 28000;
+const FOOTER_FONT_SIZE   = 2;
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + '…';
+}
+
+function truncateContent(text: string): string {
+  if (text.length <= MAX_CONTENT_LENGTH) return text;
+  const half = Math.floor(MAX_CONTENT_LENGTH / 2) - 50;
+  return text.slice(0, half) + '\n\n... (content truncated) ...\n\n' + text.slice(-half);
+}
+
+function blockToElement(block: Block): unknown {
+  switch (block.type) {
+    case 'heading':
+      return {
+        tag: 'div',
+        text: {
+          tag:     'lark_md',
+          content: '#'.repeat(block.level) + ' ' + block.text,
+        },
+      };
+
+    case 'table': {
+      const columns = block.headers.map((h, i) => ({
+        name:             `col${i}`,
+        display_name:     h,
+        data_type:        'text',
+        horizontal_align: block.align[i] ?? 'left',
+        vertical_align:   'center',
+        width:            'auto',
+      }));
+      const rows = block.rows.map((row) => {
+        const obj: Record<string, string> = {};
+        row.forEach((cell, i) => { obj[`col${i}`] = cell; });
+        return obj;
+      });
+      return {
+        tag:       'table',
+        page_size: 10,
+        row_height: 'low',
+        header_style: {
+          text_align:       'center',
+          background_style: 'grey',
+          bold:             true,
+          lines:            1,
+        },
+        columns,
+        rows,
+      };
+    }
+
+    case 'codeblock':
+      return {
+        tag:     'markdown',
+        content: '```\n' + block.code + '\n```',
+      };
+
+    case 'hr':
+      return { tag: 'hr' };
+
+    case 'markdown':
+      return {
+        tag:        'markdown',
+        content:    block.text,
+        text_align: 'left',
+      };
+  }
+}
+
+/** Split response text into blocks then map to v2 card elements */
+function responseToElements(text: string): unknown[] {
+  const truncated = truncateContent(text);
+  const blocks    = parseMarkdownToBlocks(truncated);
+  return blocks.map(blockToElement);
+}
+
+export function buildCardV2(state: CardState): string {
+  const config   = STATUS_CONFIG[state.status];
+  const elements: unknown[] = [];
+
+  // Tool calls section
+  if (state.toolCalls.length > 0) {
+    const toolLines = state.toolCalls.map((t) => {
+      const icon = t.status === 'running' ? '⏳' : '✅';
+      return `${icon} **${t.name}** ${t.detail}`;
+    });
+    elements.push({
+      tag:     'markdown',
+      content: toolLines.join('\n'),
+    });
+    elements.push({ tag: 'hr' });
+  }
+
+  // Background tasks (Monitor, etc.)
+  if (state.backgroundEvents && state.backgroundEvents.length > 0) {
+    const lines = state.backgroundEvents.map((ev) => {
+      const icon    = BG_ICON[ev.status];
+      const shortId = ev.taskId.slice(0, 6);
+      const desc    = truncate(ev.description, 60);
+      const last    = ev.lastEvent ? ` — _${truncate(ev.lastEvent, 140)}_` : '';
+      return `${icon} **${desc}** \`${shortId}\`${last}`;
+    });
+    elements.push({
+      tag:     'markdown',
+      content: '📡 **Background**\n' + lines.join('\n'),
+    });
+    elements.push({ tag: 'hr' });
+  }
+
+  // Response content (parsed into blocks)
+  if (state.responseText) {
+    elements.push(...responseToElements(state.responseText));
+  } else if (state.status === 'thinking') {
+    elements.push({
+      tag:     'markdown',
+      content: '_Thinking..._',
+    });
+  }
+
+  // Pending question section — interactive buttons + text-fallback hint
+  if (state.pendingQuestion) {
+    elements.push({ tag: 'hr' });
+    state.pendingQuestion.questions.forEach((q, qi) => {
+      const descLines = q.options.map(
+        (opt, i) => `**${i + 1}.** ${opt.label} — _${opt.description}_`,
+      );
+      elements.push({
+        tag:     'markdown',
+        content: [`**[${q.header}] ${q.question}**`, '', ...descLines].join('\n'),
+      });
+      const actions = q.options.map((opt, oi) => ({
+        tag:   'button',
+        text:  { tag: 'plain_text', content: `${oi + 1}. ${opt.label}` },
+        type:  'primary',
+        value: {
+          action:        'answer_question',
+          toolUseId:     state.pendingQuestion!.toolUseId,
+          questionIndex: qi,
+          optionIndex:   oi,
+        },
+      }));
+      elements.push({ tag: 'action', actions });
+    });
+    elements.push({
+      tag:     'markdown',
+      content: '_点击按钮选择，或直接输入自定义答案_',
+    });
+  }
+
+  // Error message
+  if (state.errorMessage) {
+    elements.push({
+      tag:     'markdown',
+      content: `**Error:** ${state.errorMessage}`,
+    });
+  }
+
+  // Stats footer — grey background panel
+  {
+    const parts: string[] = [];
+    if (state.totalTokens && state.contextWindow) {
+      const pct    = Math.round((state.totalTokens / state.contextWindow) * 100);
+      const tokensK = state.totalTokens >= 1000
+        ? `${(state.totalTokens / 1000).toFixed(1)}k`
+        : `${state.totalTokens}`;
+      const ctxK = `${Math.round(state.contextWindow / 1000)}k`;
+      parts.push(`ctx: ${tokensK}/${ctxK} (${pct}%)`);
+    }
+    if (state.status === 'complete' || state.status === 'error') {
+      if (state.sessionCostUsd != null) parts.push(`$${state.sessionCostUsd.toFixed(2)}`);
+      if (state.model) parts.push(state.model.replace(/^claude-/, ''));
+      if (state.durationMs !== undefined) parts.push(`${(state.durationMs / 1000).toFixed(1)}s`);
+    }
+    if (parts.length > 0) {
+      elements.push({
+        tag:               'column_set',
+        background_style:  'grey',
+        margin:            '12px 0px 0px 0px',
+        horizontal_spacing: '0px',
+        columns: [
+          {
+            tag:            'column',
+            width:          'weighted',
+            weight:         1,
+            vertical_align: 'center',
+            padding:        '6px 12px 6px 12px',
+            elements: [
+              {
+                tag:        'markdown',
+                content:    `<font color="grey" size="${FOOTER_FONT_SIZE}">_${parts.join(' | ')}_</font>`,
+                text_align: 'right',
+              },
+            ],
+          },
+        ],
+      });
+    }
+  }
+
+  const card = {
+    schema: '2.0',
+    config: {
+      streaming_mode: false,
+      enable_forward: true,
+      update_multi:   true,
+      summary: {
+        content: state.responseText
+          ? state.responseText.replace(/[\r\n]+/g, ' ').slice(0, 60)
+          : config.title,
+      },
+    },
+    header: {
+      template: config.color,
+      title: {
+        tag:     'plain_text',
+        content: `${config.icon} ${config.title}`,
+      },
+    },
+    body: {
+      direction:        'vertical',
+      vertical_spacing: '4px',
+      elements,
+    },
+  };
+
+  return JSON.stringify(card);
+}
+
+/** v2 help card */
+export function buildHelpCardV2(): string {
+  const card = {
+    schema: '2.0',
+    config: { enable_forward: true, update_multi: true },
+    header: {
+      template: 'blue',
+      title: { tag: 'plain_text', content: '📖 Help' },
+    },
+    body: {
+      direction: 'vertical',
+      elements: [
+        {
+          tag:     'markdown',
+          content: [
+            '**Available Commands:**',
+            '`/reset` - Clear session, start fresh',
+            '`/stop` - Abort current running task',
+            '`/status` - Show current session info',
+            '`/memory` - Memory document commands',
+            '`/help` - Show this help message',
+            '',
+            '**Usage:**',
+            'Send any text message to start a conversation with Claude Code.',
+            'Each chat has an independent session with a fixed working directory.',
+          ].join('\n'),
+        },
+      ],
+    },
+  };
+  return JSON.stringify(card);
+}
+
+/** v2 status card */
+export function buildStatusCardV2(
+  userId: string,
+  workingDirectory: string,
+  sessionId: string | undefined,
+  isRunning: boolean,
+): string {
+  const card = {
+    schema: '2.0',
+    config: { enable_forward: true, update_multi: true },
+    header: {
+      template: 'blue',
+      title: { tag: 'plain_text', content: '📊 Status' },
+    },
+    body: {
+      direction: 'vertical',
+      elements: [
+        {
+          tag:     'markdown',
+          content: [
+            `**User:** \`${userId}\``,
+            `**Working Directory:** \`${workingDirectory}\``,
+            `**Session:** ${sessionId ? `\`${sessionId.slice(0, 8)}...\`` : '_None_'}`,
+            `**Running:** ${isRunning ? 'Yes ⏳' : 'No'}`,
+          ].join('\n'),
+        },
+      ],
+    },
+  };
+  return JSON.stringify(card);
+}
+
+/** v2 generic text card */
+export function buildTextCardV2(title: string, content: string, color: string = 'blue'): string {
+  const card = {
+    schema: '2.0',
+    config: { enable_forward: true, update_multi: true },
+    header: {
+      template: color,
+      title: { tag: 'plain_text', content: title },
+    },
+    body: {
+      direction: 'vertical',
+      elements: [
+        {
+          tag: 'markdown',
+          content,
+        },
+      ],
+    },
+  };
+  return JSON.stringify(card);
+}

--- a/src/feishu/feishu-sender-adapter.ts
+++ b/src/feishu/feishu-sender-adapter.ts
@@ -3,7 +3,12 @@ import type { IMessageSender } from '../bridge/message-sender.interface.js';
 import type { CardState } from '../types.js';
 import { MessageSender } from './message-sender.js';
 import { buildCard, buildTextCard } from './card-builder.js';
+import { buildCardV2, buildTextCardV2 } from './card-builder-v2.js';
 import { OutputsManager } from '../bridge/outputs-manager.js';
+
+// CARD_SCHEMA_V2=true → use v2 (native table + lark_md headings + grey footer)
+// Default v1 for backward compatibility; switch per-bot via env var.
+const USE_V2 = process.env.CARD_SCHEMA_V2 === 'true';
 
 /**
  * Adapts the Feishu-specific MessageSender to the platform-agnostic IMessageSender interface.
@@ -13,15 +18,15 @@ export class FeishuSenderAdapter implements IMessageSender {
   constructor(private sender: MessageSender) {}
 
   async sendCard(chatId: string, state: CardState): Promise<string | undefined> {
-    return this.sender.sendCard(chatId, buildCard(state));
+    return this.sender.sendCard(chatId, USE_V2 ? buildCardV2(state) : buildCard(state));
   }
 
   async updateCard(messageId: string, state: CardState): Promise<boolean> {
-    return this.sender.updateCard(messageId, buildCard(state));
+    return this.sender.updateCard(messageId, USE_V2 ? buildCardV2(state) : buildCard(state));
   }
 
   async sendTextNotice(chatId: string, title: string, content: string, color: string = 'blue'): Promise<void> {
-    await this.sender.sendCard(chatId, buildTextCard(title, content, color));
+    await this.sender.sendCard(chatId, USE_V2 ? buildTextCardV2(title, content, color) : buildTextCard(title, content, color));
   }
 
   async sendText(chatId: string, text: string): Promise<void> {

--- a/src/feishu/markdown-parser.ts
+++ b/src/feishu/markdown-parser.ts
@@ -1,0 +1,108 @@
+/**
+ * Markdown → Block sequence parser
+ *
+ * Used by card-builder-v2: splits Claude's markdown output into a block
+ * sequence, then each block type maps to a native Feishu v2 component
+ * (heading/table/code_block/markdown).
+ *
+ * Uses `marked` to parse (handles nesting/escaping/alignment edge cases),
+ * then flattens its token tree into our block types.
+ */
+import { marked, type Tokens } from 'marked';
+
+export type Block =
+  | { type: 'heading'; level: 1 | 2 | 3 | 4 | 5 | 6; text: string }
+  | { type: 'table'; headers: string[]; align: ('left' | 'center' | 'right')[]; rows: string[][] }
+  | { type: 'codeblock'; lang: string; code: string }
+  | { type: 'hr' }
+  | { type: 'markdown'; text: string };
+
+/** Convert a token back to raw markdown text (for passthrough blocks) */
+function tokenToMarkdown(token: Tokens.Generic): string {
+  return token.raw ?? '';
+}
+
+/**
+ * Flatten inline tokens array into a markdown string.
+ * Used for heading titles, table cells, and other inline contexts.
+ */
+function inlineTokensToText(tokens: Tokens.Generic[] | undefined): string {
+  if (!tokens) return '';
+  return tokens.map((t) => t.raw ?? (t as any).text ?? '').join('');
+}
+
+export function parseMarkdownToBlocks(md: string): Block[] {
+  if (!md) return [];
+
+  const tokens = marked.lexer(md);
+  const blocks: Block[] = [];
+
+  // Collect consecutive paragraph/list/blockquote etc. into a single markdown
+  // block so Feishu's native markdown renderer handles them as a unit.
+  let buffer: string[] = [];
+  const flushBuffer = () => {
+    if (buffer.length > 0) {
+      const text = buffer.join('').trim();
+      if (text) blocks.push({ type: 'markdown', text });
+      buffer = [];
+    }
+  };
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case 'heading': {
+        flushBuffer();
+        const t = token as Tokens.Heading;
+        const level = Math.min(6, Math.max(1, t.depth)) as 1 | 2 | 3 | 4 | 5 | 6;
+        blocks.push({
+          type: 'heading',
+          level,
+          text: inlineTokensToText(t.tokens) || t.text,
+        });
+        break;
+      }
+
+      case 'table': {
+        flushBuffer();
+        const t = token as Tokens.Table;
+        const headers = t.header.map((h) => h.text);
+        const align    = t.align.map((a) => (a === 'center' ? 'center' : a === 'right' ? 'right' : 'left'));
+        const rows     = t.rows.map((row) => row.map((cell) => cell.text));
+        blocks.push({ type: 'table', headers, align, rows });
+        break;
+      }
+
+      case 'code': {
+        flushBuffer();
+        const t = token as Tokens.Code;
+        blocks.push({
+          type: 'codeblock',
+          lang: t.lang || '',
+          code: t.text,
+        });
+        break;
+      }
+
+      case 'hr': {
+        flushBuffer();
+        blocks.push({ type: 'hr' });
+        break;
+      }
+
+      // paragraph / list / blockquote / plain text → buffer, merged later
+      case 'paragraph':
+      case 'list':
+      case 'blockquote':
+      case 'space':
+      case 'text':
+      case 'html':
+      case 'br':
+      default:
+        buffer.push(tokenToMarkdown(token));
+        break;
+    }
+  }
+
+  flushBuffer();
+  return blocks;
+}


### PR DESCRIPTION
## Summary

Adds an alternative Feishu card builder using the **Card 2.0 schema** for richer rendering. The new builder coexists with v1 and is switched on per-bot via `CARD_SCHEMA_V2=true` env var (default off, v1 remains the fallback).

### What v2 improves over v1

| Feature | v1 (current) | v2 (this PR) |
|---------|-------------|-------------|
| Markdown headings | All render at body font size | Proper heading sizes via `div` + `lark_md` |
| Markdown tables | Raw markdown text (no formatting) | Native `tag: 'table'` — scrollable, aligned, styled headers |
| Footer stats | `tag: 'note'` (deprecated in v2) | `column_set` with grey background panel |
| Card schema | v1 (no `schema` field) | `schema: '2.0'` with `body.direction: 'vertical'` |
| Background events | ✅ Supported | ✅ Supported (ported from v1) |
| Pending questions | Text-only options | Interactive buttons + text fallback |

### What doesn't work in Feishu v2 (documented in code)

- `text_size` on markdown element: silently ignored
- `<font size="N">` in markdown content: ignored
- `tag: 'code'` / `tag: 'code_block'`: returns 400 "not support tag"
- `tag: 'note'`: deprecated — use `column_set` + small text instead

### New files

- **`src/feishu/markdown-parser.ts`** — `marked`-based parser that splits Claude's markdown output into a typed Block sequence (heading / table / codeblock / hr / markdown)
- **`src/feishu/card-builder-v2.ts`** — Maps Block sequence to Feishu Card 2.0 JSON elements

### Modified files

- **`src/feishu/feishu-sender-adapter.ts`** — Imports v2 builder, routes via `CARD_SCHEMA_V2` env var
- **`package.json`** — Adds `marked` dependency

### How to enable

Set env var per bot:
```bash
CARD_SCHEMA_V2=true
```

Or in `ecosystem.config.cjs`:
```javascript
env: { CARD_SCHEMA_V2: 'true' }
```

## Test plan

- [x] TypeScript build passes (`tsc --noEmit`)
- [x] Full `npm run build` succeeds
- [x] Tested on a live Feishu bot — headings, tables, code blocks, footer stats all render correctly
- [x] v1 fallback works when `CARD_SCHEMA_V2` is not set
- [ ] Verify no regression on pending question buttons
- [ ] Verify background events display

🤖 Generated with [Claude Code](https://claude.com/claude-code)