### PR TITLE
feat(session): disable session TTL so sessions never expire

### DIFF
--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -37,7 +37,13 @@ interface PersistedSession {
   engine?: EngineName;
 }
 
-const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Sessions never expire — user can /reset manually.
+// IMPORTANT: When switching a bot's defaultWorkingDirectory, do NOT delete
+// session files (~/.metabot/<bot>/sessions-*.json, sessions.db).
+// Old sessions must be preserved so the user can switch back to a previous
+// project and resume context. loadFromDisk() uses the new defaultWorkingDirectory
+// from config, not from the persisted session, so old sessions don't interfere.
+const SESSION_TTL_MS = Infinity;
 const MAX_SESSIONS = 10_000;
 
 export class SessionManager {


### PR DESCRIPTION
## Summary
- Removes the 24-hour session expiration, replaces with `SESSION_TTL_MS = Infinity`
- Users now `/reset` manually when they want to start a fresh session
- `loadFromDisk()` preserves each session's persisted `workingDirectory`, so changing `defaultWorkingDirectory` in `bots.json` doesn't disturb existing chats

## Motivation
24h auto-expiry was annoying for long-running projects — users would come back the next day and lose conversation context for no real reason. Manual `/reset` is a better fit.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm test` — `tests/session-manager.test.ts` 7/7 pass
- [ ] Send message → wait >24h → send another message → confirm session continues (manual)