### PR TITLE
fix(bridge): show full agent activity content in Feishu card

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -51,6 +51,21 @@ const IDLE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour idle → abort
  * avoid spamming the chat.
  */
 const SPONTANEOUS_COALESCE_MS = 30 * 1000;
+/**
+ * Per-snippet character cap. One runaway block (e.g. a giant code dump from
+ * an autonomous teammate) shouldn't eat the whole card budget by itself, but
+ * 400 was so tight it cut off ordinary multi-paragraph replies mid-sentence —
+ * which was the main "agent activity 显示不全" complaint. 4000 covers almost
+ * every real-world assistant text block while still bounding worst case.
+ */
+const SPONTANEOUS_SNIPPET_MAX_CHARS = 4000;
+/**
+ * Total body cap for the coalesced agent-activity card body. Sits well below
+ * card-builder-v2's 28000-char hard limit so we leave room for header rows
+ * and the team-state panel without triggering the middle-truncation safety
+ * net (which produces an ugly `... (content truncated) ...` marker).
+ */
+const SPONTANEOUS_BODY_MAX_CHARS = 12000;
 const FINAL_CARD_RETRIES = 3;
 const FINAL_CARD_BASE_DELAY_MS = 2000;
 const TASK_TIMEOUT_MESSAGE = 'Task timed out (24 hour limit)';
