### PR TITLE
fix(spontaneous): drop duplicate result snippet + rename misleading card title

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -45,6 +45,48 @@ const BATCH_DEBOUNCE_MS = 2000; // 2s window to collect multiple images/files
 const DEFAULT_IMAGE_TEXT = '请分析这张图片';
 const DEFAULT_FILE_TEXT = '请分析这个文件';
 
+/**
+ * Header text shown at the top of a between-turns "agent activity" card.
+ * Intentionally avoids the previous "long-running task" phrasing — that
+ * read to users as "still running" when in fact the card is emitted at
+ * the END of a burst (snippet buffer flushed after 30 s of quiet).
+ */
+export const SPONTANEOUS_CARD_HEADER =
+  'Agent activity between turns (background task return, teammate ping, or `/goal` evaluator):';
+
+/**
+ * Extract a one-line summary from an SDK stream message for the spontaneous
+ * activity card. Returns null if the message has nothing user-readable.
+ *
+ * Intentionally only handles `assistant` messages — `result` messages would
+ * always duplicate the last assistant text block (SDK's `result.result` is a
+ * verbatim echo), so including them caused the same content to show up twice
+ * in the card with two different prefixes. Don't add a `result` branch back
+ * without first verifying the SDK no longer echoes.
+ */
+export function extractSpontaneousSnippet(msg: unknown): string | null {
+  const m = msg as { type?: string; message?: { content?: Array<{ type?: string; text?: string; name?: string }> } };
+  if (m?.type !== 'assistant' || !m.message?.content) return null;
+  for (const blk of m.message.content) {
+    if (blk.type === 'text' && blk.text) {
+      const trimmed = String(blk.text).trim();
+      if (trimmed) return trimmed.slice(0, 400);
+    } else if (blk.type === 'tool_use' && blk.name) {
+      return `🔧 ${blk.name}`;
+    }
+  }
+  return null;
+}
+
+/** Build the markdown body of a spontaneous activity card from collected snippets. */
+export function formatSpontaneousCardBody(snippets: string[]): string {
+  return [
+    `_${SPONTANEOUS_CARD_HEADER}_`,
+    '',
+    ...snippets.map((s, i) => `**${i + 1}.** ${s}`),
+  ].join('\n');
+}
+
 interface PendingBatch {
   messages: IncomingMessage[];
   timerId: ReturnType<typeof setTimeout>;
@@ -391,24 +433,16 @@ export class MessageBridge {
    * Buffer a spontaneous message and (re)arm the coalesce timer. We extract
    * just the human-readable bits — assistant text and tool_use intent —
    * skipping noisy stream events.
+   *
+   * `result`-type messages are intentionally NOT snippeted: the SDK's
+   * `result.result` field is almost always a verbatim echo of the previous
+   * assistant text block, so emitting it would mean every spontaneous burst
+   * shows the same content twice in the card (once with no prefix from the
+   * assistant message, once with a 🤖 prefix from the result). Skipping
+   * result here removes that duplication.
    */
-  private handleSpontaneousMessage(chatId: string, msg: any): void {
-    let snippet: string | null = null;
-    if (msg?.type === 'assistant' && msg.message?.content) {
-      for (const blk of msg.message.content) {
-        if (blk.type === 'text' && blk.text) {
-          const trimmed = String(blk.text).trim();
-          if (trimmed) snippet = trimmed.slice(0, 400);
-          break;
-        } else if (blk.type === 'tool_use' && blk.name) {
-          snippet = `🔧 ${blk.name}`;
-          break;
-        }
-      }
-    } else if (msg?.type === 'result' && (msg as any).result) {
-      const r = String((msg as any).result).trim();
-      if (r) snippet = `🤖 ${r.slice(0, 400)}`;
-    }
+  private handleSpontaneousMessage(chatId: string, msg: unknown): void {
+    const snippet = extractSpontaneousSnippet(msg);
     // Tool/system events without text aren't worth a card.
     if (!snippet) return;
 
@@ -430,8 +464,16 @@ export class MessageBridge {
 
   /**
    * Flush any accumulated spontaneous activity for chatId as a single
-   * "background activity" Feishu card. No-op if buffer is empty or there's
+   * "agent activity" Feishu card. No-op if buffer is empty or there's
    * an active user turn (we'd rather merge into the live card than spam).
+   *
+   * Card title intentionally avoids the previous "long-running task"
+   * wording — users read that as "agent is still running long-running
+   * work", but the card is in fact emitted at the END of a between-turn
+   * burst (e.g. after a `run_in_background` Bash command's task-notification
+   * triggered the agent to summarize a result). Calling it "agent activity"
+   * + green status lets the user read it as "the agent did this and is now
+   * quiet" — which is the correct signal.
    */
   private async flushSpontaneous(chatId: string): Promise<void> {
     const buf = this.spontaneousBuffers.get(chatId);
@@ -446,15 +488,11 @@ export class MessageBridge {
       return;
     }
 
-    const responseText = [
-      '_Background activity from your agent team / long-running task:_',
-      '',
-      ...buf.snippets.map((s, i) => `**${i + 1}.** ${s}`),
-    ].join('\n');
+    const responseText = formatSpontaneousCardBody(buf.snippets);
 
     const card: CardState = {
       status: 'complete',
-      userPrompt: '(background)',
+      userPrompt: '(agent activity)',
       responseText,
       toolCalls: [],
       teamState: buf.snippets.length > 0 ? buf.teamState : undefined,

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { isStaleSessionError, normalizePromptForEngine } from '../src/bridge/message-bridge.js';
+import {
+  isStaleSessionError,
+  normalizePromptForEngine,
+  extractSpontaneousSnippet,
+  formatSpontaneousCardBody,
+  SPONTANEOUS_CARD_HEADER,
+} from '../src/bridge/message-bridge.js';
 
 describe('isStaleSessionError', () => {
   it('matches the GitHub issue error text', () => {
@@ -49,5 +55,112 @@ describe('normalizePromptForEngine', () => {
     expect(normalizePromptForEngine('/metaskill ios app', 'kimi')).toBe('/metaskill ios app');
     expect(normalizePromptForEngine('hello /metaskill', 'codex')).toBe('hello /metaskill');
     expect(normalizePromptForEngine('/bad/path', 'codex')).toBe('/bad/path');
+  });
+});
+
+/**
+ * Spontaneous-card helpers — extracted so the snippet generator and card
+ * title are unit-testable without booting a real MessageBridge.
+ *
+ * The history these tests guard against: an earlier version included a
+ * `msg.type === 'result'` branch in the snippet generator, which produced
+ * a `🤖 ...` snippet on top of the assistant text snippet for the same
+ * underlying agent reply — flooding the card with duplicates. And the
+ * card title used to say "Background activity from your agent team /
+ * long-running task", which made users think the agent was *still*
+ * running when in fact the card is emitted at the END of a quiet burst.
+ */
+describe('extractSpontaneousSnippet', () => {
+  it('returns assistant text as snippet', () => {
+    const msg = {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: '  Weather is sunny  ' }] },
+    };
+    expect(extractSpontaneousSnippet(msg)).toBe('Weather is sunny');
+  });
+
+  it('returns 🔧 prefixed tool name for tool_use blocks', () => {
+    const msg = {
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'Bash' }] },
+    };
+    expect(extractSpontaneousSnippet(msg)).toBe('🔧 Bash');
+  });
+
+  it('prefers the first usable block (text wins over later tool_use)', () => {
+    const msg = {
+      type: 'assistant',
+      message: { content: [
+        { type: 'text', text: 'hello' },
+        { type: 'tool_use', name: 'Bash' },
+      ] },
+    };
+    expect(extractSpontaneousSnippet(msg)).toBe('hello');
+  });
+
+  it('truncates very long text to 400 chars', () => {
+    const long = 'x'.repeat(800);
+    const out = extractSpontaneousSnippet({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: long }] },
+    });
+    expect(out).toHaveLength(400);
+  });
+
+  // Regression for Bug B (duplicate snippets): result-type messages MUST be
+  // ignored. SDK's `result.result` is a verbatim echo of the last assistant
+  // text block — including it produced two snippets for the same content.
+  it('returns null for result-type messages (regression: no duplicate result snippet)', () => {
+    expect(extractSpontaneousSnippet({ type: 'result', result: 'Weather is sunny' })).toBeNull();
+    expect(extractSpontaneousSnippet({ type: 'result', result: 'anything' })).toBeNull();
+  });
+
+  it('returns null for user/system/other message types', () => {
+    expect(extractSpontaneousSnippet({ type: 'user', message: { content: [] } })).toBeNull();
+    expect(extractSpontaneousSnippet({ type: 'system' })).toBeNull();
+    expect(extractSpontaneousSnippet(null)).toBeNull();
+    expect(extractSpontaneousSnippet({})).toBeNull();
+  });
+
+  it('returns null for assistant messages with no text/tool_use content', () => {
+    const msg = {
+      type: 'assistant',
+      message: { content: [{ type: 'thinking', text: 'silent' }, { type: 'image' }] },
+    };
+    expect(extractSpontaneousSnippet(msg)).toBeNull();
+  });
+
+  it('skips empty text blocks', () => {
+    const msg = {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: '   ' }] },
+    };
+    expect(extractSpontaneousSnippet(msg)).toBeNull();
+  });
+});
+
+describe('formatSpontaneousCardBody', () => {
+  it('renders snippets as a numbered list under the header', () => {
+    const body = formatSpontaneousCardBody(['🔧 Bash', 'Weather is sunny']);
+    expect(body).toContain(SPONTANEOUS_CARD_HEADER);
+    expect(body).toMatch(/\*\*1\.\*\*\s+🔧 Bash/);
+    expect(body).toMatch(/\*\*2\.\*\*\s+Weather is sunny/);
+  });
+
+  // Regression for Bug A (misleading title): the header used to say
+  // "Background activity from your agent team / long-running task".
+  // Users read "long-running task" as "still running" — but the card is
+  // emitted at the END of a quiet burst, so the agent is in fact idle by
+  // the time it lands. Header now describes WHAT happened, not an ongoing
+  // task. Don't relax these substring checks without re-evaluating the
+  // user mental model.
+  it('header does not claim a long-running task is in progress (regression)', () => {
+    expect(SPONTANEOUS_CARD_HEADER).not.toMatch(/long-running/i);
+    expect(SPONTANEOUS_CARD_HEADER).toMatch(/between turns/i);
+  });
+
+  it('renders even with empty snippets array (header still present)', () => {
+    const body = formatSpontaneousCardBody([]);
+    expect(body).toContain(SPONTANEOUS_CARD_HEADER);
   });
 });


