### PR TITLE
feat(transcript): public conversation-history detail page with Feishu OAuth (backend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,23 @@ META_MEMORY_URL=http://localhost:8100
 # NO_PROXY=openspeech.bytedance.com,localhost,127.0.0.1
 
 # =============================================================================
+# Transcript page (public conversation-history detail page)
+# =============================================================================
+# When a bot has `publicBaseUrl` set in bots.json, every Feishu card grows a
+# `📜 查看完整对话` link to a public read-only page. Auth uses Feishu OAuth
+# (the user logs in with the same account they chat from), then the open_id
+# is checked against a per-bot whitelist (`transcriptAllowOpenIds` in bots.json).
+#
+# METABOT_SESSION_SECRET signs both the OAuth `state` and the post-login
+# `mb_session` JWT cookie. If unset, MetaBot generates one on first start and
+# writes it to .env.local — copy it across machines if you want shared cookies.
+# METABOT_SESSION_SECRET=
+
+# Fallback open_id allowlist for bots that don't set per-bot `transcriptAllowOpenIds`.
+# Comma-separated. Also used for non-Feishu bots that don't have OAuth wired up.
+# METABOT_TRANSCRIPT_ALLOW_OPEN_IDS=ou_xxx,ou_yyy
+
+# =============================================================================
 # Logging
 # =============================================================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Slim summary only — see [docs/internal/architecture.md](docs/internal/architec
 - **Multi-bot mode**: `BOTS_CONFIG=./bots.json` runs multiple bots in one process (see `bots.example.json`). When set, the `FEISHU_APP_*` env vars are ignored.
 - **PersistentClaudeExecutor** (opt-in): `METABOT_PERSISTENT_EXECUTOR=true` keeps one long-lived `query()` per `chatId` so subagents / Agent Teams / `/background` / `/goal` survive across turns. Per-bot override via `persistentExecutor` in `bots.json`. Observability at `GET /api/executors`.
 - **MetaMemory**: external FastAPI+SQLite server at `META_MEMORY_URL` (default `http://localhost:8100`). Claude reads/writes via the `metamemory` skill; `/memory list|search|status` query directly.
+- **Transcript page** (opt-in, Feishu only): set per-bot `publicBaseUrl` + `transcriptAllowOpenIds` in `bots.json` to inject a `📜 查看完整对话` link into every card. Page is gated by Feishu OAuth (HttpOnly JWT cookie) + open_id whitelist. `METABOT_SESSION_SECRET` signs the cookie (auto-generated to `.env.local` on first start); fallback whitelist via `METABOT_TRANSCRIPT_ALLOW_OPEN_IDS`. Without `publicBaseUrl` set, cards render exactly as before — no link, no exposure.
 
 ## Branching Strategy
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ MetaBot 支持 4 种方式与你的 Agent 团队交互：
 | `maxTurns` / `maxBudgetUsd` | 否 | 不限 | 执行限制 |
 | `model` | 否 | SDK 默认 | Claude 模型 |
 | `apiKey` | 否 | — | Anthropic API Key（不设则从 `~/.claude/.credentials.json` 动态读取，兼容 cc-switch） |
+| `publicBaseUrl` | 否 | — | 详情页公网入口（设置后卡片会出现 `📜 查看完整对话` 链接） |
+| `transcriptAllowOpenIds` | 否 | `[]` | 详情页 open_id 白名单（飞书 OAuth 通过后才能访问） |
 
 </details>
 
@@ -386,6 +388,8 @@ MetaBot 支持 4 种方式与你的 Agent 团队交互：
 | `METABOT_URL` | `http://localhost:9100` | MetaBot API 地址 |
 | `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory 服务地址 |
 | `METABOT_PEERS` | — | Peer MetaBot 地址（逗号分隔） |
+| `METABOT_SESSION_SECRET` | 首次自动生成 | 详情页 OAuth state + JWT cookie 签名密钥（写入 `.env.local`） |
+| `METABOT_TRANSCRIPT_ALLOW_OPEN_IDS` | — | 详情页 open_id 全局白名单 fallback（逗号分隔，仅当 bot 未配置 `transcriptAllowOpenIds` 时生效） |
 | `LOG_LEVEL` | info | 日志级别 |
 
 </details>

--- a/README_EN.md
+++ b/README_EN.md
@@ -367,6 +367,8 @@ Supported: text, images (Claude multimodal), files (PDF/code/docs), rich text (P
 | `maxTurns` / `maxBudgetUsd` | No | unlimited | Execution limits |
 | `model` | No | SDK default | Claude model |
 | `apiKey` | No | — | Anthropic API key (leave unset for dynamic auth via cc-switch) |
+| `publicBaseUrl` | No | — | Public ingress for the transcript page. Setting this injects a `📜 View full conversation` link into every card |
+| `transcriptAllowOpenIds` | No | `[]` | Allowlist of Feishu `open_id`s that can view the transcript page (only consulted after a successful Feishu OAuth login) |
 
 </details>
 
@@ -389,6 +391,8 @@ Supported: text, images (Claude multimodal), files (PDF/code/docs), rich text (P
 | `METABOT_URL` | `http://localhost:9100` | MetaBot API URL. Default is local HTTP; for remote access prefer HTTPS or a private-network address |
 | `META_MEMORY_URL` | `http://localhost:8100` | MetaMemory server URL. Default is local HTTP; for remote access prefer HTTPS or a private-network address |
 | `METABOT_PEERS` | — | Peer MetaBot URLs (comma-separated). Prefer HTTPS for internet-reachable peers |
+| `METABOT_SESSION_SECRET` | auto-generated | Signs the transcript-page OAuth `state` and the `mb_session` JWT cookie. Generated on first start and written to `.env.local` |
+| `METABOT_TRANSCRIPT_ALLOW_OPEN_IDS` | — | Global open_id allowlist fallback for the transcript page (comma-separated). Only consulted when a bot has no per-bot `transcriptAllowOpenIds` |
 | `LOG_LEVEL` | info | Log level |
 
 </details>

--- a/bots.example.json
+++ b/bots.example.json
@@ -20,7 +20,9 @@
       "feishuAppSecret": "secret2",
       "defaultWorkingDirectory": "/home/user/project-beta",
       "maxTurns": 30,
-      "maxBudgetUsd": 0.5
+      "maxBudgetUsd": 0.5,
+      "publicBaseUrl": "https://example.com:18443",
+      "transcriptAllowOpenIds": ["ou_paste_open_id_after_first_oauth_login"]
     },
     {
       "name": "project-gamma",

--- a/src/api/http-server.ts
+++ b/src/api/http-server.ts
@@ -32,6 +32,7 @@ import {
   handleSessionRoutes,
   handleSkillHubRoutes,
   handleExecutorRoutes,
+  handleTranscriptRoutes,
 } from './routes/index.js';
 import type { RouteContext } from './routes/index.js';
 
@@ -91,7 +92,9 @@ export function startApiServer(options: ApiServerOptions): http.Server {
     skillHubStore,
   };
 
-  // Route handlers in priority order
+  // Route handlers in priority order. `handleTranscriptRoutes` must come
+  // BEFORE the static file fallback (server falls through to that when none
+  // of these handlers match the URL).
   const routeHandlers = [
     handleVoiceRoutes,
     handleFileRoutes,
@@ -103,14 +106,24 @@ export function startApiServer(options: ApiServerOptions): http.Server {
     handleSessionRoutes,
     handleSkillHubRoutes,
     handleExecutorRoutes,
+    handleTranscriptRoutes,
   ];
 
   const server = http.createServer(async (req, res) => {
     const method = req.method || 'GET';
     const url = req.url || '/';
 
-    // Auth check (exempt /web/, /memory/, /api/files/)
-    if (secret && !url.startsWith('/web') && !url.startsWith('/memory') && !url.startsWith('/api/files/')) {
+    // Auth check (exempt /web/, /memory/, /api/files/, transcript & feishu OAuth)
+    // The transcript/auth routes carry their own cookie-based auth and the
+    // OAuth callback is hit by the user's browser (no Bearer header).
+    if (
+      secret
+      && !url.startsWith('/web')
+      && !url.startsWith('/memory')
+      && !url.startsWith('/api/files/')
+      && !url.startsWith('/api/transcript/')
+      && !url.startsWith('/api/auth/feishu/')
+    ) {
       const auth = req.headers.authorization;
       const urlToken = url.includes('token=') ? new URL(url, `http://${req.headers.host || 'localhost'}`).searchParams.get('token') : null;
       if (auth !== `Bearer ${secret}` && urlToken !== secret) {

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -8,5 +8,6 @@ export { handleRtcRoutes } from './rtc-routes.js';
 export { handleSessionRoutes } from './session-routes.js';
 export { handleSkillHubRoutes } from './skill-hub-routes.js';
 export { handleExecutorRoutes } from './executor-routes.js';
+export { handleTranscriptRoutes } from './transcript-routes.js';
 export { jsonResponse, readBody, parseJsonBody } from './helpers.js';
 export type { RouteContext, RouteHandler } from './types.js';

--- a/src/api/routes/transcript-routes.ts
+++ b/src/api/routes/transcript-routes.ts
@@ -1,0 +1,241 @@
+/**
+ * Transcript page routes — drive the public-facing "查看完整对话" detail page.
+ *
+ *   GET /api/auth/feishu/login?return=<url>&bot=<botName>
+ *     302 → passport.feishu.cn OAuth (HMAC-signed state with returnUrl + botName).
+ *
+ *   GET /api/auth/feishu/callback?code=...&state=...
+ *     Verifies state, exchanges code for open_id + name, sets HttpOnly
+ *     mb_session cookie (7-day JWT), 302 → original returnUrl.
+ *
+ *   GET /api/transcript/:chatId?turn=<n|all>
+ *     Cookie-gated + open_id whitelist. Returns
+ *     { chat: { chatId, totalTurns }, turn, messages: TranscriptMessage[] }.
+ *
+ * Whitelist resolution: per-bot `transcriptAllowOpenIds` wins, else falls back
+ * to env METABOT_TRANSCRIPT_ALLOW_OPEN_IDS (comma-separated).
+ *
+ * publicBaseUrl: read from the bot's config and used to build the absolute
+ * callback URI sent to Feishu. We also accept an explicit Host header (when
+ * the bot has no publicBaseUrl) as a best-effort fallback for local dev.
+ */
+import type * as http from 'node:http';
+import { jsonResponse } from './helpers.js';
+import type { RouteContext } from './types.js';
+import type { BotConfig } from '../../config.js';
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForUser,
+  parseCookies,
+  signSession,
+  verifySession,
+  verifyState,
+  loadOrCreateSessionSecret,
+} from '../../feishu/oauth.js';
+import { sessionJsonlPath } from '../../session/session-registry.js';
+import { readTranscript } from '../../session/transcript-reader.js';
+
+function envAllowList(): string[] {
+  const v = process.env.METABOT_TRANSCRIPT_ALLOW_OPEN_IDS || '';
+  return v.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function pickFeishuBot(ctx: RouteContext, botName?: string): { name: string; cfg: BotConfig } | null {
+  const feishuBots = ctx.registry.listByPlatform('feishu');
+  if (feishuBots.length === 0) return null;
+  if (botName) {
+    const exact = feishuBots.find((b) => b.name === botName);
+    if (exact) return { name: exact.name, cfg: exact.config as BotConfig };
+    return null;
+  }
+  // No bot specified — pick the first one. Plan calls this out: in single-bot
+  // setups this is unambiguous; in multi-bot deployments callers should pass
+  // ?bot=<name> via the card link template.
+  return { name: feishuBots[0].name, cfg: feishuBots[0].config as BotConfig };
+}
+
+function resolveBaseUrl(ctx: RouteContext, req: http.IncomingMessage, bot: BotConfig): string {
+  if (bot.publicBaseUrl) return bot.publicBaseUrl.replace(/\/+$/, '');
+  // Best-effort fallback: synthesize from request headers. Only used in local
+  // dev when no publicBaseUrl is set.
+  const proto = (req.headers['x-forwarded-proto'] as string) || 'http';
+  const host  = (req.headers['x-forwarded-host'] as string) || req.headers.host || 'localhost';
+  return `${proto}://${host}`;
+}
+
+function isAllowed(openId: string, bot: BotConfig): boolean {
+  const perBot = bot.transcriptAllowOpenIds ?? [];
+  if (perBot.includes(openId)) return true;
+  return envAllowList().includes(openId);
+}
+
+export async function handleTranscriptRoutes(
+  ctx: RouteContext,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  method: string,
+  url: string,
+): Promise<boolean> {
+  // ── 1) GET /api/auth/feishu/login ────────────────────────────────────
+  if (method === 'GET' && url.startsWith('/api/auth/feishu/login')) {
+    const parsed = new URL(url, 'http://localhost');
+    const returnUrl = parsed.searchParams.get('return') || '/web';
+    const wantedBot = parsed.searchParams.get('bot') || undefined;
+    const picked = pickFeishuBot(ctx, wantedBot);
+    if (!picked) {
+      jsonResponse(res, 503, { error: 'no feishu bot configured for OAuth' });
+      return true;
+    }
+    const base = resolveBaseUrl(ctx, req, picked.cfg);
+    const redirectUri = `${base}/api/auth/feishu/callback`;
+    const authorizeUrl = buildAuthorizeUrl(
+      {
+        appId:     picked.cfg.feishu.appId,
+        appSecret: picked.cfg.feishu.appSecret,
+        botName:   picked.name,
+      },
+      redirectUri,
+      returnUrl,
+    );
+    res.writeHead(302, { Location: authorizeUrl });
+    res.end();
+    return true;
+  }
+
+  // ── 2) GET /api/auth/feishu/callback ─────────────────────────────────
+  if (method === 'GET' && url.startsWith('/api/auth/feishu/callback')) {
+    const parsed = new URL(url, 'http://localhost');
+    const code   = parsed.searchParams.get('code');
+    const state  = parsed.searchParams.get('state');
+    if (!code || !state) {
+      jsonResponse(res, 400, { error: 'missing code or state' });
+      return true;
+    }
+    const decoded = verifyState(state);
+    if (!decoded) {
+      jsonResponse(res, 400, { error: 'invalid or expired state' });
+      return true;
+    }
+    const picked = pickFeishuBot(ctx, decoded.botName);
+    if (!picked) {
+      jsonResponse(res, 503, { error: 'bot vanished between login and callback' });
+      return true;
+    }
+    let profile;
+    try {
+      profile = await exchangeCodeForUser(
+        { appId: picked.cfg.feishu.appId, appSecret: picked.cfg.feishu.appSecret },
+        code,
+      );
+    } catch (err: unknown) {
+      ctx.logger.warn({ err }, 'Feishu OAuth exchange failed');
+      jsonResponse(res, 502, { error: 'oauth exchange failed', detail: (err as Error).message });
+      return true;
+    }
+    const jwt = signSession({ open_id: profile.openId, name: profile.name });
+    const cookie = `mb_session=${encodeURIComponent(jwt)}; HttpOnly; SameSite=Lax; Max-Age=${7 * 24 * 60 * 60}; Path=/`;
+
+    // Defensive: ensure returnUrl is a relative path or under our own host —
+    // we don't want this endpoint to be an open redirect. Best-effort: if it
+    // parses as a full URL with a different host, fall back to /web.
+    let target = decoded.returnUrl;
+    try {
+      if (/^https?:\/\//i.test(target)) {
+        const t = new URL(target);
+        const myBase = resolveBaseUrl(ctx, req, picked.cfg);
+        const my = new URL(myBase);
+        if (t.host !== my.host) target = '/web';
+      }
+    } catch {
+      target = '/web';
+    }
+
+    res.writeHead(302, {
+      'Set-Cookie': cookie,
+      Location:     target,
+    });
+    res.end();
+    return true;
+  }
+
+  // ── 3) GET /api/transcript/:chatId ───────────────────────────────────
+  const m = url.match(/^\/api\/transcript\/([^/?#]+)/);
+  if (method === 'GET' && m) {
+    // Touch the secret once so the first request after install bootstraps
+    // .env.local instead of waiting for the first login attempt.
+    loadOrCreateSessionSecret();
+
+    const chatId = decodeURIComponent(m[1]);
+    const parsed = new URL(url, 'http://localhost');
+    const turnParam = parsed.searchParams.get('turn') || 'all';
+    const turn: number | 'all' = turnParam === 'all' ? 'all' : Math.max(1, parseInt(turnParam, 10) || 1);
+
+    const cookies = parseCookies(req.headers.cookie);
+    const session = cookies.mb_session ? verifySession(cookies.mb_session) : null;
+    if (!session) {
+      const returnPath = `/web/transcript/${encodeURIComponent(chatId)}${turnParam ? `?turn=${turnParam}` : ''}`;
+      jsonResponse(res, 401, {
+        error:    'unauthenticated',
+        loginUrl: `/api/auth/feishu/login?return=${encodeURIComponent(returnPath)}`,
+      });
+      return true;
+    }
+
+    if (!ctx.sessionRegistry) {
+      jsonResponse(res, 503, { error: 'session registry unavailable' });
+      return true;
+    }
+
+    const record = ctx.sessionRegistry.findByChatId(chatId);
+    if (!record) {
+      jsonResponse(res, 404, { error: 'session not found' });
+      return true;
+    }
+
+    // Resolve owning bot — used for whitelist + (future) per-bot rendering hints.
+    const bot = ctx.registry.get(record.botName);
+    if (!bot) {
+      jsonResponse(res, 404, { error: 'bot not registered' });
+      return true;
+    }
+    if (bot.platform !== 'feishu') {
+      // Non-feishu bots don't have an OAuth flow yet — they remain accessible
+      // only via the same Feishu cookie + the global env allowlist.
+      if (!envAllowList().includes(session.open_id)) {
+        jsonResponse(res, 403, { error: 'forbidden' });
+        return true;
+      }
+    } else {
+      if (!isAllowed(session.open_id, bot.config as BotConfig)) {
+        jsonResponse(res, 403, { error: 'forbidden' });
+        return true;
+      }
+    }
+
+    if (!record.claudeSessionId) {
+      jsonResponse(res, 200, {
+        chat:     { chatId, totalTurns: 0, title: record.title },
+        turn,
+        messages: [],
+      });
+      return true;
+    }
+    const jsonlPath = sessionJsonlPath(record.workingDirectory, record.claudeSessionId);
+    const result    = readTranscript(jsonlPath, turn);
+
+    jsonResponse(res, 200, {
+      chat:     {
+        chatId,
+        totalTurns: result.totalTurns,
+        title:      record.title,
+        botName:    record.botName,
+        platform:   record.platform,
+      },
+      turn,
+      messages: result.messages,
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import type { BotConfigBase } from '../config.js';
 import type { Logger } from '../utils/logger.js';
@@ -202,6 +203,16 @@ export class MessageBridge {
   readonly costTracker: CostTracker;
   private sessionRegistry?: SessionRegistry;
   private runningTasks = new Map<string, RunningTask>(); // keyed by chatId
+  /**
+   * Per-chatId monotonically-increasing turn counter. Bumped at the start of
+   * every {@link runOneTurn} invocation. Surfaced into the Feishu card as
+   * `transcriptLink=<base>/web/transcript/<chatId>?turn=<N>` so the
+   * "查看完整对话" link opens directly on the turn the card represents.
+   *
+   * Process-local: a restart resets the counter to 0 and the next card link
+   * falls back to the JSONL line count (see {@link computeTranscriptLink}).
+   */
+  private turnIndexByChat = new Map<string, number>();
   private messageQueues = new Map<string, IncomingMessage[]>(); // per-chatId message queue
   private pendingBatches = new Map<string, PendingBatch>(); // media debounce batches
   /**
@@ -865,12 +876,19 @@ export class MessageBridge {
     const session = this.sessionManager.getSession(chatId);
     const activeGoal = session.activeGoal;
 
+    // Continuation cards reuse the prior turn's index — they belong to the
+    // same logical user turn, not a new one. Bumping would point the link
+    // past the visible turn.
+    const transcriptLink = this.computeTranscriptLink(chatId);
+    processor.setTranscriptLink(transcriptLink);
+
     const initialState: CardState = {
       status: 'thinking',
       userPrompt: displayPrompt,
       responseText: '',
       toolCalls: [],
       goalCondition: activeGoal,
+      transcriptLink,
     };
 
     const messageId = await this.sender.sendCard(chatId, initialState);
@@ -1038,6 +1056,70 @@ export class MessageBridge {
    * sessionId, so `acquire()` would otherwise hand back the same broken
    * instance.
    */
+  /**
+   * Bump the per-chatId turn counter and return the new value. Called once
+   * per {@link runOneTurn} invocation so the value matches the user-message
+   * boundary used by the transcript reader.
+   */
+  private bumpTurnIndex(chatId: string): number {
+    const next = (this.turnIndexByChat.get(chatId) ?? 0) + 1;
+    this.turnIndexByChat.set(chatId, next);
+    return next;
+  }
+
+  /**
+   * Build the absolute transcript page URL for the current turn of a chat.
+   * Returns `undefined` when:
+   *   - the bot has no `publicBaseUrl` configured (graceful degradation), or
+   *   - the bot config shape doesn't include the field (non-Feishu bots).
+   *
+   * `turnIndex` falls back to the JSONL `type:'user'` count if the in-memory
+   * counter is empty (process restart), so cards sent right after a restart
+   * still point at the right turn.
+   */
+  private computeTranscriptLink(chatId: string, turnIndex?: number): string | undefined {
+    const cfg = this.config as BotConfigBase & { publicBaseUrl?: string };
+    if (!cfg.publicBaseUrl) return undefined;
+    const base = cfg.publicBaseUrl.replace(/\/+$/, '');
+    const t    = turnIndex ?? this.turnIndexByChat.get(chatId) ?? this.countUserTurnsFromJsonl(chatId);
+    return `${base}/web/transcript/${encodeURIComponent(chatId)}?turn=${t || 1}`;
+  }
+
+  /** Fallback: count the user-message lines in the chat's JSONL transcript. */
+  private countUserTurnsFromJsonl(chatId: string): number {
+    if (!this.sessionRegistry) return 0;
+    const rec = this.sessionRegistry.findByChatId(chatId);
+    if (!rec?.claudeSessionId) return 0;
+    try {
+      const raw = fs.readFileSync(
+        path.join(
+          // SessionRegistry encodes workdir identically.
+          os.homedir(),
+          '.claude', 'projects',
+          rec.workingDirectory.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 200),
+          `${rec.claudeSessionId}.jsonl`,
+        ),
+        'utf-8',
+      );
+      let n = 0;
+      for (const line of raw.split('\n')) {
+        if (!line) continue;
+        try {
+          const evt = JSON.parse(line);
+          if (evt.type === 'user' && evt.message?.role === 'user' && typeof evt.message.content !== 'undefined') {
+            // Skip pure tool_result carrier lines.
+            const c = evt.message.content;
+            if (Array.isArray(c) && c.length > 0 && c.every((b: { type?: string }) => b.type === 'tool_result')) continue;
+            n += 1;
+          }
+        } catch { /* ignore */ }
+      }
+      return n;
+    } catch {
+      return 0;
+    }
+  }
+
   private async runOneTurn(
     chatId: string,
     engineName: EngineName,
@@ -1704,12 +1786,19 @@ export class MessageBridge {
     // arrive mid-task (handleMessage rejects them with "Task In Progress"),
     // so this stays stable for the whole run.
     const activeGoal = session.activeGoal;
+    // Bump the per-chat turn counter once per user-driven turn — this is the
+    // canonical turn boundary the transcript reader uses.
+    const turnIndex = this.bumpTurnIndex(chatId);
+    const transcriptLink = this.computeTranscriptLink(chatId, turnIndex);
+    processor.setTranscriptLink(transcriptLink);
+
     const initialState: CardState = {
       status: 'thinking',
       userPrompt: displayPrompt,
       responseText: '',
       toolCalls: [],
       goalCondition: activeGoal,
+      transcriptLink,
     };
 
     const messageId = await this.sender.sendCard(chatId, initialState);
@@ -2181,6 +2270,11 @@ export class MessageBridge {
     const processor = new StreamProcessor(displayPrompt);
     const rateLimiter = new RateLimiter(1500);
     const activeGoal = session.activeGoal;
+    // API-triggered tasks also bump the per-chat turn counter so the
+    // transcript link matches the JSONL boundary.
+    const turnIndex = this.bumpTurnIndex(chatId);
+    const transcriptLink = this.computeTranscriptLink(chatId, turnIndex);
+    processor.setTranscriptLink(transcriptLink);
 
     const initialState: CardState = {
       status: 'thinking',
@@ -2188,6 +2282,7 @@ export class MessageBridge {
       responseText: '',
       toolCalls: [],
       goalCondition: activeGoal,
+      transcriptLink,
     };
 
     let messageId: string | undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,20 @@ export interface BotConfig extends BotConfigBase {
   };
   /** When true, respond to all messages in group chats without requiring @mention. */
   groupNoMention?: boolean;
+  /**
+   * Public-facing base URL where this MetaBot instance is reachable
+   * (e.g. `https://metabot.example.com`). Used to:
+   *   - assemble the `查看完整对话` link injected into every Feishu card.
+   *   - build the OAuth `redirect_uri` sent to passport.feishu.cn.
+   * When empty/undefined the link is omitted from cards (graceful degradation).
+   */
+  publicBaseUrl?: string;
+  /**
+   * Allowlist of Feishu open_ids permitted to view this bot's transcript
+   * pages. Falls back to env METABOT_TRANSCRIPT_ALLOW_OPEN_IDS when this
+   * field is missing or empty.
+   */
+  transcriptAllowOpenIds?: string[];
 }
 
 /** Telegram bot config (extends base with Telegram credentials). */
@@ -208,6 +222,10 @@ export interface FeishuBotJsonEntry extends EngineJsonFields {
   downloadsDir?: string;
   /** When true, respond to all messages in group chats without requiring @mention. */
   groupNoMention?: boolean;
+  /** Public base URL for transcript page links (e.g. `https://bot.example.com`). */
+  publicBaseUrl?: string;
+  /** Whitelisted Feishu open_ids permitted to view this bot's transcripts. */
+  transcriptAllowOpenIds?: string[];
 }
 
 function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
@@ -221,6 +239,8 @@ function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
     ...(entry.budgetLimitDaily != null ? { budgetLimitDaily: entry.budgetLimitDaily } : {}),
     ...(entry.ttsVoice ? { ttsVoice: entry.ttsVoice } : {}),
     ...(entry.groupNoMention ? { groupNoMention: true } : {}),
+    ...(entry.publicBaseUrl ? { publicBaseUrl: entry.publicBaseUrl } : {}),
+    ...(entry.transcriptAllowOpenIds?.length ? { transcriptAllowOpenIds: entry.transcriptAllowOpenIds } : {}),
     ...(entry.engine ? { engine: entry.engine } : {}),
     ...(entry.kimi ? { kimi: entry.kimi } : {}),
     ...(codex ? { codex } : {}),

--- a/src/engines/claude/stream-processor.ts
+++ b/src/engines/claude/stream-processor.ts
@@ -41,8 +41,19 @@ export class StreamProcessor {
   private _lastOutputTokens: number | undefined;
   // Live background tasks (Monitor, etc.) — task_id → latest rollup.
   private _backgroundEvents: Map<string, BackgroundEvent> = new Map();
+  /**
+   * Optional transcript-page link surfaced into every card produced by this
+   * processor. Set once per turn from MessageBridge.runOneTurn so the link
+   * stays stable across every streaming update for that turn.
+   */
+  private _transcriptLink: string | undefined;
 
   constructor(private userPrompt: string) {}
+
+  /** Bind a transcript link that will be included in every subsequent card state. */
+  setTranscriptLink(link: string | undefined): void {
+    this._transcriptLink = link;
+  }
 
   processMessage(message: SDKMessage): CardState {
     // Capture session_id from any message
@@ -98,6 +109,7 @@ export class StreamProcessor {
       backgroundEvents: this._backgroundEvents.size > 0
         ? [...this._backgroundEvents.values()]
         : undefined,
+      transcriptLink:   this._transcriptLink,
     };
   }
 
@@ -294,6 +306,7 @@ export class StreamProcessor {
       backgroundEvents: this._backgroundEvents.size > 0
         ? [...this._backgroundEvents.values()]
         : undefined,
+      transcriptLink:   this._transcriptLink,
     };
   }
 
@@ -394,6 +407,7 @@ export class StreamProcessor {
       backgroundEvents: this._backgroundEvents.size > 0
         ? [...this._backgroundEvents.values()]
         : undefined,
+      transcriptLink:   this._transcriptLink,
     };
   }
 

--- a/src/feishu/card-builder-v2.ts
+++ b/src/feishu/card-builder-v2.ts
@@ -299,6 +299,20 @@ export function buildCardV2(state: CardState): string {
     }
   }
 
+  // Transcript link — rendered as an inline markdown link below the footer
+  // so users on every Feishu surface (desktop, mobile, webview) can tap to
+  // open the public detail page. We deliberately use markdown rather than
+  // a `tag: action` button because mobile silently drops action blocks in
+  // Card v2 (see bug-feishu-v2-mobile-action-buttons).
+  if (state.transcriptLink) {
+    elements.push({
+      tag:        'markdown',
+      content:    `📜 [查看完整对话](${state.transcriptLink})`,
+      text_size:  'notation',
+      text_align: 'left',
+    });
+  }
+
   const card = {
     schema: '2.0',
     config: {

--- a/src/feishu/oauth.ts
+++ b/src/feishu/oauth.ts
@@ -1,0 +1,319 @@
+/**
+ * Feishu user OAuth helpers — drives the "查看完整对话" transcript page login.
+ *
+ * What this file gives the rest of MetaBot:
+ *   - buildAuthorizeUrl()  — assemble the passport.feishu.cn/oauth/authorize URL
+ *     with an HMAC-signed `state` (carries returnUrl + nonce + exp).
+ *   - exchangeCodeForUser() — exchange an authorization code for an
+ *     access_token, then fetch the user's open_id + name + avatar.
+ *   - signSession()/verifySession() — issue and verify a 7-day HS256
+ *     "session" JWT stored in the `mb_session` HttpOnly cookie.
+ *   - signState()/verifyState() — short-lived HS256 wrapper for the OAuth
+ *     state parameter so callbacks can't be forged.
+ *
+ * No external dependencies — we hand-roll a tiny JWT (header.payload.sig
+ * base64url) so we don't have to pull in `jsonwebtoken` for this one feature.
+ *
+ * Token endpoints (verified via Feishu open platform docs, May 2026):
+ *   POST https://open.feishu.cn/open-apis/auth/v3/app_access_token/internal
+ *     body: { app_id, app_secret }
+ *   POST https://open.feishu.cn/open-apis/authen/v1/oidc/access_token
+ *     header: Authorization: Bearer <app_access_token>
+ *     body: { grant_type: 'authorization_code', code }
+ *   GET  https://open.feishu.cn/open-apis/authen/v1/user_info
+ *     header: Authorization: Bearer <user_access_token>
+ */
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const STATE_TTL_MS    = 10 * 60 * 1000;        // 10 minutes
+const SESSION_TTL_SEC = 7 * 24 * 60 * 60;      // 7 days
+const TOKEN_CACHE_TTL_BUFFER_SEC = 60;         // refresh 60 s before stated expiry
+
+/** Bot context shape the OAuth helpers need — keeps this module decoupled
+ *  from the heavier `BotConfig` type so tests can construct fakes easily. */
+export interface OAuthBotContext {
+  appId:     string;
+  appSecret: string;
+}
+
+/** Result of a successful OAuth dance. */
+export interface FeishuUserProfile {
+  openId:           string;
+  name:             string;
+  avatarUrl?:       string;
+  userAccessToken:  string;
+}
+
+/** Payload carried inside the state parameter. */
+interface OAuthStatePayload {
+  returnUrl: string;
+  /** Bot the user is authenticating against — drives which transcript bot
+   *  the callback should use to call open-apis. */
+  botName:   string;
+  nonce:     string;
+  exp:       number;   // ms epoch
+}
+
+/** Payload carried inside the `mb_session` cookie JWT. */
+export interface SessionPayload {
+  open_id: string;
+  name:    string;
+  iat:     number; // sec epoch
+  exp:     number; // sec epoch
+}
+
+// ── base64url helpers ────────────────────────────────────────────────────
+
+function b64urlEncode(buf: Buffer | string): string {
+  const b = typeof buf === 'string' ? Buffer.from(buf, 'utf-8') : buf;
+  return b
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function b64urlDecode(s: string): Buffer {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  return Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64');
+}
+
+// ── secret bootstrap ─────────────────────────────────────────────────────
+
+/**
+ * Load (or lazily mint and persist) the secret used for both the cookie JWT
+ * and the OAuth state HMAC. Persistence target: `.env.local` in the project
+ * root — this is `dotenv`-friendly, so subsequent restarts pick it up
+ * automatically. Existing secrets in `process.env.METABOT_SESSION_SECRET`
+ * always win (so ops can override via a secret store).
+ */
+export function loadOrCreateSessionSecret(envFilePath?: string): string {
+  const existing = process.env.METABOT_SESSION_SECRET;
+  if (existing && existing.length >= 16) return existing;
+
+  const generated = crypto.randomBytes(32).toString('hex');
+  process.env.METABOT_SESSION_SECRET = generated;
+
+  // Best-effort persistence — if we can't write, the secret is process-
+  // local. That's acceptable: a restart just means users re-log via OAuth.
+  const target = envFilePath || path.join(process.cwd(), '.env.local');
+  try {
+    let body = '';
+    if (fs.existsSync(target)) {
+      body = fs.readFileSync(target, 'utf-8');
+      // Strip any prior METABOT_SESSION_SECRET line so we don't accumulate.
+      body = body
+        .split('\n')
+        .filter((l) => !l.startsWith('METABOT_SESSION_SECRET='))
+        .join('\n');
+      if (body && !body.endsWith('\n')) body += '\n';
+    }
+    body += `METABOT_SESSION_SECRET=${generated}\n`;
+    fs.writeFileSync(target, body, { mode: 0o600 });
+  } catch {
+    // Swallow — process.env override is good enough for one process lifetime.
+  }
+  return generated;
+}
+
+// ── state token (returnUrl wrapper used during OAuth callback) ───────────
+
+export function signState(payload: Omit<OAuthStatePayload, 'nonce' | 'exp'>, secret?: string): string {
+  const s = secret ?? loadOrCreateSessionSecret();
+  const full: OAuthStatePayload = {
+    ...payload,
+    nonce: crypto.randomBytes(12).toString('hex'),
+    exp:   Date.now() + STATE_TTL_MS,
+  };
+  const body = b64urlEncode(JSON.stringify(full));
+  const sig  = b64urlEncode(crypto.createHmac('sha256', s).update(body).digest());
+  return `${body}.${sig}`;
+}
+
+export function verifyState(state: string, secret?: string): OAuthStatePayload | null {
+  const s = secret ?? loadOrCreateSessionSecret();
+  const parts = state.split('.');
+  if (parts.length !== 2) return null;
+  const [body, sig] = parts;
+  const expected = b64urlEncode(crypto.createHmac('sha256', s).update(body).digest());
+  if (!timingSafeEqualStr(sig, expected)) return null;
+  let payload: OAuthStatePayload;
+  try {
+    payload = JSON.parse(b64urlDecode(body).toString('utf-8')) as OAuthStatePayload;
+  } catch {
+    return null;
+  }
+  if (typeof payload.exp !== 'number' || payload.exp < Date.now()) return null;
+  if (typeof payload.returnUrl !== 'string' || typeof payload.botName !== 'string') return null;
+  return payload;
+}
+
+// ── session JWT (mb_session cookie) ──────────────────────────────────────
+
+export function signSession(payload: Pick<SessionPayload, 'open_id' | 'name'>, secret?: string): string {
+  const s = secret ?? loadOrCreateSessionSecret();
+  const now = Math.floor(Date.now() / 1000);
+  const header  = b64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const full: SessionPayload = {
+    open_id: payload.open_id,
+    name:    payload.name,
+    iat:     now,
+    exp:     now + SESSION_TTL_SEC,
+  };
+  const body = b64urlEncode(JSON.stringify(full));
+  const sig  = b64urlEncode(crypto.createHmac('sha256', s).update(`${header}.${body}`).digest());
+  return `${header}.${body}.${sig}`;
+}
+
+export function verifySession(token: string, secret?: string): SessionPayload | null {
+  const s = secret ?? loadOrCreateSessionSecret();
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [header, body, sig] = parts;
+  const expected = b64urlEncode(crypto.createHmac('sha256', s).update(`${header}.${body}`).digest());
+  if (!timingSafeEqualStr(sig, expected)) return null;
+  let payload: SessionPayload;
+  try {
+    payload = JSON.parse(b64urlDecode(body).toString('utf-8')) as SessionPayload;
+  } catch {
+    return null;
+  }
+  if (typeof payload.exp !== 'number') return null;
+  if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+  if (typeof payload.open_id !== 'string' || !payload.open_id) return null;
+  return payload;
+}
+
+// ── app access token cache (per appId) ───────────────────────────────────
+
+interface AppTokenEntry {
+  token:    string;
+  expireAt: number; // ms epoch
+}
+const appTokenCache: Map<string, AppTokenEntry> = new Map();
+
+export async function getAppAccessToken(ctx: OAuthBotContext): Promise<string> {
+  const cached = appTokenCache.get(ctx.appId);
+  if (cached && cached.expireAt > Date.now()) return cached.token;
+
+  const resp = await fetch('https://open.feishu.cn/open-apis/auth/v3/app_access_token/internal', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body:    JSON.stringify({ app_id: ctx.appId, app_secret: ctx.appSecret }),
+  });
+  const json = (await resp.json()) as { code?: number; msg?: string; app_access_token?: string; expire?: number };
+  if (!resp.ok || json.code !== 0 || !json.app_access_token) {
+    throw new Error(`Feishu app_access_token failed: code=${json.code} msg=${json.msg}`);
+  }
+  const ttl = Math.max(60, (json.expire ?? 7200) - TOKEN_CACHE_TTL_BUFFER_SEC);
+  appTokenCache.set(ctx.appId, {
+    token:    json.app_access_token,
+    expireAt: Date.now() + ttl * 1000,
+  });
+  return json.app_access_token;
+}
+
+// ── public API: build authorize URL ──────────────────────────────────────
+
+/**
+ * Build the passport.feishu.cn authorize URL. The `state` is HMAC-signed
+ * so the callback can recover `returnUrl` + `botName` without trusting the
+ * client.
+ */
+export function buildAuthorizeUrl(
+  ctx: OAuthBotContext & { botName: string },
+  redirectUri: string,
+  returnUrl: string,
+  secret?: string,
+): string {
+  const state = signState({ returnUrl, botName: ctx.botName }, secret);
+  const params = new URLSearchParams({
+    app_id:       ctx.appId,
+    redirect_uri: redirectUri,
+    state,
+  });
+  // Note: scopes are inherited from the app config in the Feishu open
+  // platform; the OAuth endpoint doesn't accept arbitrary scope strings for
+  // OIDC user_info (we only need `contact:user.base:readonly` which is
+  // enabled by default for self-built apps).
+  return `https://passport.feishu.cn/suite/passport/oauth/authorize?${params.toString()}`;
+}
+
+// ── public API: exchange code → user profile ─────────────────────────────
+
+/**
+ * Exchange an OAuth authorization code for the user's open_id + display name.
+ * Step 1: app_access_token (cached).
+ * Step 2: POST /authen/v1/oidc/access_token  →  user_access_token, open_id
+ * Step 3: GET  /authen/v1/user_info          →  name, avatar
+ */
+export async function exchangeCodeForUser(ctx: OAuthBotContext, code: string): Promise<FeishuUserProfile> {
+  const appToken = await getAppAccessToken(ctx);
+
+  const tokenResp = await fetch('https://open.feishu.cn/open-apis/authen/v1/oidc/access_token', {
+    method:  'POST',
+    headers: {
+      'Content-Type':  'application/json; charset=utf-8',
+      'Authorization': `Bearer ${appToken}`,
+    },
+    body: JSON.stringify({ grant_type: 'authorization_code', code }),
+  });
+  const tokenJson = (await tokenResp.json()) as {
+    code?: number; msg?: string;
+    data?: { access_token?: string; open_id?: string; expires_in?: number };
+  };
+  if (!tokenResp.ok || tokenJson.code !== 0 || !tokenJson.data?.access_token) {
+    throw new Error(`Feishu OIDC access_token failed: code=${tokenJson.code} msg=${tokenJson.msg}`);
+  }
+  const userAccessToken = tokenJson.data.access_token;
+  const openIdFromToken = tokenJson.data.open_id;
+
+  const infoResp = await fetch('https://open.feishu.cn/open-apis/authen/v1/user_info', {
+    method:  'GET',
+    headers: { 'Authorization': `Bearer ${userAccessToken}` },
+  });
+  const infoJson = (await infoResp.json()) as {
+    code?: number; msg?: string;
+    data?: { open_id?: string; name?: string; avatar_url?: string };
+  };
+  if (!infoResp.ok || infoJson.code !== 0 || !infoJson.data) {
+    throw new Error(`Feishu user_info failed: code=${infoJson.code} msg=${infoJson.msg}`);
+  }
+  const openId = infoJson.data.open_id || openIdFromToken;
+  if (!openId) throw new Error('Feishu user_info returned no open_id');
+
+  return {
+    openId,
+    name:            infoJson.data.name || '',
+    ...(infoJson.data.avatar_url ? { avatarUrl: infoJson.data.avatar_url } : {}),
+    userAccessToken,
+  };
+}
+
+// ── cookie parsing helper ────────────────────────────────────────────────
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx <= 0) continue;
+    const k = part.slice(0, idx).trim();
+    const v = part.slice(idx + 1).trim();
+    if (k) out[k] = decodeURIComponent(v);
+  }
+  return out;
+}
+
+// ── timing-safe string compare ───────────────────────────────────────────
+
+function timingSafeEqualStr(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -40,6 +40,25 @@ export interface SessionLink {
 
 const MAX_MESSAGES_PER_SESSION = 200;
 
+/** Same encoder Claude Code SDK uses to derive ~/.claude/projects/<dir>. */
+export function encodeWorkdir(workdir: string): string {
+  const sanitized = workdir.replace(/[^a-zA-Z0-9]/g, '-');
+  // SDK truncates + appends a hash beyond 200 chars; we don't replicate the
+  // hash (we'd need the SDK's N16). Workdirs >200 chars are exotic — callers
+  // will just see an empty message list, which is acceptable.
+  return sanitized.length <= 200 ? sanitized : sanitized.slice(0, 200);
+}
+
+/** Project transcript dir for a given workdir. */
+export function projectTranscriptDir(workdir: string): string {
+  return path.join(os.homedir(), '.claude', 'projects', encodeWorkdir(workdir));
+}
+
+/** Resolve the JSONL transcript file path for a session, if known. */
+export function sessionJsonlPath(workdir: string, claudeSessionId: string): string {
+  return path.join(projectTranscriptDir(workdir), `${claudeSessionId}.jsonl`);
+}
+
 export class SessionRegistry {
   private db: Database.Database;
 

--- a/src/session/transcript-reader.ts
+++ b/src/session/transcript-reader.ts
@@ -1,0 +1,261 @@
+/**
+ * Transcript reader — parses a Claude Code Agent SDK jsonl transcript into a
+ * structured per-turn message list suitable for rendering in the web UI.
+ *
+ * Why this is separate from SessionRegistry.getMessages():
+ *   - getMessages strips everything except text blocks (tool_use, tool_result
+ *     and thinking are dropped) so the IM "recent history" view stays small.
+ *   - For the transcript page we MUST preserve tool calls + their results +
+ *     thinking blocks, otherwise the page is barely more useful than the
+ *     final card itself.
+ *
+ * Turn definition:
+ *   - "Turn N" is the N-th `type:'user'` jsonl entry (1-based) together with
+ *     every assistant entry that follows, up to but not including the (N+1)th
+ *     user entry.
+ *   - `turn === 'all'` returns everything.
+ *   - tool_result blocks live inside the *next* user entry's `content[]` —
+ *     we pair them back into their originating assistant message by
+ *     `tool_use_id`. Once paired, the carrier user entry that contained ONLY
+ *     tool_results (no text) is hidden from the output so the page reads as
+ *     "user → assistant (with tool calls) → user → assistant".
+ */
+import * as fs from 'node:fs';
+
+export type TranscriptToolCall = {
+  id:       string;
+  name:     string;
+  input:    unknown;
+  result?:  { content: unknown; isError?: boolean };
+  status:   'done';
+};
+
+export type TranscriptMessage = {
+  id:           string;            // jsonl line index, stringified for stability
+  role:         'user' | 'assistant';
+  text?:        string;            // markdown
+  toolCalls?:   TranscriptToolCall[];
+  thinking?:    string;
+  timestamp:    string;            // ISO-8601 if available, else ''
+};
+
+export interface ReadTranscriptResult {
+  totalTurns: number;
+  messages:   TranscriptMessage[];
+}
+
+interface RawJsonlEntry {
+  type?:      string;
+  message?:   {
+    role?:    string;
+    content?: unknown;
+  };
+  timestamp?: string | number;
+  uuid?:      string;
+}
+
+interface ContentBlock {
+  type?:        string;
+  text?:        string;
+  thinking?:    string;
+  // tool_use
+  id?:          string;
+  name?:        string;
+  input?:       unknown;
+  // tool_result
+  tool_use_id?: string;
+  content?:     unknown;
+  is_error?:    boolean;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object';
+}
+
+function toTimestamp(t: unknown): string {
+  if (typeof t === 'string') return t;
+  if (typeof t === 'number') return new Date(t).toISOString();
+  return '';
+}
+
+function blocksFromContent(content: unknown): ContentBlock[] {
+  if (Array.isArray(content)) return content as ContentBlock[];
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return [];
+}
+
+/**
+ * Read a jsonl transcript and project it onto a structured message list for
+ * the requested turn (or all turns).
+ *
+ * Robustness: invalid jsonl lines are skipped silently; missing file returns
+ * an empty result rather than throwing — the caller (HTTP route) will treat
+ * either as "transcript not available yet".
+ */
+export function readTranscript(
+  sessionJsonlPath: string,
+  turn: number | 'all',
+): ReadTranscriptResult {
+  if (!fs.existsSync(sessionJsonlPath)) {
+    return { totalTurns: 0, messages: [] };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(sessionJsonlPath, 'utf-8');
+  } catch {
+    return { totalTurns: 0, messages: [] };
+  }
+
+  // Phase 1 — parse every line, identify user-turn boundaries.
+  const lines: Array<RawJsonlEntry & { _idx: number }> = [];
+  let userTurnCount = 0;
+  // Track which "real" user lines (i.e. with at least one text/string-content
+  // block, NOT a pure tool_result carrier) bumped the turn count.
+  const userTurnIndexByLine: number[] = [];
+
+  raw.split('\n').forEach((line, idx) => {
+    if (!line) return;
+    let evt: RawJsonlEntry;
+    try {
+      evt = JSON.parse(line) as RawJsonlEntry;
+    } catch {
+      return;
+    }
+    if (!evt.type) return;
+    lines.push({ ...evt, _idx: idx });
+
+    if (evt.type === 'user' && isObject(evt.message) && evt.message.role === 'user') {
+      const blocks = blocksFromContent(evt.message.content);
+      const hasUserText =
+        blocks.some(
+          (b) =>
+            (b.type === 'text' && typeof b.text === 'string' && b.text.trim().length > 0) ||
+            (b.type === undefined && typeof (b as unknown as { text?: string }).text === 'string') ||
+            (typeof evt.message?.content === 'string'),
+        );
+      const hasOnlyToolResults =
+        blocks.length > 0 && blocks.every((b) => b.type === 'tool_result');
+      if (hasUserText && !hasOnlyToolResults) {
+        userTurnCount += 1;
+        userTurnIndexByLine[lines.length - 1] = userTurnCount;
+      }
+    }
+  });
+
+  if (userTurnCount === 0) {
+    return { totalTurns: 0, messages: [] };
+  }
+
+  // Determine [startIdx, endIdx) in `lines` for the requested turn.
+  let startIdx = 0;
+  let endIdx   = lines.length;
+  if (turn !== 'all') {
+    const turnN = Math.max(1, Math.min(userTurnCount, Math.floor(turn)));
+    let startBoundary = -1;
+    let endBoundary   = lines.length;
+    for (let i = 0; i < lines.length; i++) {
+      const idxTurn = userTurnIndexByLine[i];
+      if (idxTurn === turnN) {
+        if (startBoundary === -1) startBoundary = i;
+      } else if (idxTurn === turnN + 1) {
+        endBoundary = i;
+        break;
+      }
+    }
+    if (startBoundary === -1) {
+      return { totalTurns: userTurnCount, messages: [] };
+    }
+    startIdx = startBoundary;
+    endIdx   = endBoundary;
+  }
+
+  // Phase 2 — build a flat map of tool_use_id → result so the result blocks
+  // (which live in the *next* user entry) get folded back into the assistant
+  // message that issued the call. Scan the WHOLE file (not just the turn
+  // window) — a tool call near the end of one turn might have its result in
+  // the very next user line whose `_idx` lies past `endIdx`.
+  const toolResultById = new Map<string, { content: unknown; isError?: boolean }>();
+  for (const entry of lines) {
+    if (entry.type === 'user' && isObject(entry.message) && entry.message.role === 'user') {
+      for (const b of blocksFromContent(entry.message.content)) {
+        if (b.type === 'tool_result' && typeof b.tool_use_id === 'string') {
+          toolResultById.set(b.tool_use_id, {
+            content: b.content ?? '',
+            ...(b.is_error ? { isError: true } : {}),
+          });
+        }
+      }
+    }
+  }
+
+  // Phase 3 — render the turn window. Skip user entries that are pure
+  // tool_result carriers (their data is inlined into the prior assistant).
+  const messages: TranscriptMessage[] = [];
+  for (let i = startIdx; i < endIdx; i++) {
+    const evt = lines[i];
+    if (!evt.type) continue;
+    const ts = toTimestamp(evt.timestamp);
+
+    if (evt.type === 'user' && isObject(evt.message) && evt.message.role === 'user') {
+      const blocks = blocksFromContent(evt.message.content);
+      const onlyToolResults =
+        blocks.length > 0 && blocks.every((b) => b.type === 'tool_result');
+      if (onlyToolResults) continue;
+
+      let text: string;
+      if (typeof evt.message.content === 'string') {
+        text = evt.message.content;
+      } else {
+        text = blocks
+          .filter((b) => b.type === 'text' || b.type === undefined)
+          .map((b) => (typeof b.text === 'string' ? b.text : ''))
+          .join('\n')
+          .trim();
+      }
+      if (text || blocks.length === 0) {
+        messages.push({
+          id:        evt.uuid || String(evt._idx),
+          role:      'user',
+          text,
+          timestamp: ts,
+        });
+      }
+    } else if (evt.type === 'assistant' && isObject(evt.message) && evt.message.role === 'assistant') {
+      const blocks = blocksFromContent(evt.message.content);
+      let text     = '';
+      let thinking = '';
+      const toolCalls: TranscriptToolCall[] = [];
+
+      for (const b of blocks) {
+        if (b.type === 'text' && typeof b.text === 'string') {
+          text += (text ? '\n' : '') + b.text;
+        } else if (b.type === 'thinking' && typeof b.thinking === 'string') {
+          thinking += (thinking ? '\n' : '') + b.thinking;
+        } else if (b.type === 'tool_use' && typeof b.id === 'string' && typeof b.name === 'string') {
+          const result = toolResultById.get(b.id);
+          toolCalls.push({
+            id:     b.id,
+            name:   b.name,
+            input:  b.input ?? {},
+            status: 'done',
+            ...(result ? { result } : {}),
+          });
+        }
+      }
+
+      const isEmpty = !text && !thinking && toolCalls.length === 0;
+      if (isEmpty) continue;
+      messages.push({
+        id:         evt.uuid || String(evt._idx),
+        role:       'assistant',
+        ...(text     ? { text }     : {}),
+        ...(thinking ? { thinking } : {}),
+        ...(toolCalls.length ? { toolCalls } : {}),
+        timestamp:  ts,
+      });
+    }
+  }
+
+  return { totalTurns: userTurnCount, messages };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,14 @@ export interface CardState {
   goalCondition?: string;
   /** Snapshot of the active Agent Team (teammates + tasks), if any. */
   teamState?: TeamState;
+  /**
+   * Pre-built URL to the conversation transcript detail page (e.g.
+   * `https://bot.example.com/web/transcript/<chatId>?turn=3`). When present,
+   * the card renderer appends a `📜 [查看完整对话](...)` line below the
+   * stats footer; when absent the line is omitted (used as graceful
+   * degradation when `publicBaseUrl` is not configured).
+   */
+  transcriptLink?: string;
 }
 
 export interface IncomingMessage {

--- a/tests/card-builder-v2.test.ts
+++ b/tests/card-builder-v2.test.ts
@@ -317,6 +317,43 @@ describe('buildCardV2', () => {
     expect(table.rows[0].col0).toContain('下装32%');
     expect(table.rows[1].col2).toContain('[详情](https://example.com)');
   });
+
+  // Transcript link — surfaced only when `transcriptLink` is set on the
+  // CardState. Graceful degradation: cards omit the link when no public
+  // base URL is configured, so existing single-bot deployments don't see
+  // a half-built URL.
+  it('renders the transcript link line when transcriptLink is set', () => {
+    const state: CardState = {
+      status:         'complete',
+      userPrompt:     'task',
+      responseText:   'done',
+      toolCalls:      [],
+      transcriptLink: 'https://bot.example.com/web/transcript/oc_x?turn=3',
+    };
+    const elements = findElements(JSON.parse(buildCardV2(state)));
+    const link = elements.find(
+      (e) => e.tag === 'markdown' && typeof e.content === 'string'
+        && e.content.includes('查看完整对话'),
+    );
+    expect(link).toBeDefined();
+    expect(link.content).toContain('https://bot.example.com/web/transcript/oc_x?turn=3');
+    expect(link.content).toContain('📜');
+  });
+
+  it('omits the transcript link line when transcriptLink is unset (graceful degradation)', () => {
+    const state: CardState = {
+      status:       'complete',
+      userPrompt:   'task',
+      responseText: 'done',
+      toolCalls:    [],
+    };
+    const elements = findElements(JSON.parse(buildCardV2(state)));
+    const link = elements.find(
+      (e) => e.tag === 'markdown' && typeof e.content === 'string'
+        && /查看完整对话/.test(e.content),
+    );
+    expect(link).toBeUndefined();
+  });
 });
 
 describe('buildHelpCardV2', () => {

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  signSession,
+  verifySession,
+  signState,
+  verifyState,
+  parseCookies,
+  loadOrCreateSessionSecret,
+} from '../src/feishu/oauth.js';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as crypto from 'node:crypto';
+
+const TEST_SECRET = 'test-secret-key-of-acceptable-length-12345';
+
+describe('signSession / verifySession', () => {
+  it('round-trips and recovers the payload', () => {
+    const token = signSession({ open_id: 'ou_xxx', name: 'Aragorn' }, TEST_SECRET);
+    const decoded = verifySession(token, TEST_SECRET);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.open_id).toBe('ou_xxx');
+    expect(decoded?.name).toBe('Aragorn');
+    expect(decoded?.exp).toBeGreaterThan(decoded!.iat);
+  });
+
+  it('rejects a tampered signature', () => {
+    const token = signSession({ open_id: 'ou_xxx', name: 'A' }, TEST_SECRET);
+    const parts = token.split('.');
+    parts[2] = 'tamperedsig';
+    expect(verifySession(parts.join('.'), TEST_SECRET)).toBeNull();
+  });
+
+  it('rejects a tampered payload', () => {
+    const token = signSession({ open_id: 'ou_legit', name: 'A' }, TEST_SECRET);
+    const parts = token.split('.');
+    // Re-encode a different open_id while keeping the original signature.
+    const bad = Buffer.from(JSON.stringify({ open_id: 'ou_evil', name: 'A', iat: 1, exp: 9999999999 }))
+      .toString('base64')
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    parts[1] = bad;
+    expect(verifySession(parts.join('.'), TEST_SECRET)).toBeNull();
+  });
+
+  it('rejects an expired token', () => {
+    // Manually craft an expired token with the correct signature so we can
+    // assert the exp check fires.
+    const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64')
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const body = Buffer.from(JSON.stringify({ open_id: 'ou_a', name: 'a', iat: 0, exp: 1 })).toString('base64')
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const sig = crypto.createHmac('sha256', TEST_SECRET).update(`${header}.${body}`).digest('base64')
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(verifySession(`${header}.${body}.${sig}`, TEST_SECRET)).toBeNull();
+  });
+
+  it('rejects malformed input', () => {
+    expect(verifySession('not-a-jwt', TEST_SECRET)).toBeNull();
+    expect(verifySession('a.b', TEST_SECRET)).toBeNull();
+  });
+});
+
+describe('signState / verifyState', () => {
+  it('round-trips returnUrl + botName', () => {
+    const s = signState({ returnUrl: '/web/transcript/abc?turn=2', botName: 'metabot' }, TEST_SECRET);
+    const decoded = verifyState(s, TEST_SECRET);
+    expect(decoded?.returnUrl).toBe('/web/transcript/abc?turn=2');
+    expect(decoded?.botName).toBe('metabot');
+    expect(decoded?.nonce.length).toBeGreaterThan(0);
+  });
+
+  it('rejects tampered state', () => {
+    const s = signState({ returnUrl: '/safe', botName: 'x' }, TEST_SECRET);
+    expect(verifyState(s + 'x', TEST_SECRET)).toBeNull();
+  });
+});
+
+describe('parseCookies', () => {
+  it('parses standard cookie header', () => {
+    const r = parseCookies('mb_session=abc.def.ghi; other=1');
+    expect(r.mb_session).toBe('abc.def.ghi');
+    expect(r.other).toBe('1');
+  });
+
+  it('returns empty when header is undefined', () => {
+    expect(parseCookies(undefined)).toEqual({});
+  });
+
+  it('handles URL-encoded values', () => {
+    const r = parseCookies('mb_session=' + encodeURIComponent('a/b+c='));
+    expect(r.mb_session).toBe('a/b+c=');
+  });
+});
+
+describe('loadOrCreateSessionSecret', () => {
+  beforeAll(() => {
+    delete process.env.METABOT_SESSION_SECRET;
+  });
+
+  it('mints, persists, and re-reads the secret from .env.local', () => {
+    const tmpFile = path.join(os.tmpdir(), `mb-test-env-${Date.now()}`);
+    try {
+      const secret = loadOrCreateSessionSecret(tmpFile);
+      expect(secret.length).toBeGreaterThanOrEqual(32);
+      const body = fs.readFileSync(tmpFile, 'utf-8');
+      expect(body).toContain('METABOT_SESSION_SECRET=');
+      // Second call should be a noop (process.env now wins).
+      const secret2 = loadOrCreateSessionSecret(tmpFile);
+      expect(secret2).toBe(secret);
+    } finally {
+      try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+    }
+  });
+});

--- a/tests/transcript-reader.test.ts
+++ b/tests/transcript-reader.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { readTranscript } from '../src/session/transcript-reader.js';
+
+/**
+ * Build a deterministic 3-turn jsonl fixture with:
+ *   - turn 1: plain user → assistant text
+ *   - turn 2: user → assistant (thinking + tool_use Read) → tool_result → assistant text
+ *   - turn 3: user → assistant tool_use Bash → tool_result with isError
+ * The carrier "user" entries that hold tool_results MUST NOT count as turn
+ * boundaries — that's the most important invariant of the reader.
+ */
+function buildFixture(): string {
+  const lines: object[] = [];
+
+  // Turn 1
+  lines.push({
+    type: 'user',
+    message: { role: 'user', content: 'hello' },
+    uuid: 'u1',
+    timestamp: '2026-05-21T10:00:00.000Z',
+  });
+  lines.push({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hi there' }],
+    },
+    uuid: 'a1',
+    timestamp: '2026-05-21T10:00:01.000Z',
+  });
+
+  // Turn 2: user → assistant with thinking + tool_use → tool_result → assistant text
+  lines.push({
+    type: 'user',
+    message: { role: 'user', content: 'read pkg.json' },
+    uuid: 'u2',
+    timestamp: '2026-05-21T10:01:00.000Z',
+  });
+  lines.push({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'planning' },
+        {
+          type: 'tool_use',
+          id:   'tool-123',
+          name: 'Read',
+          input: { file_path: '/etc/hosts' },
+        },
+      ],
+    },
+    uuid: 'a2',
+    timestamp: '2026-05-21T10:01:01.000Z',
+  });
+  // Pure tool_result carrier — must NOT bump the turn counter.
+  lines.push({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'tool-123', content: '127.0.0.1 localhost' }],
+    },
+    uuid: 'tr2',
+    timestamp: '2026-05-21T10:01:02.000Z',
+  });
+  lines.push({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'localhost is mapped to 127.0.0.1' }],
+    },
+    uuid: 'a2b',
+    timestamp: '2026-05-21T10:01:03.000Z',
+  });
+
+  // Turn 3: tool_use with isError
+  lines.push({
+    type: 'user',
+    message: { role: 'user', content: 'run ls' },
+    uuid: 'u3',
+    timestamp: '2026-05-21T10:02:00.000Z',
+  });
+  lines.push({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [
+        { type: 'tool_use', id: 'tool-456', name: 'Bash', input: { command: 'ls /nope' } },
+      ],
+    },
+    uuid: 'a3',
+    timestamp: '2026-05-21T10:02:01.000Z',
+  });
+  lines.push({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'tool-456', content: 'no such file', is_error: true },
+      ],
+    },
+    uuid: 'tr3',
+    timestamp: '2026-05-21T10:02:02.000Z',
+  });
+
+  return lines.map((l) => JSON.stringify(l)).join('\n');
+}
+
+describe('readTranscript', () => {
+  const tmp = path.join(os.tmpdir(), `mb-transcript-${Date.now()}.jsonl`);
+  beforeAll(() => fs.writeFileSync(tmp, buildFixture()));
+  afterAll(() => { try { fs.unlinkSync(tmp); } catch { /* ignore */ } });
+
+  it('returns empty when the file does not exist', () => {
+    const r = readTranscript('/nonexistent.jsonl', 'all');
+    expect(r.totalTurns).toBe(0);
+    expect(r.messages).toEqual([]);
+  });
+
+  it('counts 3 user turns (carrier tool_result users do NOT count)', () => {
+    const r = readTranscript(tmp, 'all');
+    expect(r.totalTurns).toBe(3);
+  });
+
+  it('turn=1 yields only the first user + its assistant reply', () => {
+    const r = readTranscript(tmp, 1);
+    expect(r.totalTurns).toBe(3);
+    expect(r.messages.length).toBe(2);
+    expect(r.messages[0]).toMatchObject({ role: 'user',      text: 'hello' });
+    expect(r.messages[1]).toMatchObject({ role: 'assistant', text: 'hi there' });
+  });
+
+  it('turn=2 inlines tool_result back into the assistant message that issued the call', () => {
+    const r = readTranscript(tmp, 2);
+    // user + assistant(thinking+toolcall) + assistant(text). Carrier user is hidden.
+    expect(r.messages.length).toBe(3);
+    expect(r.messages[0]).toMatchObject({ role: 'user', text: 'read pkg.json' });
+    const withTool = r.messages[1];
+    expect(withTool.role).toBe('assistant');
+    expect(withTool.thinking).toContain('planning');
+    expect(withTool.toolCalls).toBeDefined();
+    expect(withTool.toolCalls?.length).toBe(1);
+    const tc = withTool.toolCalls![0];
+    expect(tc).toMatchObject({ id: 'tool-123', name: 'Read', status: 'done' });
+    expect(tc.result).toBeDefined();
+    expect(tc.result?.content).toContain('127.0.0.1');
+    expect(r.messages[2]).toMatchObject({ role: 'assistant', text: 'localhost is mapped to 127.0.0.1' });
+  });
+
+  it('turn=3 preserves isError on the tool result', () => {
+    const r = readTranscript(tmp, 3);
+    expect(r.messages.length).toBe(2);
+    const a = r.messages[1];
+    expect(a.role).toBe('assistant');
+    expect(a.toolCalls).toBeDefined();
+    expect(a.toolCalls?.[0].name).toBe('Bash');
+    expect(a.toolCalls?.[0].result?.isError).toBe(true);
+  });
+
+  it('turn=all returns every visible message', () => {
+    const r = readTranscript(tmp, 'all');
+    expect(r.totalTurns).toBe(3);
+    // 3 user + 4 assistant (2 in turn 2, 1 each in turns 1 and 3) = 7 visible.
+    expect(r.messages.length).toBe(7);
+  });
+
+  it('clamps an out-of-range turn to the last turn', () => {
+    const r = readTranscript(tmp, 99);
+    expect(r.totalTurns).toBe(3);
+    // Falls into turn 3.
+    expect(r.messages[0].text).toBe('run ls');
+  });
+});


### PR DESCRIPTION
## Summary

Add an opt-in public conversation-history detail page accessible from Feishu cards via a `📜 查看完整对话` markdown link. Page renders the complete turn history (assistant text + tool calls + tool results) from the Claude jsonl transcript, gated by Feishu OAuth + per-bot `open_id` whitelist.

**This is the backend half.** The matching frontend PR (`feat/transcript-page-frontend`) ships the React `TranscriptView` component and route registration in `web/`. Either PR can merge in any order — backend cards still render (just with a dead link until the frontend ships); the frontend page shows a friendly error against an old backend.

### What's in this PR

- **Three new HTTP routes** (`src/api/routes/transcript-routes.ts`):
  - `GET /api/auth/feishu/login?return=<url>` — kicks off Feishu OAuth (passport.feishu.cn).
  - `GET /api/auth/feishu/callback?code=...&state=...` — verifies HMAC-signed state, exchanges code for `open_id`, signs an HttpOnly `mb_session` JWT cookie (7d), 302 to `return`.
  - `GET /api/transcript/:chatId?turn=<n|all>` — cookie + whitelist gated; returns parsed transcript JSON.
- **OAuth helper** (`src/feishu/oauth.ts`) — HMAC-signed state, OIDC token exchange, hand-rolled HS256 JWT (no `jsonwebtoken` dep). `METABOT_SESSION_SECRET` auto-generated to `.env.local` on first start.
- **jsonl parser** (`src/session/transcript-reader.ts`) — walks `~/.claude/projects/<workdir>/<sessionId>.jsonl`, groups messages by turn (= user message boundaries), splits `content[]` into text / tool_use / tool_result, matches `tool_use_id` ↔ next-user-message's `tool_result` block.
- **Path helpers** in `src/session/session-registry.ts` — `encodeWorkdir`, `projectTranscriptDir`, `sessionJsonlPath` (storage-agnostic, no SQLite touched).
- **Card markdown link** — `src/feishu/card-builder-v2.ts` emits `📜 [查看完整对话历史](<publicBaseUrl>/web/transcript/<chatId>?turn=<n>)` after the footer when the bot has `transcriptLink` set.
- **Per-chat turn counter** — `MessageBridge` increments a chatId → turnIndex map each turn, `StreamProcessor.setTranscriptLink` plumbs it into CardState.
- **Typed config** — `publicBaseUrl?: string` and `transcriptAllowOpenIds?: string[]` on each bot in `bots.json`. Without `publicBaseUrl`, the link is **not rendered** — fully backwards compatible.
- **Auth exemptions** in `src/api/http-server.ts` — `/api/auth/feishu/*` (browser hits, no Bearer header) and `/api/transcript/*` (cookie-authed) bypass the global Bearer check.

### Whitelist precedence

1. `bots.json` → per-bot `transcriptAllowOpenIds: string[]` (recommended).
2. Fallback: `.env` → `METABOT_TRANSCRIPT_ALLOW_OPEN_IDS` (comma-separated).
3. Empty/missing → 403 with a friendly page that **shows the logged-in user's `open_id`** so the admin can copy/paste it into the whitelist.

### Test plan

- [x] `npm run build` — green.
- [x] `npm test` — 323/323 passing (real `tests/` dir; the 10 failures in stale `_backup_dev/` are unrelated local-only files not on this branch).
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files).
- [ ] OAuth round-trip from Feishu mobile + desktop (requires public deployment — being trialled on the SA bot at port 18443 behind a Caddy reverse-proxy to `127.0.0.1:10016`).
- [ ] First-login whitelist bootstrap: confirm the 403 page surfaces `open_id` so admins can self-serve.
- [ ] Backwards compatibility: bot **without** `publicBaseUrl` → card renders exactly as before (no link), no warnings.

### Not in this PR

- Frontend `TranscriptView` React component — separate PR.
- Real-time refresh / WebSocket — page is historical, REST-only.
- Comment / annotation / search across turns — future iteration.