@@ -80,7 +95,13 @@ export function extractSpontaneousSnippet(msg: unknown): string | null {
   for (const blk of m.message.content) {
     if (blk.type === 'text' && blk.text) {
       const trimmed = String(blk.text).trim();
-      if (trimmed) return trimmed.slice(0, 400);
+      if (!trimmed) continue;
+      if (trimmed.length <= SPONTANEOUS_SNIPPET_MAX_CHARS) return trimmed;
+      // Soft cap with an ellipsis marker. The total-body cap in
+      // formatSpontaneousCardBody enforces the card-level budget — this
+      // per-snippet cap only guards against one runaway block eating the
+      // whole card.
+      return trimmed.slice(0, SPONTANEOUS_SNIPPET_MAX_CHARS) + '…';
     }
     // tool_use blocks intentionally fall through — see docstring above.
   }
@@ -89,11 +110,19 @@ export function extractSpontaneousSnippet(msg: unknown): string | null {
 
 /**
  * Build the markdown body of a spontaneous activity card from collected
- * snippets. Shows ONLY the latest snippet (the agent's conclusion of the
- * burst); if multiple snippets were coalesced, a small footer notes the
- * count so users know there was more activity if they want to dig into
- * logs. Mirrors the "show only the final result, hide the play-by-play"
- * pattern from PR #268's main-card tool indicator.
+ * snippets. Renders ALL snippets in chronological order, separated by a
+ * horizontal rule so the reader can tell discrete bursts apart.
+ *
+ * Earlier versions showed ONLY the latest snippet (the "agent's conclusion"
+ * — same UX bet as the main card's single-line tool indicator from PR #268),
+ * but that turned out to drop most of the useful content: teammate pings,
+ * /loop iterations, and cron tasks each emit their own snippet and the user
+ * needs to see all of them, not just the final one. The "经常显示不全" bug.
+ *
+ * Total length is capped at SPONTANEOUS_BODY_MAX_CHARS; if the burst would
+ * exceed that we keep the most recent snippets (latest are most relevant)
+ * and prepend a one-line "N earlier events omitted" notice. The card
+ * builder's own 28000-char safety net still applies as a last resort.
  *
  * No header line in the body — earlier versions prepended an italic
  * "Agent activity between turns (…)" caption, but users found it long
@@ -105,12 +134,30 @@ export function extractSpontaneousSnippet(msg: unknown): string | null {
  */
 export function formatSpontaneousCardBody(snippets: string[]): string {
   if (snippets.length === 0) return '';
-  const lines: string[] = [snippets[snippets.length - 1]];
-  if (snippets.length > 1) {
-    lines.push('');
-    lines.push(`_(${snippets.length} events coalesced; showing latest)_`);
+  if (snippets.length === 1) return snippets[0];
+
+  const sep = '\n\n---\n\n';
+  // Walk newest → oldest, keeping snippets until the next one would push us
+  // over the body budget. Anything older is summarized in a single header.
+  const kept: string[] = [];
+  let total = 0;
+  let droppedCount = 0;
+  for (let i = snippets.length - 1; i >= 0; i--) {
+    const next = snippets[i];
+    const cost = next.length + (kept.length > 0 ? sep.length : 0);
+    if (total + cost > SPONTANEOUS_BODY_MAX_CHARS) {
+      droppedCount = i + 1;
+      break;
+    }
+    kept.unshift(next);
+    total += cost;
   }
-  return lines.join('\n');
+  const body = kept.join(sep);
+  if (droppedCount > 0) {
+    const noun = droppedCount === 1 ? 'event' : 'events';
+    return `_(${droppedCount} earlier ${noun} omitted; ${kept.length} shown)_\n\n` + body;
+  }
+  return body;
 }
 
 interface PendingBatch {

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -115,13 +115,27 @@ describe('extractSpontaneousSnippet', () => {
     expect(extractSpontaneousSnippet(msg)).toBeNull();
   });
 
-  it('truncates very long text to 400 chars', () => {
-    const long = 'x'.repeat(800);
+  it('truncates very long text at the snippet cap with an ellipsis marker', () => {
+    // The cap is 4000 (raised from 400, which cut off ordinary multi-paragraph
+    // replies mid-sentence — see "经常显示不全" bug). Snippets above the cap
+    // are still tagged with an ellipsis so the reader knows truncation happened.
+    const long = 'x'.repeat(8000);
     const out = extractSpontaneousSnippet({
       type: 'assistant',
       message: { content: [{ type: 'text', text: long }] },
     });
-    expect(out).toHaveLength(400);
+    expect(out).toHaveLength(4001); // 4000 + the trailing ellipsis char
+    expect(out!.endsWith('…')).toBe(true);
+  });
+
+  it('does not touch text shorter than the snippet cap (no ellipsis appended)', () => {
+    const ordinary = 'A two-paragraph reply.\n\nWith another paragraph that is well under 4 KB.';
+    const out = extractSpontaneousSnippet({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: ordinary }] },
+    });
+    expect(out).toBe(ordinary);
+    expect(out!.endsWith('…')).toBe(false);
   });
 
   // Regression for Bug B (duplicate snippets): result-type messages MUST be
@@ -157,37 +171,59 @@ describe('extractSpontaneousSnippet', () => {
 });
 
 describe('formatSpontaneousCardBody', () => {
-  // After the post-#268 simplification, the card shows ONLY the latest
-  // snippet (the agent's conclusion of the burst). Earlier snippets are
-  // hidden — same UX bet as the main card's single-line tool indicator,
-  // i.e. surface only the final result, not the play-by-play. If the user
-  // wants the intermediate steps, they can read pm2 logs or the web UI's
-  // expandable tool view.
+  // The card body renders ALL snippets (chronological), separated by a
+  // horizontal rule. Earlier behavior was "show only the latest + a
+  // (N coalesced) footer" — that turned out to drop most of the useful
+  // content (the "经常显示不全" bug) because teammate pings, /loop
+  // iterations, and cron tasks each emit their own snippet and the user
+  // needs to see all of them. Total length is capped at
+  // SPONTANEOUS_BODY_MAX_CHARS; overflow drops the oldest snippets and
+  // prepends a one-line summary of how many were omitted.
   //
-  // The body never carries a header caption anymore — the card itself is
-  // sent with the `agent_activity` status, which renders a blue
-  // "Agent activity" title at the top. Don't re-add a body header without
-  // confirming the card-status signal is no longer sufficient.
-  it('renders only the latest snippet, with no italic header caption, for a single snippet', () => {
+  // The body never carries a header caption when nothing was dropped —
+  // the card itself is sent with the `agent_activity` status, which
+  // renders a blue "Agent activity" title at the top. Don't re-add a
+  // body header without confirming the card-status signal is no longer
+  // sufficient.
+  it('renders the single snippet verbatim with no header caption', () => {
     const body = formatSpontaneousCardBody(['Weather is sunny']);
     expect(body).toBe('Weather is sunny');
   });
 
-  it('renders only the latest snippet + a coalesced-count footer when N>1', () => {
+  it('renders ALL snippets chronologically with a horizontal-rule separator', () => {
     const body = formatSpontaneousCardBody([
       'Looking at the PR comments…',
       'Found 3 things to address.',
       'Pushed commit abc1234 to the branch.',
     ]);
-    expect(body).toContain('Pushed commit abc1234 to the branch.');
-    expect(body).toMatch(/3 events coalesced/);
-    // Earlier snippets must NOT appear in the body.
-    expect(body).not.toContain('Looking at the PR comments');
-    expect(body).not.toContain('Found 3 things to address');
-    // No numbered list prefixes either, and no body-level "between turns" caption.
-    expect(body).not.toMatch(/\*\*1\.\*\*/);
+    // All three must appear, in order.
+    const idxA = body.indexOf('Looking at the PR comments');
+    const idxB = body.indexOf('Found 3 things to address');
+    const idxC = body.indexOf('Pushed commit abc1234');
+    expect(idxA).toBeGreaterThanOrEqual(0);
+    expect(idxB).toBeGreaterThan(idxA);
+    expect(idxC).toBeGreaterThan(idxB);
+    // Snippets are separated by `---` rules (two between three snippets).
+    expect((body.match(/^---$/gm) ?? []).length).toBe(2);
+    // No body-level "between turns" / "long-running" caption, and no
+    // "N events coalesced; showing latest" footer (that's the old behavior).
+    expect(body).not.toMatch(/coalesced/i);
     expect(body).not.toMatch(/between turns/i);
     expect(body).not.toMatch(/long-running/i);
+    expect(body).not.toMatch(/showing latest/i);
+  });
+
+  it('drops the oldest snippets and prepends an "omitted" notice when total exceeds the body budget', () => {
+    // Each snippet ~3500 chars; 5 of them = ~17500 chars total → over the
+    // 12000 budget. We should keep the most recent N that fit, drop the rest.
+    const big = (label: string) => label + ' ' + 'x'.repeat(3500);
+    const snippets = ['old1', 'old2', 'old3', 'old4', 'newest'].map(big);
+    const body = formatSpontaneousCardBody(snippets);
+    // newest MUST be present (most relevant).
+    expect(body).toContain('newest');
+    // At least the oldest one MUST be omitted, with an "omitted" notice.
+    expect(body).toMatch(/^_\(\d+ earlier events? omitted; \d+ shown\)_/);
+    expect(body).not.toContain('old1');
   });
 
   it('returns an empty string when the snippets array is empty', () => {


### PR DESCRIPTION
## Why

The "agent activity" status card emitted between turns by `MessageBridge.flushSpontaneous()` was dropping most of what each spontaneous event carried.

## Root cause

Two compounding bugs in the snippet pipeline (`src/bridge/message-bridge.ts`):

1. **Per-event 400-char hard slice** in `extractSpontaneousSnippet`. Tool results, plan bodies, and any multi-line progress output got chopped well below the Feishu card's actual capacity.
2. **Only the latest snippet rendered** in `formatSpontaneousCardBody`. The 30s coalesce window (`SPONTANEOUS_COALESCE_MS`) routinely batches 3-5 events, but the body only showed `snippet[N-1]` — every earlier event silently vanished.

## Fix

- Raised per-snippet cap to `SPONTANEOUS_SNIPPET_MAX_CHARS = 4000` with an ellipsis marker on overflow.
- Rewrote `formatSpontaneousCardBody` to render **every** snippet chronologically, joined by `\n\n---\n\n`, under a `SPONTANEOUS_BODY_MAX_CHARS = 12000` body budget (well under the 28K card hard limit).
- On overflow, the oldest snippets drop with a prepended `_(N earlier events omitted; M shown)_` notice so the user can see the activity is being trimmed.

## Tests

`tests/message-bridge.test.ts` — 34 tests pass. New cases:
- truncates very long text at the snippet cap with an ellipsis marker
- does not touch text shorter than the snippet cap
- renders ALL snippets chronologically with a horizontal-rule separator
- drops the oldest snippets and prepends an omitted notice when total exceeds the body budget