### PR DESCRIPTION
## What this fixes

Two adjacent bugs in the between-turns "spontaneous" card path that a **live reproduction** with a `sleep 3 && date` background task surfaced together.

### Bug B — duplicate snippet inside the card

`handleSpontaneousMessage` generated a snippet for BOTH:

- `msg.type === 'assistant'` (text or tool_use block)
- `msg.type === 'result'` (with a 🤖 prefix on `result.result`)

But the SDK's `result.result` is almost always a verbatim echo of the preceding assistant text block, so each background-task-returning agent reply produced **the same content twice** in the same card, the second copy with a 🤖 prefix.

The user-observed pattern (reproduction):

```
Background activity from your agent team / long-running task:

1. 🔧 Bash                              ← assistant tool_use
2. Wed May 13 10:15:58 UTC 2026 ...     ← assistant text
3. 🤖 Wed May 13 10:15:58 UTC 2026 ...  ← result.result echo (duplicate)
```

### Bug A — misleading card title

The card header read:

```
Background activity from your agent team / long-running task:
```

Users read "long-running task" as "**agent is still running**" — but the card is emitted only after a 30 s coalesce window closes (i.e. at the END of a quiet burst). So when the user sees this card, the agent has in fact been **idle for 30 s**. The phrase is the opposite of what's happening, defeating the entire reason for the card existing: telling the user what happened while they weren't looking.

