### PR TITLE
feat(memory): default folder visibility = private + mm share opt-in (Phase 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ MEMORY_INSTANCE_TOKEN=instance-scoped-token
 
 `METABOT_CLUSTER_URL` 会自动作为 peer 加入，当前实例就能发现对方的 Bot 和 Skill。`MEMORY_INSTANCE_TOKEN` 可写当前实例兜底 namespace 以及已配置的 bot/project namespace，读共享内容；管理员 token 仍保留完整访问权限。
 
+> ⚠️ **破坏性语义变更（Phase 0 默认私有）**：新建文件夹默认 `visibility=private`，对**其他实例的 peer-token 读者不可见**，直到你显式 `mm share` 它。本地 admin / instance-token 读写**不受影响**，已有文件夹也不动（迁移保留原 `visibility=shared`）。
+>
+> ```bash
+> mm share /projects/our-team          # 让 peer 实例能读到
+> mm unshare /projects/our-team        # 收回共享
+> # 或直接 PUT /api/folders/<id>  body: { "visibility": "shared" | "private" }
+> ```
+>
+> 这是在中心化架构（Phase 2–3）落地前，对 P2P 联邦更安全的默认值——避免新文件夹一旦创建就立刻对全网内其他 MetaBot 可见。
+
 ### 定时任务（Claude Code 原生）
 
 直接用 CC 内置的 `CronCreate` 和 `/loop`，会话内即开即用：

--- a/bin/mm
+++ b/bin/mm
@@ -246,6 +246,57 @@ print(json.dumps({'name': sys.argv[1], 'parent_id': sys.argv[2]}))
     _curl -X DELETE "$META_MEMORY_URL/api/documents/$1" | _json
     ;;
 
+  # --- Share folder (set visibility=shared so cross-instance peers can read) ---
+  # Usage: mm share <folder-path|folder-id>
+  #   Default-private (Phase 0): newly created folders are invisible to peer
+  #   instances until explicitly shared. Use this to opt a folder in.
+  share|unshare)
+    _verb="$cmd"
+    _vis="shared"
+    [[ "$_verb" == "unshare" ]] && _vis="private"
+    if [[ -z "${1:-}" ]]; then
+      echo "Usage: mm $_verb <folder-path|folder-id>"
+      echo "  e.g. mm $_verb /metabot/weekly-updates"
+      echo "       mm $_verb 1234abcd-..."
+      exit 1
+    fi
+    _target="$1"
+    # If looks like a UUID, use directly; otherwise resolve path -> id by
+    # walking the folder tree from /api/folders.
+    _id=""
+    if [[ "$_target" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+      _id="$_target"
+    else
+      _tree=$(_curl "$META_MEMORY_URL/api/folders")
+      _id=$(python3 -c "
+import json, sys
+tree = json.loads(sys.argv[1])
+target = sys.argv[2].strip('/')
+parts = [p for p in target.split('/') if p]
+def walk(nodes, parts):
+    if not parts:
+        return None
+    head, rest = parts[0], parts[1:]
+    for n in nodes:
+        if n.get('name') == head:
+            if not rest:
+                return n.get('id')
+            return walk(n.get('children', []) or [], rest)
+    return None
+fid = walk(tree if isinstance(tree, list) else tree.get('children', []) or [], parts)
+print(fid or '')
+" "$_tree" "$_target" 2>/dev/null || true)
+    fi
+    if [[ -z "$_id" ]]; then
+      echo "mm $_verb: folder not found: $_target" >&2
+      exit 1
+    fi
+    python3 -c "import json,sys; print(json.dumps({'visibility': sys.argv[1]}))" "$_vis" | \
+    _curl -X PUT "$META_MEMORY_URL/api/folders/$_id" \
+      -H "Content-Type: application/json" \
+      -d @- | _json
+    ;;
+
   health|h)
     _curl "$META_MEMORY_URL/api/health" | _json
     ;;
@@ -276,6 +327,10 @@ print(json.dumps({'name': sys.argv[1], 'parent_id': sys.argv[2]}))
     echo ""
     echo "    mm mkdir <name> [parent_id]    - Create folder (default parent: root)"
     echo "    mm delete <doc_id>             - Delete document"
+    echo ""
+    echo "  Visibility (Phase 0 default-private):"
+    echo "    mm share <folder-path|id>      - Mark folder shared (visible to peers)"
+    echo "    mm unshare <folder-path|id>    - Mark folder private (peer-invisible)"
     echo ""
     echo "  System:"
     echo "    mm health                      - Health check"

--- a/src/memory/memory-routes.ts
+++ b/src/memory/memory-routes.ts
@@ -19,11 +19,11 @@ export function handleCreateFolder(storage: MemoryStorage, body: Record<string, 
     return { status: 400, body: { detail: 'name is required' } };
   }
   const parentId = (body.parent_id as string) || 'root';
-  const visibility = (body.visibility as Visibility) || 'shared';
-  // Only admin can create private folders
-  if (visibility === 'private' && (typeof role !== 'string' || role !== 'admin')) {
-    return { status: 403, body: { detail: 'Only admin can create private folders' } };
-  }
+  // Default-private: folders are invisible to cross-instance peers until
+  // explicitly marked `shared` (via `mm share` or PUT /api/folders/<id>).
+  // Anyone with write access to the namespace may create folders; visibility
+  // can be flipped later by an admin.
+  const visibility = (body.visibility as Visibility) || 'private';
   try {
     const folder = storage.createFolder(name, parentId, visibility, role);
     memoryEvents.emitChange({ type: 'folder_created', folderId: folder.id });

--- a/src/memory/memory-storage.ts
+++ b/src/memory/memory-storage.ts
@@ -237,14 +237,21 @@ export class MemoryStorage {
       END;
     `);
 
-    // Migration: add visibility column if not exists
+    // Migration: add visibility column if not exists.
+    //
+    // First-rollout default is 'shared' so pre-existing folders stay visible
+    // to peers after upgrade (backward-compat for the federated P2P era).
+    // New folders created after this rollout default to 'private' — see
+    // `createFolder` below. To make a folder cross-peer visible, mark it
+    // `shared` explicitly (CLI: `mm share <path>`).
     const cols = this.db.prepare("PRAGMA table_info('folders')").all() as { name: string }[];
     if (!cols.some((c) => c.name === 'visibility')) {
       this.db.exec("ALTER TABLE folders ADD COLUMN visibility TEXT NOT NULL DEFAULT 'shared'");
       this.logger.info('Migration: added visibility column to folders');
     }
 
-    // Seed root folder if not exists
+    // Seed root folder if not exists. Root stays 'shared' — it's the navigation
+    // entry point; per-folder marking takes over below the root.
     const root = this.db.prepare('SELECT id FROM folders WHERE id = ?').get('root');
     if (!root) {
       const now = nowISO();
@@ -263,7 +270,7 @@ export class MemoryStorage {
     return `${parentPath}/${name}`;
   }
 
-  createFolder(name: string, parentId = 'root', visibility: Visibility = 'shared', access: MemoryAccess = 'admin'): Folder {
+  createFolder(name: string, parentId = 'root', visibility: Visibility = 'private', access: MemoryAccess = 'admin'): Folder {
     const folderPath = this.computeFolderPath(parentId, name);
     const principal = normalizeAccess(access);
     if (!this.canWritePath(folderPath, principal) && !canCreateNamespacePath(principal, folderPath)) {

--- a/tests/federated-search.test.ts
+++ b/tests/federated-search.test.ts
@@ -64,9 +64,12 @@ describe('fanOutFederatedSearch (Stage 3)', () => {
 
   async function seedDoc(memoryUrl: string, adminToken: string, title: string, content: string) {
     const adminHeaders = { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` };
+    // Phase 0 default-private: peer-token readers can only see folders explicitly
+    // marked `shared`. Federated search tests need cross-instance visibility,
+    // so opt in here.
     const folderResp = await fetch(`${memoryUrl}/api/folders`, {
       method: 'POST', headers: adminHeaders,
-      body: JSON.stringify({ name: `f-${title}` }),
+      body: JSON.stringify({ name: `f-${title}`, visibility: 'shared' }),
     });
     const folder = await folderResp.json() as { id: string };
     await fetch(`${memoryUrl}/api/documents`, {

--- a/tests/memory-default-private.test.ts
+++ b/tests/memory-default-private.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { startMemoryServer } from '../src/memory/memory-server.js';
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(), child: vi.fn() } as any;
+}
+
+/**
+ * Phase 0 — Default-Private Folder semantics.
+ *
+ * Folders created without an explicit `visibility` now default to `private`,
+ * meaning cross-instance peer-token readers cannot see them. `mm share`
+ * (PUT /api/folders/<id> { visibility: 'shared' }) opts a folder in.
+ *
+ * These tests cover the new default + the share/unshare flip.
+ */
+describe('Phase 0 default-private folders', () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      const cleanup = cleanups.pop();
+      cleanup?.();
+    }
+  });
+
+  async function startServerWithPeerToken() {
+    const databaseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metamemory-default-private-test-'));
+    cleanups.push(() => fs.rmSync(databaseDir, { recursive: true, force: true }));
+
+    const peerTokenLookup = (token: string) =>
+      token === 'alice-reader-token' ? { peerName: 'alice', instanceId: 'alice-id' } : undefined;
+
+    const { server, storage } = startMemoryServer({
+      port: 0,
+      databaseDir,
+      adminToken: 'admin-token',
+      peerTokenLookup,
+      logger: createLogger(),
+    });
+
+    cleanups.push(() => storage.close());
+    cleanups.push(() => server.close());
+
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const address = server.address() as AddressInfo;
+    return { url: `http://127.0.0.1:${address.port}` };
+  }
+
+  async function startInstanceTokenServer() {
+    const databaseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metamemory-default-private-inst-'));
+    cleanups.push(() => fs.rmSync(databaseDir, { recursive: true, force: true }));
+
+    const { server, storage } = startMemoryServer({
+      port: 0,
+      databaseDir,
+      adminToken: 'admin-token',
+      instanceToken: 'instance-token',
+      instanceId: 'alice',
+      memoryNamespace: '/instances/alice',
+      logger: createLogger(),
+    });
+
+    cleanups.push(() => storage.close());
+    cleanups.push(() => server.close());
+
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const address = server.address() as AddressInfo;
+    return { url: `http://127.0.0.1:${address.port}` };
+  }
+
+  const adminHeaders = { 'Content-Type': 'application/json', Authorization: 'Bearer admin-token' };
+  const peerHeaders = { Authorization: 'Bearer alice-reader-token' };
+
+  it('folder created without visibility defaults to private', async () => {
+    const { url } = await startServerWithPeerToken();
+
+    const folderResp = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ name: 'unspecified' }),
+    });
+    expect(folderResp.status).toBe(201);
+    const folder = await folderResp.json() as { id: string; visibility: string };
+    expect(folder.visibility).toBe('private');
+  });
+
+  it('explicit visibility=shared is honored on create', async () => {
+    const { url } = await startServerWithPeerToken();
+
+    const folderResp = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ name: 'opt-in-shared', visibility: 'shared' }),
+    });
+    expect(folderResp.status).toBe(201);
+    const folder = await folderResp.json() as { id: string; visibility: string };
+    expect(folder.visibility).toBe('shared');
+  });
+
+  it('admin sees default-private folders in tree (local backward compat)', async () => {
+    const { url } = await startServerWithPeerToken();
+
+    await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ name: 'admin-visible' }),
+    });
+
+    const tree = await fetch(`${url}/api/folders`, { headers: { Authorization: 'Bearer admin-token' } });
+    expect(tree.status).toBe(200);
+    expect(JSON.stringify(await tree.json())).toContain('admin-visible');
+  });
+
+  it('peer-token reader cannot see default-private folder', async () => {
+    const { url } = await startServerWithPeerToken();
+
+    const folderResp = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ name: 'hidden-from-peer' }),
+    });
+    expect(folderResp.status).toBe(201);
+    const folder = await folderResp.json() as { id: string };
+
+    await fetch(`${url}/api/documents`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ title: 'Private doc', folder_id: folder.id, content: 'shh' }),
+    });
+
+    const peerTree = await fetch(`${url}/api/folders`, { headers: peerHeaders });
+    expect(peerTree.status).toBe(200);
+    expect(JSON.stringify(await peerTree.json())).not.toContain('hidden-from-peer');
+  });
+
+  it('mm share (PUT visibility=shared) makes a default-private folder peer-visible', async () => {
+    const { url } = await startServerWithPeerToken();
+
+    const folderResp = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ name: 'will-be-shared' }),
+    });
+    const folder = await folderResp.json() as { id: string };
+
+    // Before share: invisible to peer.
+    const before = await fetch(`${url}/api/folders`, { headers: peerHeaders });
+    expect(JSON.stringify(await before.json())).not.toContain('will-be-shared');
+
+    // Flip to shared.
+    const shareResp = await fetch(`${url}/api/folders/${folder.id}`, {
+      method: 'PUT',
+      headers: adminHeaders,
+      body: JSON.stringify({ visibility: 'shared' }),
+    });
+    expect(shareResp.status).toBe(200);
+
+    // After share: visible to peer.
+    const after = await fetch(`${url}/api/folders`, { headers: peerHeaders });
+    expect(JSON.stringify(await after.json())).toContain('will-be-shared');
+  });
+
+  it('mm unshare (PUT visibility=private) hides a shared folder again', async () => {
+    const { url } = await startServerWithPeerToken();
+
+    const folderResp = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ name: 'will-be-unshared', visibility: 'shared' }),
+    });
+    const folder = await folderResp.json() as { id: string };
+
+    // Initially shared, peer sees it.
+    const before = await fetch(`${url}/api/folders`, { headers: peerHeaders });
+    expect(JSON.stringify(await before.json())).toContain('will-be-unshared');
+
+    const unshareResp = await fetch(`${url}/api/folders/${folder.id}`, {
+      method: 'PUT',
+      headers: adminHeaders,
+      body: JSON.stringify({ visibility: 'private' }),
+    });
+    expect(unshareResp.status).toBe(200);
+
+    const after = await fetch(`${url}/api/folders`, { headers: peerHeaders });
+    expect(JSON.stringify(await after.json())).not.toContain('will-be-unshared');
+  });
+
+  it('instance-token can create default-private folders in its namespace', async () => {
+    const { url } = await startInstanceTokenServer();
+
+    // Build the namespace path /instances/alice using the instance token,
+    // creating each folder default-private along the way.
+    const instanceHeaders = { 'Content-Type': 'application/json', Authorization: 'Bearer instance-token' };
+
+    const instancesResp = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: instanceHeaders,
+      body: JSON.stringify({ name: 'instances' }),
+    });
+    expect(instancesResp.status).toBe(201);
+    const instances = await instancesResp.json() as { id: string; visibility: string };
+    expect(instances.visibility).toBe('private');
+
+    const aliceResp = await fetch(`${url}/api/folders`, {
+      method: 'POST',
+      headers: instanceHeaders,
+      body: JSON.stringify({ name: 'alice', parent_id: instances.id }),
+    });
+    expect(aliceResp.status).toBe(201);
+    const alice = await aliceResp.json() as { id: string; visibility: string };
+    expect(alice.visibility).toBe('private');
+  });
+});

