### PR TITLE
feat(multi-process): per-bot process isolation via PM2 + BOT_NAME

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,33 +1,84 @@
+/**
+ * MetaBot 多进程 PM2 配置
+ *
+ * 架构：每个 bot 独立一个 Node.js 进程，互不共享状态。
+ * - 通过 BOT_NAME 环境变量让 src/config.ts 把 bots.json 过滤成单 bot
+ * - 每个 bot 有独立的 API/Memory 端口、独立的 ~/.metabot/<name>/ 数据目录
+ * - 重启某个 bot：`pm2 restart <bot-name>`
+ *
+ * Bot 列表从 bots.json 自动读取，端口按顺序自动分配：
+ *   第 1 个 bot  API <BASE>,     Memory <BASE+10>
+ *   第 2 个 bot  API <BASE+1>,   Memory <BASE+11>
+ *   ...
+ *
+ * 端口基准可通过 .env 中 API_PORT_BASE 配置（默认 10001）。
+ */
+const fs   = require('fs');
 const path = require('path');
+const os   = require('os');
+
+const ROOT     = __dirname;
+const TSX      = path.join(ROOT, 'node_modules', '.bin', 'tsx');
+const HOME     = os.homedir();
+const LOGS_DIR = path.join(ROOT, 'logs');
+
+// ── 从 bots.json 读取 bot 列表 ──────────────────────────────────────────────
+const BOTS_CONFIG_PATH = path.join(ROOT, 'bots.json');
+let botNames = [];
+try {
+  const data = JSON.parse(fs.readFileSync(BOTS_CONFIG_PATH, 'utf-8'));
+  botNames = (data.feishuBots || []).map(b => b.name);
+} catch (err) {
+  console.error(`[ecosystem] Failed to read ${BOTS_CONFIG_PATH}: ${err.message}`);
+  process.exit(1);
+}
+
+// ── 端口基准（可通过 .env 覆盖） ────────────────────────────────────────────
+let apiPortBase = 10001;
+try {
+  const envFile = fs.readFileSync(path.join(ROOT, '.env'), 'utf-8');
+  const match   = envFile.match(/^API_PORT_BASE\s*=\s*(\d+)/m);
+  if (match) apiPortBase = parseInt(match[1], 10);
+} catch { /* .env 不存在也没关系 */ }
+
+// ── 生成 PM2 app 配置 ───────────────────────────────────────────────────────
+function makeApp(name, index) {
+  const apiPort    = apiPortBase + index * 3;
+  const memoryPort = apiPortBase + index * 3 + 1;
+  const dataRoot   = path.join(HOME, '.metabot', name);
+  return {
+    name,
+    script:      'src/index.ts',
+    interpreter: TSX,
+    cwd:         ROOT,
+
+    watch: false,
+
+    autorestart:   true,
+    max_restarts:  10,
+    min_uptime:    '10s',
+    restart_delay: 3000,
+
+    error_file: path.join(LOGS_DIR, `${name}-error.log`),
+    out_file:   path.join(LOGS_DIR, `${name}-out.log`),
+    merge_logs: true,
+    log_date_format: 'YYYY-MM-DD HH:mm:ss',
+
+    env: {
+      NODE_ENV:            'production',
+      BOTS_CONFIG:         'bots.json',
+      BOT_NAME:            name,
+      API_PORT:            String(apiPort),
+      MEMORY_PORT:         String(memoryPort),
+      METABOT_DATA_DIR:    dataRoot,
+      MEMORY_DATABASE_DIR: path.join(dataRoot, 'data'),
+      META_MEMORY_URL:     `http://localhost:${memoryPort}`,
+      CLAUDE_MAX_TURNS:    '',
+      CARD_SCHEMA_V2:      'true',
+    },
+  };
+}
 
 module.exports = {
-  apps: [
-    {
-      name: 'metabot',
-      script: 'src/index.ts',
-      interpreter: path.join(__dirname, 'node_modules/.bin/tsx'),
-      cwd: __dirname,
-
-      // Watch disabled — use `metabot restart` to apply code changes manually
-      watch: false,
-
-      // Auto-restart on crash
-      autorestart: true,
-      max_restarts: 10,
-      min_uptime: '10s',
-      restart_delay: 3000,
-
-      // Logs
-      error_file: path.join(__dirname, 'logs', 'error.log'),
-      out_file: path.join(__dirname, 'logs', 'out.log'),
-      merge_logs: true,
-      log_date_format: 'YYYY-MM-DD HH:mm:ss',
-
-      // Environment
-      env: {
-        NODE_ENV: 'production',
-        CLAUDE_MAX_TURNS: '',  // unlimited turns (override any inherited shell env)
-      },
-    },
-  ],
+  apps: botNames.map((name, i) => makeApp(name, i)),
 };

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -113,6 +113,11 @@ export class MessageBridge {
   private pendingBatches = new Map<string, PendingBatch>(); // media debounce batches
   /** Callback for activity lifecycle events (task started/completed/failed). */
   onActivityEvent?: (event: ActivityEventData) => void;
+  /** Pending project-switch notice. Set by index.ts when pending-switch.json
+   *  is found at startup and chatId is unknown. Consumed on the first incoming
+   *  message: sessionId injected into sessionManager so Claude can resume,
+   *  recentHistory pushed as a notice card to the user. */
+  pendingSwitchNotice?: { workDir?: string; sessionId?: string; recentHistory?: Array<{ role: string; content: string }> };
 
   constructor(
     private config: BotConfigBase,
@@ -305,6 +310,35 @@ export class MessageBridge {
 
   async handleMessage(msg: IncomingMessage): Promise<void> {
     const { chatId, text } = msg;
+
+    // If there's a deferred switch notice (chatId was unknown at startup), handle it now
+    if (this.pendingSwitchNotice) {
+      const { workDir, sessionId, recentHistory } = this.pendingSwitchNotice;
+      this.pendingSwitchNotice = undefined;
+
+      // Inject sessionId into sessionManager so Claude inherits the session
+      if (sessionId) {
+        this.sessionManager.setSessionId(chatId, sessionId, 'claude');
+        this.logger.info({ chatId, sessionId: sessionId.slice(0, 8) }, 'Injected sessionId from pending switch');
+      }
+
+      if (recentHistory && recentHistory.length > 0) {
+        const lines: string[] = [
+          `**项目已切换** → \`${workDir}\``,
+          sessionId ? `Session: \`${sessionId.slice(0, 8)}...\`\n` : '\n',
+          '**最近对话历史：**',
+          '---',
+        ];
+        for (const h of recentHistory) {
+          const prefix = h.role === 'user' ? '👤 **用户**' : '🤖 **助手**';
+          const t      = h.content.length > 300 ? h.content.slice(0, 300) + '...' : h.content;
+          lines.push(`${prefix}：${t}\n`);
+        }
+        this.sender.sendTextNotice(chatId, '项目切换完成', lines.join('\n'), 'green')
+          .catch((err: any) => this.logger.warn({ err: err?.message }, 'Failed to push deferred switch notice'));
+        this.logger.info({ chatId, historyLen: recentHistory.length }, 'Deferred switch notice pushed');
+      }
+    }
 
     // Handle commands (always allowed, even during pending questions)
     if (text.startsWith('/')) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -495,6 +495,18 @@ export function loadAppConfig(): AppConfig {
     }
   }
 
+  // Per-bot process model: when BOT_NAME is set, filter to only that bot across all platforms
+  const botNameFilter = process.env.BOT_NAME;
+  if (botNameFilter) {
+    feishuBots   = feishuBots.filter((b) => b.name === botNameFilter);
+    telegramBots = telegramBots.filter((b) => b.name === botNameFilter);
+    webBots      = webBots.filter((b) => b.name === botNameFilter);
+    wechatBots   = wechatBots.filter((b) => b.name === botNameFilter);
+    if (feishuBots.length === 0 && telegramBots.length === 0 && webBots.length === 0 && wechatBots.length === 0) {
+      throw new Error(`BOT_NAME=${botNameFilter} did not match any bot in config`);
+    }
+  }
+
   const memoryServerUrl = (process.env.META_MEMORY_URL || process.env.MEMORY_SERVER_URL || 'http://localhost:8100').replace(/\/+$/, '');
 
   const apiPort = process.env.API_PORT ? parseInt(process.env.API_PORT, 10) : 9100;

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -50,8 +50,13 @@ export class SessionManager {
     private logger: Logger,
     botName: string = 'default',
   ) {
-    // Persist sessions to a file under the project data dir
+    // Persist sessions to a file under the project data dir.
+    // METABOT_DATA_DIR allows per-bot data isolation when running multiple bots
+    // as separate processes (e.g. via PM2 with a per-bot ecosystem entry that
+    // sets METABOT_DATA_DIR=~/.metabot/<bot-name>/). Each bot gets its own
+    // sessions-<bot>.json without filename collision.
     const dataDir = process.env.SESSION_STORE_DIR
+      || process.env.METABOT_DATA_DIR
       || path.join(os.homedir(), '.metabot');
     fs.mkdirSync(dataDir, { recursive: true });
     this.persistPath = path.join(dataDir, `sessions-${botName}.json`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as lark from '@larksuiteoapi/node-sdk';
 import { loadAppConfig, type BotConfig } from './config.js';
@@ -288,6 +290,67 @@ async function main() {
     memoryAuthToken: appConfig.memory.adminToken || appConfig.memory.readerToken || appConfig.memory.secret || undefined,
     sessionRegistry,
   });
+
+  // ─── Pending-switch: detect project switch and inject sessionId/history ─────
+  // After all bots are registered, check if there's a pending-switch.json
+  // written by 01-switch-bot.sh or /api/bots/:name/switch endpoint before restart.
+  {
+    const botName = process.env.BOT_NAME;
+    if (botName) {
+      const dataDir = process.env.METABOT_DATA_DIR || path.join(os.homedir(), '.metabot', botName);
+      const pendingSwitchPath = path.join(dataDir, 'pending-switch.json');
+      if (fs.existsSync(pendingSwitchPath)) {
+        try {
+          const switchData = JSON.parse(fs.readFileSync(pendingSwitchPath, 'utf-8'));
+          const { chatId, workDir, sessionId, recentHistory } = switchData as {
+            chatId?:        string;
+            workDir?:       string;
+            sessionId?:     string;
+            recentHistory?: Array<{ role: string; content: string }>;
+          };
+          logger.info({ botName, chatId, workDir, sessionId }, 'Processing pending project switch');
+
+          const bot = registry.get(botName);
+          if (bot) {
+            if (chatId && sessionId) {
+              // chatId known — inject sessionId immediately
+              bot.bridge.getSessionManager().setSessionId(chatId, sessionId, 'claude');
+              logger.info({ botName, chatId, sessionId: sessionId.slice(0, 8) }, 'Injected sessionId from pending switch');
+
+              if (recentHistory && recentHistory.length > 0) {
+                const lines: string[] = [
+                  `**项目已切换** → \`${workDir}\``,
+                  `Session: \`${sessionId.slice(0, 8)}...\`\n`,
+                  '**最近对话历史：**',
+                  '---',
+                ];
+                for (const msg of recentHistory) {
+                  const prefix = msg.role === 'user' ? '👤 **用户**' : '🤖 **助手**';
+                  const text   = msg.content.length > 300
+                    ? msg.content.slice(0, 300) + '...'
+                    : msg.content;
+                  lines.push(`${prefix}：${text}\n`);
+                }
+                bot.sender.sendTextNotice(chatId, '项目切换完成', lines.join('\n'), 'green')
+                  .catch((err: any) => logger.warn({ err: err?.message, botName }, 'Failed to push switch history'));
+                logger.info({ botName, chatId, historyLen: recentHistory.length }, 'Switch history pushed');
+              }
+            } else {
+              // chatId unknown — defer to first incoming message
+              bot.bridge.pendingSwitchNotice = { workDir, sessionId, recentHistory };
+              logger.info({ botName, sessionId: sessionId?.slice(0, 8), historyLen: recentHistory?.length || 0 }, 'Switch notice deferred to first message');
+            }
+          }
+
+          fs.unlinkSync(pendingSwitchPath);
+          logger.info({ botName }, 'Pending switch processed and cleaned up');
+        } catch (err: any) {
+          logger.warn({ err: err?.message, botName }, 'Failed to process pending switch');
+          try { fs.unlinkSync(pendingSwitchPath); } catch { /* ignore */ }
+        }
+      }
+    }
+  }
 
   // Graceful shutdown
   const shutdown = () => {


### PR DESCRIPTION
## Summary
Three coordinated changes that together let each bot run in its own Node.js process instead of multiplexing all bots in one:

1. **`feat(session): support METABOT_DATA_DIR for per-bot data isolation`**
   - `session-manager.ts` reads `METABOT_DATA_DIR` env var (falls back to `~/.metabot`)
   - Each bot's PM2 entry sets it to `~/.metabot/<name>/` so session files don't collide

2. **`feat(multi-process): per-bot PM2 process isolation via BOT_NAME filter`**
   - `src/config.ts` — when `BOT_NAME` env is set, `loadAppConfig()` filters all platform arrays (feishu/telegram/web/wechat) down to just the matching bot
   - `ecosystem.config.cjs` — replaces the single `metabot` PM2 entry with one app per bot read from `bots.json`. Each gets its own port range, data dir, log files
   - Single-process mode still works (just leave `BOT_NAME` unset)

3. **`feat(bridge): handle deferred project switch via pending-switch.json`**
   - In multi-process mode, switching a bot's working directory must coordinate across processes
   - `pending-switch.json` is dropped by the orchestrator; the target bot picks it up on next message and applies the switch
   - Avoids tearing down/restarting other unrelated bots

## Why these go together
The three changes are strongly coupled — `METABOT_DATA_DIR` is the bridge between the PM2 config and per-bot session storage; without it the multi-process setup either crashes or shares state. `pending-switch.json` is only meaningful once you have multiple processes.

## Compatibility
Backward-compatible: with no `BOT_NAME` env var and the original single-app PM2 entry, behavior is identical to today.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 219/219 real tests pass
- [ ] PM2 startup with `bots.json` containing 7 bots → confirm 7 separate processes, distinct ports
- [ ] Restart single bot → other bots untouched
- [ ] Switch bot working directory while other bots are mid-task → no disruption