### PR TITLE
fix(claude): auto-approve ExitPlanMode via canUseTool

### DIFF
--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -7,6 +7,7 @@ import type { SDKUserMessage, SpawnOptions, SpawnedProcess } from '@anthropic-ai
 import type { BotConfigBase } from '../../config.js';
 import type { Logger } from '../../utils/logger.js';
 import { AsyncQueue } from '../../utils/async-queue.js';
+import { makeCanUseTool } from './exit-plan-mode.js';
 
 const isWindows = process.platform === 'win32';
 
@@ -514,6 +515,14 @@ export class ClaudeExecutor {
         return {};
       };
     };
+
+    // ExitPlanMode: the native tool's checkPermissions returns
+    // `{behavior: "ask", message: "Exit plan mode?"}` even under
+    // bypassPermissions, and that "ask" routes through the can_use_tool
+    // control_request — NOT through PreToolUse hooks. We auto-allow via
+    // canUseTool; the bridge still ships the plan body to the user as a
+    // separate card (StreamProcessor + sendPlanContent).
+    queryOptions.canUseTool = makeCanUseTool(this.logger);
 
     queryOptions.hooks = {
       PreToolUse: [{

--- a/src/engines/claude/exit-plan-mode.ts
+++ b/src/engines/claude/exit-plan-mode.ts
@@ -1,0 +1,30 @@
+import type { Logger } from '../../utils/logger.js';
+
+/**
+ * ExitPlanMode's native checkPermissions always returns `{behavior: "ask",
+ * message: "Exit plan mode?"}` outside sub-agent contexts — independent of
+ * `permissionMode: 'bypassPermissions'` and unreachable from PreToolUse hooks
+ * (the "ask" path goes via a can_use_tool control_request). Without a
+ * canUseTool handler the bridge gets back an is_error tool_result, the agent
+ * stays in plan mode, and the user sees a perpetual "Exit plan mode?" loop.
+ *
+ * We always allow — the bridge already ships the plan body to the user as a
+ * separate card via StreamProcessor + sendPlanContent, so they still see what
+ * was decided before implementation continues. Non-ExitPlanMode tool calls
+ * normally never reach this callback under bypassPermissions; we allow them
+ * too as a safety net so a stray "ask" can't deadlock the session.
+ */
+export function makeCanUseTool(logger: Logger) {
+  return async function canUseTool(
+    toolName: string,
+    input: Record<string, unknown>,
+    opts: { toolUseID: string },
+  ): Promise<{ behavior: 'allow'; updatedInput: Record<string, unknown> }> {
+    if (toolName === 'ExitPlanMode') {
+      logger.info({ toolUseId: opts.toolUseID }, 'canUseTool: auto-approving ExitPlanMode');
+    } else {
+      logger.warn({ toolName, toolUseId: opts.toolUseID }, 'canUseTool: unexpected ask under bypassPermissions — allowing');
+    }
+    return { behavior: 'allow', updatedInput: input };
+  };
+}

--- a/src/engines/claude/persistent-executor.ts
+++ b/src/engines/claude/persistent-executor.ts
@@ -36,6 +36,7 @@ import type { Logger } from '../../utils/logger.js';
 import { AsyncQueue } from '../../utils/async-queue.js';
 import type { SDKMessage, TeamEvent, ApiContext } from './executor.js';
 import { apply1MContextSettings } from './executor.js';
+import { makeCanUseTool } from './exit-plan-mode.js';
 
 const isWindows = process.platform === 'win32';
 
@@ -414,6 +415,14 @@ export class PersistentClaudeExecutor extends EventEmitter {
     // that questions can be answered by users via Feishu cards) + Agent
     // Teams observation hooks for the team panel.
     queryOptions.hooks = this.buildHooks();
+
+    // ExitPlanMode: the native tool's checkPermissions returns
+    // `{behavior: "ask", message: "Exit plan mode?"}` even under
+    // bypassPermissions, and that "ask" routes through the can_use_tool
+    // control_request — NOT through PreToolUse hooks. Auto-allow via
+    // canUseTool; the bridge still ships the plan body to the user as a
+    // separate card (StreamProcessor + sendPlanContent).
+    queryOptions.canUseTool = makeCanUseTool(this.options.logger);
 
     const stream = query({
       prompt: this.inputQueue,

--- a/tests/exit-plan-mode-auto-approve.test.ts
+++ b/tests/exit-plan-mode-auto-approve.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { makeCanUseTool } from '../src/engines/claude/exit-plan-mode.js';
+import { PersistentClaudeExecutor } from '../src/engines/claude/persistent-executor.js';
+
+/**
+ * Outside a sub-agent context, the native ExitPlanMode tool's
+ * checkPermissions returns `{behavior: "ask", message: "Exit plan mode?"}`
+ * even under `permissionMode: 'bypassPermissions'`. The SDK routes that
+ * "ask" through the can_use_tool control_request, NOT through PreToolUse
+ * hooks ("PreToolUse hook denies bypass canUseTool" — sdk.d.ts) — so a
+ * PreToolUse-based fix would log "auto-approving" but never actually
+ * unblock the gate; the bridge gets back an is_error tool_result and the
+ * agent stays in plan mode.
+ *
+ * The fix: wire `canUseTool` on the SDK query options, which IS the
+ * channel the "ask" lands on. The `allow` branch MUST include
+ * `updatedInput: Record<string, unknown>` — the SDK's Zod schema for
+ * PermissionResult rejects `{behavior: 'allow'}` without it
+ * (ZodError: invalid_type expected record, received undefined at updatedInput).
+ */
+
+const collected: { level: string; obj: unknown; msg?: string }[] = [];
+const mockLogger = {
+  debug: () => {},
+  info: (obj: unknown, msg?: string) => { collected.push({ level: 'info', obj, msg }); },
+  warn: (obj: unknown, msg?: string) => { collected.push({ level: 'warn', obj, msg }); },
+  error: () => {},
+} as any;
+
+describe('makeCanUseTool (ExitPlanMode auto-approve)', () => {
+  it('returns behavior=allow with updatedInput echoed back for ExitPlanMode', async () => {
+    collected.length = 0;
+    const canUseTool = makeCanUseTool(mockLogger);
+    const input = { plan: 'p' };
+    const result = await canUseTool('ExitPlanMode', input, { toolUseID: 'toolu_plan_1' });
+    // updatedInput MUST be present — the SDK's Zod schema rejects `allow` without it
+    expect(result).toEqual({ behavior: 'allow', updatedInput: input });
+    const info = collected.find((c) => c.level === 'info');
+    expect(info?.msg).toBe('canUseTool: auto-approving ExitPlanMode');
+    expect((info?.obj as any).toolUseId).toBe('toolu_plan_1');
+  });
+
+  it('allows non-ExitPlanMode tools too (safety net) with updatedInput', async () => {
+    collected.length = 0;
+    const canUseTool = makeCanUseTool(mockLogger);
+    const input = { command: 'ls' };
+    const result = await canUseTool('Bash', input, { toolUseID: 'toolu_bash_1' });
+    expect(result).toEqual({ behavior: 'allow', updatedInput: input });
+    const warn = collected.find((c) => c.level === 'warn');
+    expect(warn?.msg).toContain('unexpected ask under bypassPermissions');
+    expect((warn?.obj as any).toolName).toBe('Bash');
+  });
+
+  it('resolves synchronously (the SDK waits on this — must not block)', async () => {
+    const canUseTool = makeCanUseTool(mockLogger);
+    let resolved = false;
+    const p = canUseTool('ExitPlanMode', {}, { toolUseID: 'toolu_plan_2' }).then((r) => {
+      resolved = true;
+      return r;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+    await p;
+  });
+});
+
+describe('PersistentClaudeExecutor wires canUseTool / drops PreToolUse ExitPlanMode entry', () => {
+  function makeExec(): PersistentClaudeExecutor {
+    return new PersistentClaudeExecutor({
+      cwd: '/tmp',
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as any,
+      idleTimeoutMs: 0,
+    });
+  }
+
+  it('does NOT register a PreToolUse entry for ExitPlanMode (the old hook is dead)', () => {
+    const exec = makeExec();
+    const hooks = (exec as any).buildHooks();
+    const exitEntry = hooks.PreToolUse.find((e: any) => e.matcher === 'ExitPlanMode');
+    expect(exitEntry, 'PreToolUse ExitPlanMode hook must be removed — the gate is on canUseTool now').toBeUndefined();
+  });
+
+  it('keeps AskUserQuestion entry at PreToolUse[0] (no ordering regression)', () => {
+    const exec = makeExec();
+    const hooks = (exec as any).buildHooks();
+    expect(hooks.PreToolUse[0].matcher).toBe('AskUserQuestion');
+  });
+});


### PR DESCRIPTION
## Problem

When the Claude agent enters plan mode and tries to exit it (via the `ExitPlanMode` tool), the Feishu bridge gets stuck — the user sees a perpetual "Exit plan mode?" prompt with no way to answer it, and the only escape is `Ctrl+C` on the bridge process.

Root cause: `ExitPlanMode`'s native `checkPermissions` returns `{behavior: "ask", message: "Exit plan mode?"}` outside sub-agent contexts, **even under `permissionMode: 'bypassPermissions'`**. That "ask" is routed by the SDK through the `can_use_tool` control_request — *not* through `PreToolUse` hooks. Without a `canUseTool` handler, the bridge has nothing to reply with, the SDK gives back an `is_error` tool_result, and the plan-mode gate never lifts.

Extracted from the SDK binary:

```js
async checkPermissions(H, $) {
  if ($A()) return { behavior: "allow", updatedInput: H };
  return { behavior: "ask", message: "Exit plan mode?", updatedInput: H };
}
```

## Fix

Wire a `canUseTool` callback on the SDK query options for both `ClaudeExecutor` and `PersistentClaudeExecutor` that auto-allows `ExitPlanMode` (and any other unexpected "ask" as a safety net). The user still sees the plan body — the bridge already ships it as a separate card via `StreamProcessor` + `sendPlanContent` before this gate is hit.

## Two SDK gotchas worth keeping in mind

1. **`PreToolUse` hook `allow` does NOT bypass `canUseTool`'s `ask`.** They're two independent gates. `PreToolUse: deny` short-circuits `canUseTool`, but `allow` doesn't. So `{ matcher: 'ExitPlanMode', hooks: [hook that returns allow] }` would log "auto-approving" but never unblock anything.

2. **The `allow` branch of `canUseTool` MUST include `updatedInput: Record<string, unknown>`.** The SDK Zod-validates the response and rejects `{behavior: 'allow'}` alone with `ZodError: invalid_type expected record, received undefined at updatedInput`. Echo `input` back when there's no mutation to apply.

## Tests

`tests/exit-plan-mode-auto-approve.test.ts` asserts the full return shape (not just `behavior`) so a regression on (2) would fail the suite — an earlier iteration passed `toEqual({behavior:'allow'})` against the broken shape because `toEqual` is structural and missing keys are silently OK.

```
 ✓ tests/exit-plan-mode-auto-approve.test.ts (5 tests) 4ms
```

Also verified end-to-end on the internal bridge: EnterPlanMode → ExitPlanMode now succeeds silently, with no `Tool permission request failed: ZodError` and no perpetual "Exit plan mode?" loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)