--- a/tests/memory-server.test.ts
+++ b/tests/memory-server.test.ts
@@ -318,7 +318,7 @@ describe('MetaMemory server request limits', () => {
     expect([401, 403, 404]).toContain(docFetch.status);
   });
 
-  it('peer-token reader can read shared folders (default visibility)', async () => {
+  it('peer-token reader can read shared folders (when explicitly marked shared)', async () => {
     const { url } = await startPeerTokenTestServer((token) =>
       token === 'alice-reader-token' ? { peerName: 'alice', instanceId: 'alice-id' } : undefined,
     );
@@ -327,11 +327,12 @@ describe('MetaMemory server request limits', () => {
       'Content-Type': 'application/json',
       Authorization: 'Bearer admin-token',
     };
-    // Default folder visibility is 'shared'.
+    // Phase 0: folders are private by default — must opt-in to `shared` for
+    // peer-token readers to see them.
     const folderResp = await fetch(`${url}/api/folders`, {
       method: 'POST',
       headers: adminHeaders,
-      body: JSON.stringify({ name: 'public-notes' }),
+      body: JSON.stringify({ name: 'public-notes', visibility: 'shared' }),
     });
     expect(folderResp.status).toBe(201);
     const folder = await folderResp.json() as { id: string };


### PR DESCRIPTION
## Summary

Phase 0 of the central-architecture pivot (see ADR in metamemory: `decision-central-architecture-pivot`). Folders now default to `visibility: 'private'` instead of `'shared'`, so a new folder isn't immediately readable across the LAN federation.

- `POST /api/folders` defaults to `private`
- `mm share <path|id>` / `mm unshare <path|id>` CLI commands (UUID or path)
- Local admin / instance-token access unchanged
- Existing folders untouched (no migration)
- Federated-search test opts into `shared` where it needs cross-instance visibility

## Why now

Insider-exfil threat model — central architecture (Phase 1+) removes peer-token visibility entirely, but until that ships, defaulting new folders to `shared` is too loud.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 359/359 passing (incl. 7 new in `tests/memory-default-private.test.ts`)
- [x] `npm run lint` — 0 errors, 2 pre-existing warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)