### PR TITLE
fix(claude): only enable 1M context beta when model has [1m] suffix

### DIFF
--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -365,9 +365,20 @@ export class ClaudeExecutor {
       queryOptions.resume = sessionId;
     }
 
-    // Beta flags are ignored by the SDK on OAuth/Pro-Max auth. For 1M context,
-    // use the model-name suffix `[1m]` (e.g. `claude-opus-4-7[1m]`) instead.
-    queryOptions.betas = ['context-1m-2025-08-07'];
+    // 1M context window is opt-in via the `[1m]` model-name suffix
+    // (`claude-opus-4-7[1m]`). The suffix is the canonical signal — the SDK
+    // parses it directly on both OAuth and API-key auth paths.
+    //
+    // We *also* set the matching `betas` flag when the suffix is present,
+    // belt-and-braces: harmless when the SDK already inferred it, and a
+    // safety net if a future SDK rev only honors the explicit beta header
+    // for some auth modes. Without the suffix, leave `betas` unset —
+    // setting it unconditionally on API-key auth had the side-effect of
+    // forcing every model (e.g. plain `opus-4-7`) into 1M context at 2×
+    // the price, which the user never asked for.
+    if (this.config.claude.model?.includes('[1m]')) {
+      queryOptions.betas = ['context-1m-2025-08-07'];
+    }
 
     return queryOptions;
   }

--- a/src/engines/claude/persistent-executor.ts
+++ b/src/engines/claude/persistent-executor.ts
@@ -365,8 +365,21 @@ export class PersistentClaudeExecutor extends EventEmitter {
         append: '\n\n' + appendSections.join('\n\n'),
       };
     }
-    // Beta flags (parity with legacy executor)
-    queryOptions.betas = ['context-1m-2025-08-07'];
+    // 1M context window is opt-in via the `[1m]` model-name suffix
+    // (`claude-opus-4-7[1m]`). The suffix is the canonical signal — the SDK
+    // parses it directly on both OAuth and API-key auth paths.
+    //
+    // We *also* set the matching `betas` flag when the suffix is present,
+    // belt-and-braces: harmless when the SDK already inferred it, and a
+    // safety net if a future SDK rev only honors the explicit beta header
+    // for some auth modes. Without the suffix, leave `betas` unset —
+    // setting it unconditionally on API-key auth had the side-effect of
+    // forcing every model (e.g. plain `opus-4-7`) into 1M context at 2×
+    // the price, which the user never asked for. (Parity with legacy
+    // executor; both spots must stay in sync.)
+    if (this.options.model?.includes('[1m]')) {
+      queryOptions.betas = ['context-1m-2025-08-07'];
+    }
 
     // Hooks: AskUserQuestion (mirrored from legacy executor — required so
     // that questions can be answered by users via Feishu cards) + Agent


### PR DESCRIPTION
## Summary

Both Claude executors unconditionally set the 1M-context beta flag on every request:

\`\`\`ts
queryOptions.betas = ['context-1m-2025-08-07'];
\`\`\`

The comment correctly noted that betas are ignored on OAuth / Pro-Max auth (where the \`[1m]\` model-name suffix is the real lever), but on **API-key** auth the SDK *does* honor the beta header — so every API-key user got 1M context for every model, including plain \`opus-4-7\`.

### User-visible symptom
Picking \`/model claude-opus-4-7\` showed \`1000k\` in the card footer (and billed at ~2× rate) instead of the expected \`200k\`. The 1M was supposed to be opt-in only via \`/model claude-opus-4-7[1m]\`.

### Fix
Only emit the beta flag when the model name contains \`[1m]\`. The suffix is now the single canonical signal for both auth paths:
- SDK parses the suffix directly (covers OAuth / Pro-Max).
- We re-send the matching beta header as belt-and-braces (safety net for API-key auth, and for any future SDK rev that needs the explicit header).

Both \`executor.ts\` and \`persistent-executor.ts\` had the same unconditional line — both fixed, both comment-tagged that they need to stay in sync.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx vitest run\` — 291 / 291 pass
- [x] \`npm run lint\` — 0 errors, 2 pre-existing warnings (untouched)
- [ ] Manual on Feishu (API-key auth): \`/model claude-opus-4-7\` then send a prompt, confirm card footer shows \`ctx: …/200k\`
- [ ] Manual: \`/model claude-opus-4-7[1m]\` then send a prompt, confirm card footer shows \`ctx: …/1000k\`
- [ ] Manual (OAuth / Pro-Max): same two checks — \`[1m]\` suffix should be the only way to enable 1M

🤖 Generated with [Claude Code](https://claude.com/claude-code)