### PR TITLE
fix(bridge): handle AskUserQuestion during continuation turns

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -888,6 +888,10 @@ export class MessageBridge {
 
     let lastState: CardState = initialState;
     const outputsDir = this.outputsManager.prepareDir(chatId);
+    // Set of pending AskUserQuestion toolUseIds we've already surfaced on
+    // this stream — prevents re-sending the question card on every delta
+    // while the same question is still waiting for an answer.
+    const surfacedQuestionIds = new Set<string>();
 
     try {
       for await (const message of handle.stream) {
@@ -895,6 +899,45 @@ export class MessageBridge {
         const state = processor.processMessage(message);
         if (activeGoal) state.goalCondition = activeGoal;
         lastState = state;
+
+        // AskUserQuestion during a continuation turn: route through the
+        // same standalone-question-card path used between turns. The
+        // continuation stream stays open (the SDK hook is awaiting
+        // resolveQuestion) — we just surface the question on its own card
+        // and replace the in-card response with a pointer note. When the
+        // user replies, handleMessage routes the answer via
+        // tryHandleBetweenTurnQuestionReply → executor.resolveQuestion,
+        // which unblocks the hook and the continuation stream continues.
+        if (state.status === 'waiting_for_input' && state.pendingQuestion) {
+          const q = state.pendingQuestion;
+          if (!surfacedQuestionIds.has(q.toolUseId)) {
+            surfacedQuestionIds.add(q.toolUseId);
+            await rateLimiter.flush();
+            // Main card pointer note, mirroring runOneTurn's runtime hint.
+            const hint = '_Waiting for your answer to the question card below…_';
+            const hintedState: CardState = {
+              ...state,
+              pendingQuestion: undefined,
+              responseText: state.responseText
+                ? state.responseText + '\n\n' + hint
+                : hint,
+            };
+            try {
+              await this.sender.updateCard(messageId, hintedState);
+            } catch (err) {
+              this.logger.warn({ err, chatId }, 'MessageBridge: continuation hint update failed');
+            }
+            // Surface the question on its own card via the shared between-
+            // turn pipeline. Re-uses pendingBetweenTurnQuestions bookkeeping
+            // so handleMessage's reply-interception path Just Works.
+            await this.handleBetweenTurnQuestion(chatId, {
+              toolUseId: q.toolUseId,
+              questions: q.questions,
+            });
+          }
+          continue;
+        }
+
         if (state.status === 'complete' || state.status === 'error') break;
         rateLimiter.schedule(() => {
           if (!abortController.signal.aborted) {


### PR DESCRIPTION
## Summary

- Follow-up to #274. Continuation turns (`handleContinuationTurn` — agent's response to an SDK-injected `<task-notification>` after a background task settles) didn't recognise `state.pendingQuestion` from the stream processor. AskUserQuestion fired during a continuation turn rendered as inline text in the main card; the user's typed reply was treated as a fresh user turn that immediately blocked for 6 minutes on the still-hanging hook.
- Reuse the between-turn question pipeline from #274: surface a dedicated question card, intercept the reply in `handleMessage`, route it via `executor.resolveQuestion()` to unblock the hook so the continuation stream continues normally.

## What changed

`src/bridge/message-bridge.ts` — inside the stream loop in `handleContinuationTurn`:

- When `state.status === 'waiting_for_input' && state.pendingQuestion`:
  - update the main continuation card with a `_Waiting for your answer to the question card below…_` hint (drops `pendingQuestion`, same pattern as `runOneTurn` at L1573-1586)
  - call `handleBetweenTurnQuestion(chatId, { toolUseId, questions })` — reuses the bookkeeping introduced in #274 (`pendingBetweenTurnQuestions`), so `handleMessage`'s reply-interception path Just Works
  - track `toolUseId`s in a per-stream `surfacedQuestionIds: Set<string>` so the card isn't re-sent on each subsequent delta while the same question is still waiting
- `executor-removed` cleanup (added in #274) already handles the case where the executor is evicted while a continuation question is pending.

## Test plan

Automated:

- [x] `npm run build` — clean.
- [x] `npx vitest run` — 298/298 pass.
- [x] `npm run lint` — 0 errors (pre-existing warnings unrelated).

Manual:

- [ ] Trigger a background bash task that settles after a delay, then have the agent invoke AskUserQuestion in its post-settle continuation reply.
- [ ] Confirm a dedicated question card appears below the continuation card.
- [ ] Reply with option number or free text — question card flips to "✅ Reply: …", continuation card resumes (does not freeze on "Thinking…").
- [ ] During the wait, `/reset` should mark the question card "canceled" and the continuation card "interrupted" (existing #274 cleanup path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)