### PR TITLE
feat(claude): default-enable auto-memory for new installs

### DIFF
--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -42,6 +42,7 @@ const CLAUDE_ENV_PASSTHROUGH = new Set([
   'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS', // /agent teams (multi-instance coordination)
   'CLAUDE_CODE_DISABLE_AGENT_VIEW',       // disable claude agents / --bg / /background
   'CLAUDE_CODE_SIMPLE',                   // --bare equivalent
+  'CLAUDE_CODE_DISABLE_AUTO_MEMORY',      // toggle auto-memory (project patterns/learnings)
 ]);
 
 /**
@@ -129,6 +130,17 @@ function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => Spaw
     // setting CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=0 in MetaBot's parent env.
     if (env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === undefined) {
       env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
+    }
+
+    // Default-enable Claude Code auto-memory so Claude can write project
+    // patterns / preferences / decisions to ~/.claude/projects/<projDir>/memory/
+    // across sessions — the user-facing memory system the bot's skills /
+    // metaskill flows rely on. Users can disable by setting
+    // CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 in MetaBot's parent env.
+    // Pinning to '0' here makes the feature immune to upstream default
+    // changes; the user shouldn't need to keep a magic line in .env.
+    if (env.CLAUDE_CODE_DISABLE_AUTO_MEMORY === undefined) {
+      env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '0';
     }
 
     const child = spawn(options.command, options.args, {

--- a/src/engines/claude/persistent-executor.ts
+++ b/src/engines/claude/persistent-executor.ts
@@ -55,6 +55,7 @@ const CLAUDE_ENV_PASSTHROUGH = new Set([
   'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS',
   'CLAUDE_CODE_DISABLE_AGENT_VIEW',
   'CLAUDE_CODE_SIMPLE',
+  'CLAUDE_CODE_DISABLE_AUTO_MEMORY',
 ]);
 const AUTH_ENV_VARS = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'];
 
@@ -93,6 +94,13 @@ function createSpawnFn(explicitApiKey?: string): (options: SpawnOptions) => Spaw
     if (explicitApiKey) env.ANTHROPIC_API_KEY = explicitApiKey;
     if (env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === undefined) {
       env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
+    }
+    // Default-enable auto-memory so Claude can persist project patterns /
+    // preferences / decisions across sessions. Pin to '0' (= "don't disable")
+    // here so MetaBot stays on this default even if Claude Code flips its
+    // upstream default. Users can disable with CLAUDE_CODE_DISABLE_AUTO_MEMORY=1.
+    if (env.CLAUDE_CODE_DISABLE_AUTO_MEMORY === undefined) {
+      env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '0';
     }
     const child = spawn(options.command, options.args, {
       cwd: options.cwd,


### PR DESCRIPTION
## Summary

Sibling to #265 (persistent-executor default-on): fresh installs of MetaBot should get the documented memory-across-sessions behaviour without needing to set anything in `.env`.

Auto-memory backs the `/metamemory` and `/metaskill` skill flows and the `~/.claude/projects/<projDir>/memory/MEMORY.md` index that other sessions read for context. The env var the user had been keeping in `.env` (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=0`) was actually a no-op — `ALWAYS_FILTERED_PREFIXES=['CLAUDE']` was silently stripping it when spawning the Claude subprocess, because the var wasn't in `CLAUDE_ENV_PASSTHROUGH`. Auto-memory worked anyway because Claude Code's own default happened to be ON.

## Changes

Mirrors the existing `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` default-on pattern in both spawn paths:

- `src/engines/claude/executor.ts` (legacy per-turn spawn)
- `src/engines/claude/persistent-executor.ts` (long-lived pool)

1. Add `CLAUDE_CODE_DISABLE_AUTO_MEMORY` to `CLAUDE_ENV_PASSTHROUGH` so user-set values actually reach the subprocess.
2. After the env filter pass, force `env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '0'` if not already set. Pins MetaBot to "auto-memory on" regardless of any future Claude Code upstream default change.

## Back-compat

- Anyone with `CLAUDE_CODE_DISABLE_AUTO_MEMORY=0` in `.env`: keeps working (no-op now but harmless).
- Opt out: set `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` (or any value the Claude Code CLI recognises as "disable").

## Test plan

- [x] `npx vitest run`: 286/286 pass.
- [x] Typecheck clean.
- [ ] Smoke: comment out `CLAUDE_CODE_DISABLE_AUTO_MEMORY=0` from `.env`, restart MetaBot, send a message, verify `~/.claude/projects/<chatProjDir>/memory/MEMORY.md` still gets written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)