### PR TITLE
feat(ui): blue 'Agent activity' card status, drop the ugly body caption

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -60,15 +60,6 @@ const DEFAULT_IMAGE_TEXT = '请分析这张图片';
 const DEFAULT_FILE_TEXT = '请分析这个文件';
 
 /**
- * Header text shown at the top of a between-turns "agent activity" card.
- * Intentionally avoids the previous "long-running task" phrasing — that
- * read to users as "still running" when in fact the card is emitted at
- * the END of a burst (snippet buffer flushed after 30 s of quiet).
- */
-export const SPONTANEOUS_CARD_HEADER =
-  'Agent activity between turns (background task return, teammate ping, or `/goal` evaluator):';
-
-/**
  * Extract a one-line summary from an SDK stream message for the spontaneous
  * activity card. Returns null if the message has nothing user-readable.
  *
@@ -103,11 +94,18 @@ export function extractSpontaneousSnippet(msg: unknown): string | null {
  * count so users know there was more activity if they want to dig into
  * logs. Mirrors the "show only the final result, hide the play-by-play"
  * pattern from PR #268's main-card tool indicator.
+ *
+ * No header line in the body — earlier versions prepended an italic
+ * "Agent activity between turns (…)" caption, but users found it long
+ * and visually noisy. The card itself is rendered with the
+ * `agent_activity` status (blue header, "Agent activity" title), which
+ * is enough to tell it apart from a regular "complete" reply card.
+ * Don't re-add a body header without verifying the card-header signal
+ * is no longer sufficient.
  */
 export function formatSpontaneousCardBody(snippets: string[]): string {
-  const lines: string[] = [`_${SPONTANEOUS_CARD_HEADER}_`, ''];
-  if (snippets.length === 0) return lines.join('\n');
-  lines.push(snippets[snippets.length - 1]);
+  if (snippets.length === 0) return '';
+  const lines: string[] = [snippets[snippets.length - 1]];
   if (snippets.length > 1) {
     lines.push('');
     lines.push(`_(${snippets.length} events coalesced; showing latest)_`);
@@ -555,13 +553,12 @@ export class MessageBridge {
    * "agent activity" Feishu card. No-op if buffer is empty or there's
    * an active user turn (we'd rather merge into the live card than spam).
    *
-   * Card title intentionally avoids the previous "long-running task"
-   * wording — users read that as "agent is still running long-running
-   * work", but the card is in fact emitted at the END of a between-turn
-   * burst (e.g. after a `run_in_background` Bash command's task-notification
-   * triggered the agent to summarize a result). Calling it "agent activity"
-   * + green status lets the user read it as "the agent did this and is now
-   * quiet" — which is the correct signal.
+   * Uses the `agent_activity` status, which renders a blue header with
+   * an "Agent activity" title — that's the entire visual signal that
+   * this is a between-turn burst, not a normal "complete" reply.
+   * Earlier versions used `status: 'complete'` (green) plus an italic
+   * body caption, but users found the caption ugly and the green color
+   * indistinguishable from a regular turn.
    */
   private async flushSpontaneous(chatId: string): Promise<void> {
     const buf = this.spontaneousBuffers.get(chatId);
@@ -576,14 +573,22 @@ export class MessageBridge {
       return;
     }
 
+    // Nothing user-meaningful to surface — buffer might exist because a
+    // teammate ping landed but extractSpontaneousSnippet filtered all of
+    // its blocks (e.g. tool-only burst). Silently skip the card.
+    if (buf.snippets.length === 0) {
+      this.logger.debug({ chatId }, 'MessageBridge: drop spontaneous (no text snippets)');
+      return;
+    }
+
     const responseText = formatSpontaneousCardBody(buf.snippets);
 
     const card: CardState = {
-      status: 'complete',
+      status: 'agent_activity',
       userPrompt: '(agent activity)',
       responseText,
       toolCalls: [],
-      teamState: buf.snippets.length > 0 ? buf.teamState : undefined,
+      teamState: buf.teamState,
     };
     try {
       await this.sender.sendCard(chatId, card);

--- a/src/feishu/card-builder-v2.ts
+++ b/src/feishu/card-builder-v2.ts
@@ -25,6 +25,10 @@ const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: st
   complete:           { color: 'green',  title: 'Complete',          icon: '🟢' },
   error:              { color: 'red',    title: 'Error',             icon: '🔴' },
   waiting_for_input:  { color: 'yellow', title: 'Waiting for Input', icon: '🟡' },
+  // Blue with a distinct title so users can tell a between-turn burst card
+  // apart from both a live "running" turn and a finished "complete" reply
+  // without reading body text. See message-bridge.flushSpontaneous.
+  agent_activity:     { color: 'blue',   title: 'Agent activity',    icon: '🔵' },
 };
 
 const BG_ICON: Record<'running' | 'completed' | 'failed' | 'stopped', string> = {

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -15,6 +15,10 @@ const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: st
   complete: { color: 'green', title: 'Complete', icon: '🟢' },
   error: { color: 'red', title: 'Error', icon: '🔴' },
   waiting_for_input: { color: 'yellow', title: 'Waiting for Input', icon: '🟡' },
+  // Blue with a distinct title so users can tell a between-turn burst card
+  // apart from both a live "running" turn and a finished "complete" reply
+  // without reading body text. See message-bridge.flushSpontaneous.
+  agent_activity: { color: 'blue', title: 'Agent activity', icon: '🔵' },
 };
 
 const BG_ICON: Record<'running' | 'completed' | 'failed' | 'stopped', string> = {

--- a/src/telegram/telegram-sender.ts
+++ b/src/telegram/telegram-sender.ts
@@ -11,11 +11,12 @@ import { shouldBypassProxy } from '../utils/http.js';
 const MAX_MESSAGE_LENGTH = 4096;
 
 const STATUS_EMOJI: Record<CardStatus, string> = {
-  thinking: '\u{1F535}',      // 🔵
-  running: '\u{1F535}',       // 🔵
-  complete: '\u{1F7E2}',      // 🟢
-  error: '\u{1F534}',         // 🔴
+  thinking: '\u{1F535}',          // 🔵
+  running: '\u{1F535}',           // 🔵
+  complete: '\u{1F7E2}',          // 🟢
+  error: '\u{1F534}',             // 🔴
   waiting_for_input: '\u{1F7E1}', // 🟡
+  agent_activity: '\u{1F535}',    // 🔵 — between-turn burst, see message-bridge.flushSpontaneous
 };
 
 const STATUS_LABEL: Record<CardStatus, string> = {
@@ -24,6 +25,7 @@ const STATUS_LABEL: Record<CardStatus, string> = {
   complete: 'Complete',
   error: 'Error',
   waiting_for_input: 'Waiting for Input',
+  agent_activity: 'Agent activity',
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,18 @@
 // Shared types used across IM platforms (Feishu, Telegram, etc.)
 
-export type CardStatus = 'thinking' | 'running' | 'complete' | 'error' | 'waiting_for_input';
+export type CardStatus =
+  | 'thinking'
+  | 'running'
+  | 'complete'
+  | 'error'
+  | 'waiting_for_input'
+  /**
+   * Card was emitted by `flushSpontaneous` at the end of a between-turn
+   * burst (background task return / teammate ping / `/goal` evaluator).
+   * Rendered in blue with an "Agent activity" title so users can tell
+   * it apart from a normal user-prompted turn without reading body text.
+   */
+  | 'agent_activity';
 
 export interface ToolCall {
   name: string;

--- a/tests/card-builder-v2.test.ts
+++ b/tests/card-builder-v2.test.ts
@@ -103,6 +103,35 @@ describe('buildCardV2', () => {
     expect(team).toBeUndefined();
   });
 
+  // Cards from flushSpontaneous (between-turn agent activity) get the
+  // `agent_activity` status. Header must be blue with the "Agent activity"
+  // title, and the body must NOT include the legacy "Agent activity
+  // between turns (background task return, …)" italic caption — that's
+  // exactly the line users called out as ugly. The card-status signal IS
+  // the indicator now.
+  it('builds an agent_activity card with a blue header, "Agent activity" title, and no italic caption', () => {
+    const state: CardState = {
+      status:       'agent_activity',
+      userPrompt:   '(agent activity)',
+      responseText: 'Pushed commit abc1234.',
+      toolCalls:    [],
+    };
+    const json = JSON.parse(buildCardV2(state));
+    expect(json.header.template).toBe('blue');
+    expect(json.header.title.content).toContain('Agent activity');
+    const elements = findElements(json);
+    const captionEl = elements.find(
+      (e) => e.tag === 'markdown' && typeof e.content === 'string'
+        && /Agent activity between turns/.test(e.content),
+    );
+    expect(captionEl).toBeUndefined();
+    const bodyEl = elements.find(
+      (e) => e.tag === 'markdown' && typeof e.content === 'string'
+        && e.content.includes('Pushed commit abc1234'),
+    );
+    expect(bodyEl).toBeDefined();
+  });
+
   it('renders the running tool indicator as a single line (latest tool + count)', () => {
     const state: CardState = {
       status:       'running',

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -73,6 +73,33 @@ describe('buildCard', () => {
     expect(note.elements[0].content).toContain('5.0s');
   });
 
+  // Cards from flushSpontaneous (between-turn agent activity) are sent with
+  // the `agent_activity` status so users can see at a glance that the card
+  // isn't a normal user-turn reply. Blue header, distinct title — the body
+  // no longer carries the long italic "Agent activity between turns (…)"
+  // caption that v1 had.
+  it('builds an agent_activity card with a blue header and an "Agent activity" title', () => {
+    const state: CardState = {
+      status: 'agent_activity',
+      userPrompt: '(agent activity)',
+      responseText: 'Pushed commit abc1234.',
+      toolCalls: [],
+    };
+    const json = JSON.parse(buildCard(state));
+    expect(json.header.template).toBe('blue');
+    expect(json.header.title.content).toContain('Agent activity');
+    // The body must NOT include the legacy italic caption.
+    const captionEl = json.elements.find(
+      (e: any) => e.tag === 'markdown' && /Agent activity between turns/.test(e.content),
+    );
+    expect(captionEl).toBeUndefined();
+    // The actual conclusion text must be present.
+    const bodyEl = json.elements.find(
+      (e: any) => e.tag === 'markdown' && e.content.includes('Pushed commit abc1234'),
+    );
+    expect(bodyEl).toBeDefined();
+  });
+
   it('builds error card with error message', () => {
     const state: CardState = {
       status: 'error',

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -5,7 +5,6 @@ import {
   extractSpontaneousSnippet,
   formatSpontaneousCardBody,
   resolvePersistentExecutorEnvDefault,
-  SPONTANEOUS_CARD_HEADER,
 } from '../src/bridge/message-bridge.js';
 import { classifyBurstSource } from '../src/engines/claude/persistent-executor.js';
 
@@ -164,12 +163,14 @@ describe('formatSpontaneousCardBody', () => {
   // i.e. surface only the final result, not the play-by-play. If the user
   // wants the intermediate steps, they can read pm2 logs or the web UI's
   // expandable tool view.
-  it('renders only the latest snippet when a single snippet is present', () => {
+  //
+  // The body never carries a header caption anymore — the card itself is
+  // sent with the `agent_activity` status, which renders a blue
+  // "Agent activity" title at the top. Don't re-add a body header without
+  // confirming the card-status signal is no longer sufficient.
+  it('renders only the latest snippet, with no italic header caption, for a single snippet', () => {
     const body = formatSpontaneousCardBody(['Weather is sunny']);
-    expect(body).toContain(SPONTANEOUS_CARD_HEADER);
-    expect(body).toContain('Weather is sunny');
-    // No numbered prefix — single snippet doesn't need one.
-    expect(body).not.toMatch(/\*\*1\.\*\*/);
+    expect(body).toBe('Weather is sunny');
   });
 
   it('renders only the latest snippet + a coalesced-count footer when N>1', () => {
@@ -178,31 +179,19 @@ describe('formatSpontaneousCardBody', () => {
       'Found 3 things to address.',
       'Pushed commit abc1234 to the branch.',
     ]);
-    expect(body).toContain(SPONTANEOUS_CARD_HEADER);
     expect(body).toContain('Pushed commit abc1234 to the branch.');
     expect(body).toMatch(/3 events coalesced/);
     // Earlier snippets must NOT appear in the body.
     expect(body).not.toContain('Looking at the PR comments');
     expect(body).not.toContain('Found 3 things to address');
-    // No numbered list prefixes either.
+    // No numbered list prefixes either, and no body-level "between turns" caption.
     expect(body).not.toMatch(/\*\*1\.\*\*/);
+    expect(body).not.toMatch(/between turns/i);
+    expect(body).not.toMatch(/long-running/i);
   });
 
-  // Regression for Bug A (misleading title): the header used to say
-  // "Background activity from your agent team / long-running task".
-  // Users read "long-running task" as "still running" — but the card is
-  // emitted at the END of a quiet burst, so the agent is in fact idle by
-  // the time it lands. Header now describes WHAT happened, not an ongoing
-  // task. Don't relax these substring checks without re-evaluating the
-  // user mental model.
-  it('header does not claim a long-running task is in progress (regression)', () => {
-    expect(SPONTANEOUS_CARD_HEADER).not.toMatch(/long-running/i);
-    expect(SPONTANEOUS_CARD_HEADER).toMatch(/between turns/i);
-  });
-
-  it('renders even with empty snippets array (header still present)', () => {
-    const body = formatSpontaneousCardBody([]);
-    expect(body).toContain(SPONTANEOUS_CARD_HEADER);
+  it('returns an empty string when the snippets array is empty', () => {
+    expect(formatSpontaneousCardBody([])).toBe('');
   });
 });
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -7,7 +7,12 @@ export type CardStatus =
   | 'running'
   | 'complete'
   | 'error'
-  | 'waiting_for_input';
+  | 'waiting_for_input'
+  // Server-side `flushSpontaneous` emits this when a between-turn burst
+  // (background task return / teammate ping / `/goal` evaluator) lands;
+  // styled blue with an "Agent activity" header to tell it apart from a
+  // regular completed reply. Mirror of the server type.
+  | 'agent_activity';
 
 export interface ToolCall {
   name: string;


### PR DESCRIPTION
## Summary

The spontaneous between-turn card was prepending an italic \`Agent activity between turns (background task return, teammate ping, or /goal evaluator):\` caption to every body. Users said it was visual clutter, and the underlying signal ("this is a between-turn burst, not a normal turn") should come from card chrome anyway.

This PR moves the signal into the card header:

- **New \`CardStatus = 'agent_activity'\`** — blue header, title "Agent activity", 🔵 icon. Distinct from \`running\` / \`thinking\` (also blue but titled "Running…"/"Thinking…") and from \`complete\` (green), so the user can tell at a glance whether the card is a live turn, a finished reply, or a between-turn burst.
- **\`flushSpontaneous\`** uses the new status; \`formatSpontaneousCardBody\` returns just the latest snippet (plus the coalesced-count footer when N>1) — no italic caption.
- **Empty-buffer guard**: if all snippets get filtered out (e.g. tool-only burst, per the #269 text-only extractor), \`flushSpontaneous\` drops the card entirely rather than emitting an empty one.
- **Status threaded through** every renderer that pattern-matches on \`CardStatus\`: v1 + v2 Feishu card builders, Telegram \`STATUS_EMOJI\` / \`STATUS_LABEL\`, web frontend \`CardStatus\` union. The unused \`SPONTANEOUS_CARD_HEADER\` export and its phrasing-pinning regression tests are gone.

### Before / After (v2 card)

| Before | After |
| --- | --- |
| 🟢 **Complete** | 🔵 **Agent activity** |
| _Agent activity between turns (background task return, teammate ping, or `/goal` evaluator):_ | Pushed commit abc1234. |
| | _(3 events coalesced; showing latest)_ |
| Pushed commit abc1234. | |
| _(3 events coalesced; showing latest)_ | |

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npx vitest run\` — 291 / 291 pass; new render tests in card-builder + card-builder-v2; rewritten message-bridge tests
- [x] \`npm run lint\` — 0 errors, 2 pre-existing warnings (untouched)
- [ ] Manual: trigger an Agent Teams burst between turns, confirm the resulting Feishu card has a blue "Agent activity" header and the body starts directly with the agent's text — no italic caption
- [ ] Manual: confirm a tool-only burst produces no card (previously would have surfaced a card with just the caption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)