### PR TITLE
fix(bridge): key AskUserQuestion answers by question text, not header

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -685,11 +685,14 @@ export class MessageBridge {
       answerText = trimmed;
     }
 
-    const answers: Record<string, string> = { [firstQ.header]: answerText };
+    // Key by `question` text (NOT header) — required by the SDK's
+    // AskUserQuestionOutput schema. See handleAnswer for the long-form
+    // comment on the same gotcha.
+    const answers: Record<string, string> = { [firstQ.question]: answerText };
     // For multi-sub-question between-turn calls (rare; logged on arrival),
     // synthesize empty answers for the rest so the hook still resolves.
     for (let i = 1; i < pending.questions.length; i++) {
-      answers[pending.questions[i].header] = '';
+      answers[pending.questions[i].question] = '';
     }
 
     const executor = this.persistentRegistry?.peek(chatId);
@@ -1379,8 +1382,14 @@ export class MessageBridge {
       answerText = trimmed;
     }
 
-    // Store answer for this question
-    task.collectedAnswers[currentQuestion.header] = answerText;
+    // Store answer for this question. The Claude Agent SDK's
+    // AskUserQuestionOutput schema (sdk-tools.d.ts) keys answers by the
+    // QUESTION TEXT, not the header — the docstring on the `answers` field
+    // says "question text -> answer string". Using header as the key produces
+    // a structurally valid dict but the SDK's tool_result text template can't
+    // interpolate it, surfacing as "User has answered your questions: ."
+    // (empty) to the model and a wasted turn.
+    task.collectedAnswers[currentQuestion.question] = answerText;
 
     this.logger.info(
       { chatId, answer: answerText, questionIndex: task.currentQuestionIndex, total: pending.questions.length, toolUseId: pending.toolUseId },
@@ -1516,11 +1525,12 @@ export class MessageBridge {
 
     this.logger.warn({ chatId: task.chatId, toolUseId: pending.toolUseId }, 'Question timeout, auto-answering remaining questions');
 
-    // Fill remaining unanswered questions with timeout message
+    // Fill remaining unanswered questions with timeout message. Keyed by
+    // `question` text — see handleAnswer for the SDK schema gotcha.
     for (let i = task.currentQuestionIndex; i < pending.questions.length; i++) {
       const q = pending.questions[i];
-      if (!task.collectedAnswers[q.header]) {
-        task.collectedAnswers[q.header] = '用户未及时回复，请自行判断继续';
+      if (!task.collectedAnswers[q.question]) {
+        task.collectedAnswers[q.question] = '用户未及时回复，请自行判断继续';
       }
     }
 

--- a/tests/between-turn-question.test.ts
+++ b/tests/between-turn-question.test.ts
@@ -141,7 +141,14 @@ describe('PersistentClaudeExecutor between-turn AskUserQuestion', () => {
 
     // Feed an answer back through the executor's resolveQuestion API —
     // this is what the bridge will do when the user replies in chat.
-    exec.resolveQuestion('toolu_btw_1', { cont: 'Yes' });
+    //
+    // IMPORTANT: keys MUST be the question TEXT, not the `header` field.
+    // The SDK's AskUserQuestionOutput schema (sdk-tools.d.ts) documents
+    // the answers dict as "question text -> answer string". The SDK's
+    // tool_result template looks up `answers[question.question]`; keying
+    // by header silently renders an empty answers list to the model
+    // ("User has answered your questions: .") and burns a turn.
+    exec.resolveQuestion('toolu_btw_1', { 'Continue?': 'Yes' });
 
     const result = await hookPromise;
     expect(result).toEqual({
@@ -150,7 +157,7 @@ describe('PersistentClaudeExecutor between-turn AskUserQuestion', () => {
         permissionDecision: 'allow',
         updatedInput: {
           questions: expect.any(Array),
-          answers: { cont: 'Yes' },
+          answers: { 'Continue?': 'Yes' },
         },
       },
     });
@@ -180,8 +187,9 @@ describe('PersistentClaudeExecutor between-turn AskUserQuestion', () => {
 
     expect(events).toHaveLength(0);
 
-    // Still resolves through the normal path
-    exec.resolveQuestion('toolu_in_turn_1', { h: 'answer' });
+    // Still resolves through the normal path (keyed by question text per
+    // the SDK schema — see the first test in this describe block).
+    exec.resolveQuestion('toolu_in_turn_1', { 'In-turn q': 'answer' });
     await hookPromise;
   });
 
@@ -210,7 +218,7 @@ describe('PersistentClaudeExecutor between-turn AskUserQuestion', () => {
     );
 
     expect(resolverPresentWhenEventFired).toBe(true);
-    exec.resolveQuestion('toolu_race_1', { h: 'x' });
+    exec.resolveQuestion('toolu_race_1', { q: 'x' });
     await p;
   });
 


### PR DESCRIPTION
## Summary

`AskUserQuestion` answers were being keyed by `question.header` when handed back to the SDK. The hook resolved correctly, but the SDK's `tool_result` text template looks up `answers[question.question]`, so the model received an empty answers list:

> User has answered your questions: . You can now continue with the user's answers in mind.

Every multi-choice question between Paul and the user was effectively silent — the user's reply was lost, the assistant burned a turn re-asking, and there were no visible errors in the bridge logs (the resolver path looked healthy).

## Root cause

`@anthropic-ai/claude-agent-sdk` (`sdk-tools.d.ts`) documents `AskUserQuestionOutput.answers` as `"question text -> answer string"`. The SDK's hidden `tool_result` template interpolates `answers[question.question]` per sub-question; mismatched keys silently render to empty strings (no schema validation rejects the wrong-shape dict, since both shapes are `Record<string, string>`).

## Evidence

Bridge log (Paul handled three sub-questions, all collected by `header`):

```
INFO PersistentExecutor: resolving AskUserQuestion
  toolUseId: toolu_01VxVphMG3mpieL9oVtcMjEm
  count: 3
INFO Resolved AskUserQuestion hook with collected answers
  answers: {
    "项目归属": "新建独立项目 bfm-design",
    "群定位": "本群是中枢，需要时再开子群",
    "Agent team": "暂不组建，先讨论拍板方案"
  }
```

Same `tool_use_id` in the Claude session transcript:

```json
"content": [{
  "type": "tool_result",
  "content": "User has answered your questions: . You can now continue with the user's answers in mind.",
  "tool_use_id": "toolu_01VxVphMG3mpieL9oVtcMjEm"
}],
"toolUseResult": {
  "questions": [...],
  "answers": { "项目归属": "新建独立项目 bfm-design", ... }
}
```

The structured `toolUseResult.answers` carries the data, but the assistant-visible `tool_result.content` is empty.

## Fix

Switch the answer-dict key from `question.header` to `question.question` at all four sites in `src/bridge/message-bridge.ts`:

- `handleAnswer` — in-turn answer collection (line ~1392)
- `tryHandleBetweenTurnQuestionReply` — between-turn first-question + remaining-fill (lines ~691, 695)
- `autoAnswerRemainingQuestions` — timeout fallback (lines ~1532–1533)

Plus `tests/between-turn-question.test.ts`, which previously asserted on `{ cont: 'Yes' }` (the header), encoding the bug into the regression suite. The assertions now use the question text, matching the SDK schema.

Verbose code comments at each site point at `sdk-tools.d.ts` and explain the silent failure mode so this doesn't regress.

## Test plan

- [x] `npx vitest run tests/between-turn-question.test.ts tests/message-bridge.test.ts` — pass (39/39)
- [x] `npx vitest run` — pass (315/315)
- [x] `npx tsc` — clean
- [x] `npm run lint` — clean for touched files (unrelated preexisting warnings only)
- [x] Manual end-to-end: restart Feishu bot, call `AskUserQuestion` with 3 sub-questions, reply `1` to each — Claude now sees the three labels instead of an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)