### PR TITLE
fix(output): tell users when output files are dropped for being too large

### DIFF
--- a/src/bridge/output-handler.ts
+++ b/src/bridge/output-handler.ts
@@ -5,6 +5,31 @@ import type { IMessageSender } from './message-sender.interface.js';
 import { StreamProcessor, extractImagePaths } from '../engines/index.js';
 import { OutputsManager } from './outputs-manager.js';
 
+/**
+ * Feishu API limits documented at
+ *   https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/image/create
+ *   https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/file/create
+ *
+ * Previous value of 50 MB for FILE_MAX_BYTES was incorrect — uploads in
+ * the 30-50 MB range would attempt and silently fail at the Feishu API
+ * level with the user never knowing. Aligning to the documented cap
+ * lets the OversizedNotice path catch them instead.
+ */
+const IMAGE_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+const FILE_MAX_BYTES  = 30 * 1024 * 1024; // 30 MB
+
+interface OversizedFile {
+  fileName:  string;
+  sizeBytes: number;
+  isImage:   boolean;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+
 export class OutputHandler {
   constructor(
     private logger: Logger,
@@ -19,15 +44,16 @@ export class OutputHandler {
     state: CardState,
   ): Promise<void> {
     const sentPaths = new Set<string>();
+    const oversized: OversizedFile[] = [];
 
-    // 1. Scan the outputs directory for any files Claude placed there
+    // 1. Scan the outputs directory for any files the agent placed there
     const outputFiles = this.outputsManager.scanOutputs(outputsDir);
     for (const file of outputFiles) {
       try {
-        if (file.isImage && file.sizeBytes < 10 * 1024 * 1024) {
+        if (file.isImage && file.sizeBytes <= IMAGE_MAX_BYTES) {
           this.logger.info({ filePath: file.filePath }, 'Sending output image from outputs dir');
           await this.sender.sendImageFile(chatId, file.filePath);
-        } else if (!file.isImage && file.sizeBytes < 50 * 1024 * 1024) {
+        } else if (!file.isImage && file.sizeBytes <= FILE_MAX_BYTES) {
           this.logger.info({ filePath: file.filePath }, 'Sending output file from outputs dir');
           const sent = await this.sender.sendLocalFile(chatId, file.filePath, file.fileName);
           if (!sent && OutputsManager.isTextFile(file.extension) && file.sizeBytes < 30 * 1024) {
@@ -36,7 +62,10 @@ export class OutputHandler {
             await this.sender.sendText(chatId, `📄 ${file.fileName}\n\n${content}`);
           }
         } else {
+          // Track for a single end-of-batch notice so users know files exist
+          // but were dropped — silently logging warn was the original bug.
           this.logger.warn({ filePath: file.filePath, sizeBytes: file.sizeBytes }, 'Output file too large to send');
+          oversized.push({ fileName: file.fileName, sizeBytes: file.sizeBytes, isImage: file.isImage });
         }
         sentPaths.add(file.filePath);
       } catch (err) {
@@ -57,14 +86,40 @@ export class OutputHandler {
       try {
         if (fs.existsSync(imgPath) && fs.statSync(imgPath).isFile()) {
           const size = fs.statSync(imgPath).size;
-          if (size > 0 && size < 10 * 1024 * 1024) {
+          if (size <= 0) continue;
+          if (size <= IMAGE_MAX_BYTES) {
             this.logger.info({ imgPath }, 'Sending output image (fallback)');
             await this.sender.sendImageFile(chatId, imgPath);
+          } else {
+            // Same notice path as the outputs-dir scan — match user-visible behaviour.
+            this.logger.warn({ imgPath, sizeBytes: size }, 'Fallback output image too large to send');
+            oversized.push({ fileName: imgPath.split('/').pop() ?? imgPath, sizeBytes: size, isImage: true });
           }
         }
       } catch (err) {
         this.logger.warn({ err, imgPath }, 'Failed to send output image');
       }
+    }
+
+    // 3. If anything was dropped for being too large, tell the user. Previously
+    //    these failed silently — users assumed the bot just didn't generate
+    //    the file. One coalesced notice for the whole batch instead of one
+    //    per file so a 10-file batch with all-oversized doesn't spam.
+    if (oversized.length > 0) {
+      await this.sendOversizedNotice(chatId, oversized);
+    }
+  }
+
+  private async sendOversizedNotice(chatId: string, files: OversizedFile[]): Promise<void> {
+    const lines = [
+      `Cannot send **${files.length}** file${files.length === 1 ? '' : 's'} because ${files.length === 1 ? 'it exceeds' : 'they exceed'} the Feishu upload limit (max ${IMAGE_MAX_BYTES / 1024 / 1024}MB images, ${FILE_MAX_BYTES / 1024 / 1024}MB files):`,
+      '',
+      ...files.map((f) => `- \`${f.fileName}\` — ${formatBytes(f.sizeBytes)}${f.isImage ? ' (image)' : ''}`),
+    ];
+    try {
+      await this.sender.sendTextNotice(chatId, '⚠️ Files Too Large', lines.join('\n'), 'orange');
+    } catch (err) {
+      this.logger.warn({ err, chatId, count: files.length }, 'Failed to send oversized-file notice');
     }
   }
 }

--- a/tests/output-handler.test.ts
+++ b/tests/output-handler.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { OutputHandler } from '../src/bridge/output-handler.js';
+import { OutputsManager } from '../src/bridge/outputs-manager.js';
+import type { CardState } from '../src/types.js';
+
+/**
+ * Output-file handling has two failure modes that look identical to a
+ * Feishu user — "the bot didn't generate anything":
+ *
+ *   1. The agent never wrote a file (correctly silent)
+ *   2. The file is too large to upload (was silent — bug)
+ *
+ * These tests lock in case (2): a single coalesced ⚠️ notice for the
+ * whole batch, citing actual file names and sizes. Don't relax to per-
+ * file notices (a 10-file all-oversized batch would spam) or back to
+ * a logger.warn-only path (the regression).
+ */
+
+const mockLogger = {
+  debug: () => {},
+  info:  () => {},
+  warn:  () => {},
+  error: () => {},
+} as any;
+
+const mockProcessor = {
+  getImagePaths: () => [],
+} as any;
+
+interface RecordedNotice {
+  chatId:  string;
+  title:   string;
+  content: string;
+  color?:  string;
+}
+
+interface RecordedSend {
+  type:   'image' | 'file' | 'text';
+  chatId: string;
+  filePath?: string;
+  fileName?: string;
+}
+
+function buildSender(opts: { failImage?: boolean; failFile?: boolean } = {}) {
+  const notices: RecordedNotice[] = [];
+  const sends:   RecordedSend[]   = [];
+  const sender = {
+    sendCard:      async () => undefined,
+    updateCard:    async () => true,
+    sendTextNotice: async (chatId: string, title: string, content: string, color?: string) => {
+      notices.push({ chatId, title, content, color });
+    },
+    sendText:      async (chatId: string, text: string) => {
+      sends.push({ type: 'text', chatId, filePath: text });
+    },
+    sendImageFile: async (chatId: string, filePath: string) => {
+      sends.push({ type: 'image', chatId, filePath });
+      return !opts.failImage;
+    },
+    sendLocalFile: async (chatId: string, filePath: string, fileName: string) => {
+      sends.push({ type: 'file', chatId, filePath, fileName });
+      return !opts.failFile;
+    },
+    downloadImage: async () => true,
+    downloadFile:  async () => true,
+  };
+  return { sender: sender as any, notices, sends };
+}
+
+function emptyState(): CardState {
+  return { status: 'complete', userPrompt: '', responseText: '', toolCalls: [] };
+}
+
+describe('OutputHandler.sendOutputFiles', () => {
+  let tmpDir:   string;
+  let outputs:  OutputsManager;
+  let chatDir:  string;
+
+  beforeEach(() => {
+    tmpDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'metabot-output-handler-'));
+    outputs  = new OutputsManager(tmpDir, mockLogger);
+    chatDir  = outputs.prepareDir('chat-1');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('sends a small image via sendImageFile', async () => {
+    fs.writeFileSync(path.join(chatDir, 'pic.png'), Buffer.alloc(100));
+    const { sender, sends, notices } = buildSender();
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toEqual([expect.objectContaining({ type: 'image', chatId: 'chat-1' })]);
+    expect(notices).toHaveLength(0);
+  });
+
+  it('sends a small file via sendLocalFile', async () => {
+    fs.writeFileSync(path.join(chatDir, 'report.pdf'), Buffer.alloc(1024));
+    const { sender, sends, notices } = buildSender();
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toEqual([expect.objectContaining({ type: 'file', fileName: 'report.pdf' })]);
+    expect(notices).toHaveLength(0);
+  });
+
+  it('sends an oversized-file notice when an image exceeds 10MB (regression)', async () => {
+    // 10 MB + 1 byte
+    const big = Buffer.alloc(10 * 1024 * 1024 + 1);
+    fs.writeFileSync(path.join(chatDir, 'huge.png'), big);
+    const { sender, sends, notices } = buildSender();
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toHaveLength(0);                   // upload skipped
+    expect(notices).toHaveLength(1);
+    expect(notices[0].title).toContain('Too Large');
+    expect(notices[0].content).toContain('huge.png');
+    expect(notices[0].content).toMatch(/MB/);
+    expect(notices[0].color).toBe('orange');
+  });
+
+  it('sends an oversized-file notice when a file exceeds 30MB (regression — previous limit was 50MB)', async () => {
+    // 30 MB + 1 byte — would have squeezed through the old 50MB gate
+    // and silently failed at the Feishu API. New cap catches it client-side.
+    const big = Buffer.alloc(30 * 1024 * 1024 + 1);
+    fs.writeFileSync(path.join(chatDir, 'video.mp4'), big);
+    const { sender, sends, notices } = buildSender();
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toHaveLength(0);
+    expect(notices).toHaveLength(1);
+    expect(notices[0].content).toContain('video.mp4');
+    expect(notices[0].content).toMatch(/30MB/);      // limit cited
+  });
+
+  it('coalesces multiple oversized files into a single notice', async () => {
+    fs.writeFileSync(path.join(chatDir, 'huge1.png'), Buffer.alloc(10 * 1024 * 1024 + 1));
+    fs.writeFileSync(path.join(chatDir, 'huge2.zip'), Buffer.alloc(30 * 1024 * 1024 + 1));
+    fs.writeFileSync(path.join(chatDir, 'ok.txt'),    Buffer.alloc(100));
+    const { sender, sends, notices } = buildSender();
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    // ok.txt should still be sent
+    expect(sends).toEqual([expect.objectContaining({ fileName: 'ok.txt' })]);
+    // Single notice listing both oversized files
+    expect(notices).toHaveLength(1);
+    expect(notices[0].content).toContain('huge1.png');
+    expect(notices[0].content).toContain('huge2.zip');
+    expect(notices[0].content).toContain('2');  // count
+  });
+
+  it('uses singular wording when exactly one file is oversized', async () => {
+    fs.writeFileSync(path.join(chatDir, 'huge.png'), Buffer.alloc(10 * 1024 * 1024 + 1));
+    const { sender, notices } = buildSender();
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(notices[0].content).toMatch(/1\*\* file because it exceeds/);
+    expect(notices[0].content).not.toMatch(/files because they/);
+  });
+});


### PR DESCRIPTION
## What this fixes

UX review flagged two related bugs in the file-handling path that fold into one user-facing complaint (\"the bot didn't generate the file\"):

1. The 'too large' branch only called `logger.warn` — users never saw it. Big report.pdf / chart.png / video.mp4 outputs looked like silent agent failure.
2. The file size cap in `output-handler.ts:30` was **50 MB**, but Feishu's documented `im.v1.file.create` limit is **30 MB**. Files in the 30-50 MB range were attempted, silently rejected by Feishu, then thrown away — invisible to both the user AND the original 'too large' branch.

## Change

`src/bridge/output-handler.ts`:

- Promoted magic numbers to named constants with API-doc links:
  - `IMAGE_MAX_BYTES = 10 MB` (Feishu `im.v1.image.create` cap)
  - `FILE_MAX_BYTES  = 30 MB` (Feishu `im.v1.file.create` cap — **corrected from 50 MB**)
- Collect oversized files during the scan loop, then emit a single ⚠️ \"Files Too Large\" orange notice listing each file with its size. **One coalesced notice**, not one per file, so a batch of 10 oversized doesn't spam.
- Fallback image path (Write-tool tracking + response-text regex) also catches oversized images now — previously silently skipped via the `size < 10MB` guard.
- Switched `<` to `<=` so users get the full documented capacity.
- Singular/plural wording in the notice body.

`tests/output-handler.test.ts` — new file with six cases:

- small image: sent via `sendImageFile`, no notice
- small file:  sent via `sendLocalFile`, no notice
- **10MB+1 image**: notice cites filename, MB, color=orange (regression)
- **30MB+1 file**:  notice cites filename, 30MB limit cited (regression — would have squeezed past the old 50MB gate)
- **multiple oversized**: coalesced into one notice listing both files
- **exactly one oversized**: singular wording ('1 file because it exceeds')

## CI / Quality

- Tests: 248 passed (was 242 after #258 merge; +6 here)
- Lint: 0 errors
- Build: ✅

## Risk

- Files that used to fail silently at Feishu (30-50 MB range) now get caught client-side. Same user outcome (file not sent), but **with explanation**.
- The notice itself is a new outbound message per turn (only when oversized files exist). No additional API cost in the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)