### PR TITLE
feat(executor): allow env-based Anthropic auth to bypass credentials.json filter

### DIFF
--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -60,8 +60,25 @@ function hasCredentialsFile(): boolean {
  * - Optionally injects an explicit ANTHROPIC_API_KEY from bots.json config.
  */
 function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => SpawnedProcess {
+  // Force-use-env mode: pass ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY /
+  // ANTHROPIC_BASE_URL through to the Claude Code subprocess instead of
+  // filtering them out. Triggered by either:
+  //   (a) METABOT_PREFER_ENV_AUTH=true (explicit opt-in flag), or
+  //   (b) presence of ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL
+  //       in the process env (auto-detect — user clearly wants env-based auth).
+  // Use case: a bot points Claude Code at a third-party Anthropic-compatible
+  // proxy while other bots on the same machine still use OAuth via
+  // ~/.claude/.credentials.json (which can't be deleted).
+  const preferEnvAuth =
+    process.env.METABOT_PREFER_ENV_AUTH === 'true' ||
+    !!(
+      process.env.ANTHROPIC_AUTH_TOKEN ||
+      process.env.ANTHROPIC_API_KEY ||
+      process.env.ANTHROPIC_BASE_URL
+    );
+
   // Decide once whether to filter auth env vars
-  const filterAuthVars = !!(explicitApiKey || hasCredentialsFile());
+  const filterAuthVars = !preferEnvAuth && !!(explicitApiKey || hasCredentialsFile());
 
   return (options: SpawnOptions): SpawnedProcess => {
     const nodePath = process.execPath;


### PR DESCRIPTION
## Summary
- Disengage the ANTHROPIC_* env filter in the Claude engine's spawn function when the user has explicitly opted into env-based auth — either via the existing `METABOT_PREFER_ENV_AUTH=true` flag, or by simply having `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` in the process env (auto-detect).
- Enables pointing Claude Code at an Anthropic-compatible third-party proxy / model gateway while OAuth-using bots on the same machine continue to share `~/.claude/.credentials.json`.
- Mirrors the pattern already in place for the Codex engine (`codex.env: Record<string, string>` per-bot env injection).

## Why
Today, `createSpawnFn` in `src/engines/claude/executor.ts` filters out `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the spawned Claude Code subprocess's env whenever `~/.claude/.credentials.json` exists. This protects OAuth users from accidental env overrides, but it also blocks a legitimate use case: a user wanting one bot to talk to a self-hosted proxy / model gateway while keeping OAuth login intact for other bots (since deleting `credentials.json` would break the OAuth bots).

## What changed
A single file: `src/engines/claude/executor.ts` (+18 / -1).

The filter now disengages when **either** of these signals is present:

1. **Explicit flag:** `METABOT_PREFER_ENV_AUTH=true` — opt-in for users who want zero ambiguity.
2. **Auto-detect:** any of `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` is already in `process.env` — clear intent to use env-based auth.

```ts
const preferEnvAuth =
  process.env.METABOT_PREFER_ENV_AUTH === 'true' ||
  !!(process.env.ANTHROPIC_AUTH_TOKEN || process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_BASE_URL);

const filterAuthVars = !preferEnvAuth && !!(explicitApiKey || hasCredentialsFile());
```

## Backward compatibility
Fully backward compatible. Users who set none of these env vars get **byte-identical** behavior to before: OAuth-only or explicit-apiKey path is unchanged. Only users who explicitly export Anthropic env vars (or set the new flag) see the new pass-through behavior.

## Test plan
- [x] Set `ANTHROPIC_BASE_URL=<proxy-url>` + `ANTHROPIC_AUTH_TOKEN=<proxy-token>` in env, run a Claude task → routes through proxy, returns expected response. ✅ tested with two routing methods (per-bot env via PM2 ecosystem block, and global `.env` via dotenv).
- [x] Without any Anthropic env vars + existing `credentials.json` → still uses OAuth as before. ✅
- [x] With explicit `apiKey` in bots.json + no Anthropic env vars → still uses the explicit key, no behavior change. ✅