### PR TITLE
fix(persistent-executor): honor env-based Anthropic auth like executor.ts

### DIFF
--- a/src/engines/claude/persistent-executor.ts
+++ b/src/engines/claude/persistent-executor.ts
@@ -67,7 +67,17 @@ function hasCredentialsFile(): boolean {
 }
 
 function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => SpawnedProcess {
-  const filterAuthVars = !!(explicitApiKey || hasCredentialsFile());
+  // Mirror executor.ts: when env-based Anthropic auth is in use (proxy /
+  // gateway via ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN), bypass the
+  // credentials.json filter so ANTHROPIC_AUTH_TOKEN reaches the subprocess.
+  const preferEnvAuth =
+    process.env.METABOT_PREFER_ENV_AUTH === 'true' ||
+    !!(
+      process.env.ANTHROPIC_AUTH_TOKEN ||
+      process.env.ANTHROPIC_API_KEY ||
+      process.env.ANTHROPIC_BASE_URL
+    );
+  const filterAuthVars = !preferEnvAuth && !!(explicitApiKey || hasCredentialsFile());
   return (options: SpawnOptions): SpawnedProcess => {
     const baseEnv = options.env && Object.keys(options.env).length > 0
       ? { ...process.env, ...options.env }


### PR DESCRIPTION
## Summary
- PR #252 fixed `ClaudeExecutor` so that `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` in `process.env` bypass the `~/.claude/.credentials.json` filter. The same logic was never ported to `PersistentClaudeExecutor`.
- When the persistent-executor flag is on and OAuth credentials.json exists, the subprocess gets `ANTHROPIC_BASE_URL` (not in `AUTH_ENV_VARS`) but no token — falls back to OAuth and traffic skips the configured proxy.
- This PR mirrors `executor.ts:89-98` into `persistent-executor.ts:69` so both code paths agree on env-auth preference.

## Test plan
- [ ] With `.env` set to `ANTHROPIC_BASE_URL=https://proxy` + `ANTHROPIC_AUTH_TOKEN=…` and `~/.claude/.credentials.json` present, confirm a turn under the persistent path reaches the proxy (check proxy logs / `executor-routes.ts` status).
- [ ] With only `~/.claude/.credentials.json` (no `ANTHROPIC_*` env), confirm OAuth path still works (no regression on `preferEnvAuth=false`).
- [ ] `METABOT_PREFER_ENV_AUTH=true` opt-in still triggers env-auth even when no `ANTHROPIC_*` vars are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)