## Change

`src/bridge/message-bridge.ts`:

- Removed the `result`-type branch in `handleSpontaneousMessage` — replaced inline body with a call to a new exported pure helper **`extractSpontaneousSnippet`** that only handles `assistant` messages
- Renamed the card header to:
  > Agent activity between turns (background task return, teammate ping, or `/goal` evaluator):
  
  via the new exported `SPONTANEOUS_CARD_HEADER` constant
- Extracted **`formatSpontaneousCardBody(snippets)`** so the card formatter is unit-testable without booting a real `MessageBridge`

## Tests

`tests/message-bridge.test.ts` gains two `describe` blocks (11 new cases):

`extractSpontaneousSnippet`:
- assistant text snippet
- 🔧 tool_use snippet
- block ordering (first usable block wins)
- truncation to 400 chars
- **regression: result-type messages return `null`** (Bug B)
- edge cases: user/system/null/empty messages, blocks with no usable content

`formatSpontaneousCardBody`:
- header presence + numbered list rendering
- **regression: header does not claim a long-running task is in progress** (Bug A)
- empty snippets array

## CI / Quality

- Tests: **262** passed (was 251 after #261; +11 new here)
- Lint: 0 errors
- Build: ✅

## Not fixed in this PR (intentional, follow-up)

Distinguishing **task-notification-triggered** output from **genuinely spontaneous** teammate / `/goal` output. Both *are* "between turns" in the same sense, so the new header is honest about both. If we ever want a stronger "agent finished a background return" signal (different colour / title), we'd need to thread the source through `consumeLoop` in `persistent-executor.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)