### PR TITLE
Fix Codex resume after engine switch

### DIFF
--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -356,7 +356,7 @@ export class CommandHandler {
 
     // Set the model (use only the first token, ignore trailing junk)
     const newModel = args.split(/\s+/)[0];
-    this.sessionManager.setSessionModel(chatId, newModel);
+    this.sessionManager.setSessionModel(chatId, newModel, activeEngine);
     await this.sender.sendTextNotice(
       chatId,
       '✅ Model Set',

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -166,6 +166,37 @@ export class MessageBridge {
     return entry.executor;
   }
 
+  /**
+   * Session ids and model overrides are engine-specific. If a bot's default
+   * engine changes between restarts, discard the old per-chat state before the
+   * next execution so another engine does not try to resume it.
+   */
+  private prepareSessionForExecution(chatId: string) {
+    const session = this.sessionManager.getSession(chatId);
+    const engineName: EngineName = session.engine ?? resolveEngineName(this.config);
+
+    if (session.sessionId && session.sessionIdEngine && session.sessionIdEngine !== engineName) {
+      this.logger.info(
+        { chatId, sessionIdEngine: session.sessionIdEngine, engine: engineName },
+        'Clearing session id from a different engine',
+      );
+      this.sessionManager.resetSession(chatId);
+    }
+
+    if (session.model && session.modelEngine && session.modelEngine !== engineName) {
+      this.logger.info(
+        { chatId, modelEngine: session.modelEngine, engine: engineName },
+        'Clearing model override from a different engine',
+      );
+      this.sessionManager.setSessionModel(chatId, undefined);
+    }
+
+    return {
+      session: this.sessionManager.getSession(chatId),
+      engineName,
+    };
+  }
+
   /** Inject the doc sync service for /sync commands. */
   setDocSync(docSync: DocSync): void {
     this.commandHandler.setDocSync(docSync);
@@ -588,7 +619,7 @@ export class MessageBridge {
 
   private async executeQuery(msg: IncomingMessage): Promise<void> {
     const { userId, chatId, text, imageKey, fileKey, fileName, messageId: msgId } = msg;
-    const session = this.sessionManager.getSession(chatId);
+    const { session, engineName } = this.prepareSessionForExecution(chatId);
     const cwd = session.workingDirectory;
     const abortController = new AbortController();
 
@@ -741,8 +772,8 @@ export class MessageBridge {
 
         // Update session ID if discovered
         const newSessionId = processor.getSessionId();
-        if (newSessionId && newSessionId !== session.sessionId) {
-          this.sessionManager.setSessionId(chatId, newSessionId);
+        if (newSessionId && (newSessionId !== session.sessionId || session.sessionIdEngine !== engineName)) {
+          this.sessionManager.setSessionId(chatId, newSessionId, engineName);
         }
 
         // Check if we hit a waiting_for_input state
@@ -858,7 +889,7 @@ export class MessageBridge {
           const state = processor.processMessage(message);
           lastState = state;
           const newSid = processor.getSessionId();
-          if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+          if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
           if (state.status === 'complete' || state.status === 'error') break;
           rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
         }
@@ -884,7 +915,7 @@ export class MessageBridge {
           const state = processor.processMessage(message);
           lastState = state;
           const newSid = processor.getSessionId();
-          if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+          if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
           if (state.status === 'complete' || state.status === 'error') break;
           rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
         }
@@ -950,7 +981,7 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
             const newSid = processor.getSessionId();
-            if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+            if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
             if (state.status === 'complete' || state.status === 'error') break;
             rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
           }
@@ -1039,7 +1070,7 @@ export class MessageBridge {
       return { success: false, responseText: '', error: 'Chat is busy with another task' };
     }
 
-    const session = this.sessionManager.getSession(chatId);
+    const { session, engineName } = this.prepareSessionForExecution(chatId);
     const cwd = session.workingDirectory;
     const abortController = new AbortController();
 
@@ -1135,8 +1166,8 @@ export class MessageBridge {
         lastState = state;
 
         const newSessionId = processor.getSessionId();
-        if (newSessionId && newSessionId !== session.sessionId) {
-          this.sessionManager.setSessionId(chatId, newSessionId);
+        if (newSessionId && (newSessionId !== session.sessionId || session.sessionIdEngine !== engineName)) {
+          this.sessionManager.setSessionId(chatId, newSessionId, engineName);
         }
 
         if (state.status === 'waiting_for_input' && state.pendingQuestion) {
@@ -1223,7 +1254,7 @@ export class MessageBridge {
           const state = processor.processMessage(message);
           lastState = state;
           const newSid = processor.getSessionId();
-          if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+          if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
           if (state.status === 'complete' || state.status === 'error') break;
           if (sendCards && messageId) {
             rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
@@ -1301,7 +1332,7 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
             const newSid = processor.getSessionId();
-            if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+            if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
             if (state.status === 'complete' || state.status === 'error') break;
             if (sendCards && messageId) {
               rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
@@ -1514,11 +1545,10 @@ export class MessageBridge {
 
 export function isStaleSessionError(errorMessage?: string): boolean {
   if (!errorMessage) return false;
-  return /no conversation found|conversation not found|session id|invalid session|multiple.*tool_result.*blocks|each tool_use must have a single result/i.test(errorMessage);
+  return /no conversation found|conversation not found|session id|invalid session|thread\/resume.*failed|no rollout found|multiple.*tool_result.*blocks|each tool_use must have a single result/i.test(errorMessage);
 }
 
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) return false;
   return /context.window.exceeds.limit|context.length.exceeded|context.too.long|max.context.length|token.limit.exceeded|maximum.context/i.test(errorMessage);
 }
-

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -6,6 +6,8 @@ import type { EngineName } from '../types.js';
 
 export interface UserSession {
   sessionId: string | undefined;
+  /** Engine that owns sessionId. Engine session stores are not interchangeable. */
+  sessionIdEngine?: EngineName;
   workingDirectory: string;
   lastUsed: number;
   /** Cumulative token usage across all queries in this session */
@@ -16,18 +18,22 @@ export interface UserSession {
   cumulativeDurationMs: number;
   /** Per-session model override (e.g. "claude-opus-4-7"). Falls back to bot default when undefined. */
   model?: string;
-  /** Per-session engine override ("claude" | "kimi"). Falls back to bot default when undefined. */
+  /** Engine that owns model. Model names are engine-specific. */
+  modelEngine?: EngineName;
+  /** Per-session engine override. Falls back to bot default when undefined. */
   engine?: EngineName;
 }
 
 interface PersistedSession {
   sessionId: string;
+  sessionIdEngine?: EngineName;
   workingDirectory: string;
   lastUsed: number;
   cumulativeTokens?: number;
   cumulativeCostUsd?: number;
   cumulativeDurationMs?: number;
   model?: string;
+  modelEngine?: EngineName;
   engine?: EngineName;
 }
 
@@ -92,18 +98,20 @@ export class SessionManager {
     }
   }
 
-  setSessionId(chatId: string, sessionId: string): void {
+  setSessionId(chatId: string, sessionId: string, engine?: EngineName): void {
     const session = this.getSession(chatId);
     session.sessionId = sessionId;
-    this.logger.debug({ chatId, sessionId: sessionId.slice(0, 8) }, 'Session ID updated');
+    session.sessionIdEngine = engine;
+    this.logger.debug({ chatId, sessionId: sessionId.slice(0, 8), engine }, 'Session ID updated');
     this.saveToDisk();
   }
 
   /** Set per-session model override. Pass undefined to clear. */
-  setSessionModel(chatId: string, model: string | undefined): void {
+  setSessionModel(chatId: string, model: string | undefined, engine?: EngineName): void {
     const session = this.getSession(chatId);
     session.model = model;
-    this.logger.info({ chatId, model }, 'Session model override updated');
+    session.modelEngine = model ? engine : undefined;
+    this.logger.info({ chatId, model, engine: session.modelEngine }, 'Session model override updated');
     this.saveToDisk();
   }
 
@@ -118,7 +126,9 @@ export class SessionManager {
     if (session.engine === engine) return;
     session.engine = engine;
     session.sessionId = undefined;
+    session.sessionIdEngine = undefined;
     session.model = undefined;
+    session.modelEngine = undefined;
     this.logger.info({ chatId, engine }, 'Session engine override updated (session reset)');
     this.saveToDisk();
   }
@@ -136,6 +146,7 @@ export class SessionManager {
     const session = this.sessions.get(chatId);
     if (session) {
       session.sessionId = undefined;
+      session.sessionIdEngine = undefined;
       session.cumulativeTokens = 0;
       session.cumulativeCostUsd = 0;
       session.cumulativeDurationMs = 0;
@@ -168,12 +179,14 @@ export class SessionManager {
         if (session.sessionId || session.model || session.engine) {
           data[chatId] = {
             sessionId: session.sessionId || '',
+            sessionIdEngine: session.sessionIdEngine,
             workingDirectory: session.workingDirectory,
             lastUsed: session.lastUsed,
             cumulativeTokens: session.cumulativeTokens,
             cumulativeCostUsd: session.cumulativeCostUsd,
             cumulativeDurationMs: session.cumulativeDurationMs,
             model: session.model,
+            modelEngine: session.modelEngine,
             engine: session.engine,
           };
         }
@@ -196,12 +209,14 @@ export class SessionManager {
         if (now - persisted.lastUsed > SESSION_TTL_MS) continue;
         this.sessions.set(chatId, {
           sessionId: persisted.sessionId || undefined,
+          sessionIdEngine: persisted.sessionIdEngine,
           workingDirectory: persisted.workingDirectory,
           lastUsed: persisted.lastUsed,
           cumulativeTokens: persisted.cumulativeTokens ?? 0,
           cumulativeCostUsd: persisted.cumulativeCostUsd ?? 0,
           cumulativeDurationMs: persisted.cumulativeDurationMs ?? 0,
           model: persisted.model,
+          modelEngine: persisted.modelEngine,
           engine: persisted.engine,
         });
         loaded++;

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -13,6 +13,12 @@ describe('isStaleSessionError', () => {
     expect(isStaleSessionError('Conversation not found')).toBe(true);
   });
 
+  it('matches Codex stale thread resume errors', () => {
+    expect(
+      isStaleSessionError('Error: Codex exited with code 1: Error: thread/resume: thread/resume failed: no rollout found for thread id ea0dd6d2-7418-4545-8427-63cc8aed81f2'),
+    ).toBe(true);
+  });
+
   it('matches conversation corruption errors (duplicate tool_result)', () => {
     expect(
       isStaleSessionError('API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.148.content.1: each tool_use must have a single result. Found multiple `tool_result` blocks with id: toolu_01TPsHXcmpuz5cAY97fM5vXv"}}'),

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SessionManager } from '../src/engines/claude/session-manager.js';
 
 function createLogger() {
@@ -7,9 +10,17 @@ function createLogger() {
 
 describe('SessionManager', () => {
   let manager: SessionManager;
+  let storeDir: string;
+
+  beforeEach(() => {
+    storeDir = mkdtempSync(join(tmpdir(), 'metabot-session-test-'));
+    process.env.SESSION_STORE_DIR = storeDir;
+  });
 
   afterEach(() => {
     if (manager) manager.destroy();
+    delete process.env.SESSION_STORE_DIR;
+    rmSync(storeDir, { recursive: true, force: true });
   });
 
   it('creates a new session with default working directory', () => {
@@ -36,17 +47,47 @@ describe('SessionManager', () => {
   it('sets session ID', () => {
     manager = new SessionManager('/tmp/test-dir', createLogger());
     manager.getSession('chat1');
-    manager.setSessionId('chat1', 'sess-abc');
+    manager.setSessionId('chat1', 'sess-abc', 'codex');
     const session = manager.getSession('chat1');
     expect(session.sessionId).toBe('sess-abc');
+    expect(session.sessionIdEngine).toBe('codex');
   });
 
   it('resets session (clears sessionId)', () => {
     manager = new SessionManager('/tmp/test-dir', createLogger());
     manager.getSession('chat1');
-    manager.setSessionId('chat1', 'sess-abc');
+    manager.setSessionId('chat1', 'sess-abc', 'codex');
     manager.resetSession('chat1');
     const session = manager.getSession('chat1');
     expect(session.sessionId).toBeUndefined();
+    expect(session.sessionIdEngine).toBeUndefined();
+  });
+
+  it('tracks model engine and clears it with the model override', () => {
+    manager = new SessionManager('/tmp/test-dir', createLogger());
+    manager.setSessionModel('chat1', 'gpt-5.5-codex', 'codex');
+
+    let session = manager.getSession('chat1');
+    expect(session.model).toBe('gpt-5.5-codex');
+    expect(session.modelEngine).toBe('codex');
+
+    manager.setSessionModel('chat1', undefined);
+    session = manager.getSession('chat1');
+    expect(session.model).toBeUndefined();
+    expect(session.modelEngine).toBeUndefined();
+  });
+
+  it('persists session and model engine metadata', () => {
+    manager = new SessionManager('/tmp/test-dir', createLogger(), 'persist-test');
+    manager.setSessionId('chat1', 'sess-abc', 'codex');
+    manager.setSessionModel('chat1', 'gpt-5.5-codex', 'codex');
+    manager.destroy();
+
+    manager = new SessionManager('/tmp/test-dir', createLogger(), 'persist-test');
+    const session = manager.getSession('chat1');
+    expect(session.sessionId).toBe('sess-abc');
+    expect(session.sessionIdEngine).toBe('codex');
+    expect(session.model).toBe('gpt-5.5-codex');
+    expect(session.modelEngine).toBe('codex');
   });
 });


### PR DESCRIPTION
## Summary
- Track the engine that owns persisted chat session IDs and model overrides.
- Clear stale per-chat session/model state when the active engine changes before execution.
- Treat Codex \`thread/resume failed: no rollout found\` errors as stale sessions so MetaBot retries with a fresh Codex thread.

## Why
Switching a bot default from Claude to Codex could leave an old Claude session ID in the persisted session store. Codex then tried to run \`codex exec resume\` with that non-Codex ID and failed with \`no rollout found\`.

## Verification
- \`npm test\`
- \`npm run lint\` (passes with existing warnings)
- \`npm run build\`