### PR TITLE
feat(feishu): preserve image/text ordering in post messages

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -1929,7 +1929,7 @@ export class MessageBridge {
       imagePath = path.join(downloadsDir, `${imageKey}.png`);
       const ok = await this.sender.downloadImage(msgId, imageKey, imagePath);
       if (ok) {
-        prompt = `${enginePromptText}\n\n[Image saved at: ${imagePath}]\nPlease use the Read tool to read and analyze this image file.`;
+        prompt = `${enginePromptText}\n\n[Image 1 saved at: ${imagePath}]\nPlease use the Read tool to read and analyze this image file.`;
       } else {
         prompt = `${enginePromptText}\n\n(Note: Failed to download the image)`;
       }
@@ -1946,16 +1946,21 @@ export class MessageBridge {
       }
     }
 
-    // Handle extra media from batched messages
+    // Handle extra media from batched messages.
+    // imageCounter aligns with [Image N] placeholders that event-handler injected into the post text:
+    // main imageKey is [Image 1], extras are [Image 2], [Image 3], ... — keep the same order so file
+    // paths and the in-text references line up.
     const extraPaths: string[] = [];
+    let imageCounter = imageKey ? 1 : 0;
     if (msg.extraMedia && msg.extraMedia.length > 0) {
       for (const media of msg.extraMedia) {
         if (media.imageKey) {
+          imageCounter++;
           const p = path.join(downloadsDir, `${media.imageKey}.png`);
           const ok = await this.sender.downloadImage(media.messageId, media.imageKey, p);
           if (ok) {
             extraPaths.push(p);
-            prompt += `\n[Image saved at: ${p}]`;
+            prompt += `\n[Image ${imageCounter} saved at: ${p}]`;
           }
         }
         if (media.fileKey && media.fileName) {

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -364,17 +364,18 @@ export function createEventDispatcher(
           text = '请分析这个文件';
           logger.info({ userId, chatId, chatType, fileKey, fileName }, 'Received file message');
         } else if (msgType === 'post') {
-          // Rich text (post) message: extract plain text and images from nested structure
+          // Rich text (post) message: extract plain text and images from nested structure,
+          // preserving the original ordering by inlining [图N] placeholders where images appeared.
           try {
             const content = JSON.parse(message.content);
             logger.debug({ postContent: JSON.stringify(content).slice(0, 500) }, 'Raw post content');
-            text = extractTextFromPost(content);
-            const postImages = extractImagesFromPost(content);
-            if (postImages.length > 0) {
-              imageKey = postImages[0];
-              postExtraImages = postImages.slice(1);
+            const interleaved = extractPostInterleaved(content);
+            text = interleaved.text;
+            if (interleaved.imageKeys.length > 0) {
+              imageKey = interleaved.imageKeys[0];
+              postExtraImages = interleaved.imageKeys.slice(1);
             }
-            logger.debug({ extractedText: text.slice(0, 200), imageKey, postImageCount: postImages.length }, 'Extracted post content');
+            logger.debug({ extractedText: text.slice(0, 200), imageKey, postImageCount: interleaved.imageKeys.length }, 'Extracted post content');
           } catch {
             logger.warn({ content: message.content }, 'Failed to parse post message content');
             return;
@@ -467,58 +468,23 @@ function parseMediaMessage(
 }
 
 /**
- * Extract all image_keys from a Feishu post (rich text) message.
- * Looks for { tag: "img", image_key: "..." } elements in the post content.
+ * Extract text and images from a Feishu post (rich text) message in a single pass,
+ * preserving the original ordering. Images are replaced with [图N] placeholders
+ * (1-indexed) inside the text, and the matching image_keys are returned in the
+ * same order, so the caller can re-align them downstream.
+ *
+ * Handles two content shapes:
+ *   With locale wrapper:    { "zh_cn": { "title": "...", "content": [[{tag, ...}, ...], ...] } }
+ *   Without locale wrapper: { "title": "...", "content": [[{tag, ...}, ...], ...] }
  */
-function extractImagesFromPost(content: Record<string, unknown>): string[] {
+function extractPostInterleaved(
+  content: Record<string, unknown>,
+): { text: string; imageKeys: string[] } {
   const bodies: Array<Record<string, unknown>> = [];
 
   if (Array.isArray(content.content)) {
     bodies.push(content);
   } else {
-    for (const locale of Object.values(content)) {
-      if (locale && typeof locale === 'object' && !Array.isArray(locale)) {
-        const loc = locale as Record<string, unknown>;
-        if (Array.isArray(loc.content)) {
-          bodies.push(loc);
-        }
-      }
-    }
-  }
-
-  const keys: string[] = [];
-  for (const body of bodies) {
-    const paragraphs = body.content as unknown[][];
-    for (const paragraph of paragraphs) {
-      if (!Array.isArray(paragraph)) continue;
-      for (const element of paragraph) {
-        if (!element || typeof element !== 'object') continue;
-        const el = element as Record<string, unknown>;
-        if (el.tag === 'img' && typeof el.image_key === 'string') {
-          keys.push(el.image_key);
-        }
-      }
-    }
-  }
-
-  return keys;
-}
-
-/**
- * Extract plain text from Feishu post (rich text) message content.
- * Handles two formats:
- *   With locale wrapper: { "zh_cn": { "title": "...", "content": [[{tag, text}, ...], ...] } }
- *   Without locale wrapper: { "title": "...", "content": [[{tag, text}, ...], ...] }
- */
-function extractTextFromPost(content: Record<string, unknown>): string {
-  // Try to find the post body — either the content itself or nested under a locale key
-  const bodies: Array<Record<string, unknown>> = [];
-
-  if (Array.isArray(content.content)) {
-    // Direct format (no locale wrapper)
-    bodies.push(content);
-  } else {
-    // Locale-wrapped format: values are { title, content }
     for (const locale of Object.values(content)) {
       if (locale && typeof locale === 'object' && !Array.isArray(locale)) {
         const loc = locale as Record<string, unknown>;
@@ -531,6 +497,7 @@ function extractTextFromPost(content: Record<string, unknown>): string {
 
   for (const body of bodies) {
     const parts: string[] = [];
+    const imageKeys: string[] = [];
 
     if (body.title && typeof body.title === 'string') {
       parts.push(body.title);
@@ -545,6 +512,9 @@ function extractTextFromPost(content: Record<string, unknown>): string {
         const el = element as Record<string, unknown>;
         if ((el.tag === 'text' || el.tag === 'a') && typeof el.text === 'string') {
           line.push(el.text);
+        } else if (el.tag === 'img' && typeof el.image_key === 'string') {
+          imageKeys.push(el.image_key);
+          line.push(`[图${imageKeys.length}]`);
         }
       }
       if (line.length > 0) {
@@ -552,10 +522,10 @@ function extractTextFromPost(content: Record<string, unknown>): string {
       }
     }
 
-    if (parts.length > 0) {
-      return parts.join('\n');
+    if (parts.length > 0 || imageKeys.length > 0) {
+      return { text: parts.join('\n'), imageKeys };
     }
   }
 
-  return '';
+  return { text: '', imageKeys: [] };
 }

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -514,7 +514,7 @@ function extractPostInterleaved(
           line.push(el.text);
         } else if (el.tag === 'img' && typeof el.image_key === 'string') {
           imageKeys.push(el.image_key);
-          line.push(`[图${imageKeys.length}]`);
+          line.push(`[Image ${imageKeys.length}]`);
         }
       }
       if (line.length > 0) {

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -469,7 +469,7 @@ function parseMediaMessage(
 
 /**
  * Extract text and images from a Feishu post (rich text) message in a single pass,
- * preserving the original ordering. Images are replaced with [图N] placeholders
+ * preserving the original ordering. Images are replaced with [Image N] placeholders
  * (1-indexed) inside the text, and the matching image_keys are returned in the
  * same order, so the caller can re-align them downstream.
  *

--- a/tests/post-image-text-ordering.test.ts
+++ b/tests/post-image-text-ordering.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import { createEventDispatcher } from '../src/feishu/event-handler.js';
+import type { IncomingMessage } from '../src/types.js';
+
+/**
+ * PR #320 invariant, tested end-to-end through the public dispatcher entry
+ * (no internals exported):
+ *
+ *   event-handler injects [Image N] placeholders into post text in visual
+ *   order; the first image travels as `imageKey`, the rest as `extraMedia`
+ *   in that same order. message-bridge numbers downloads identically
+ *   (main imageKey = [Image 1], extra images increment the counter, files
+ *   never take a number), so if this ordering breaks, the agent silently
+ *   maps the wrong file path to the wrong in-text anchor.
+ *
+ * Covers the three review asks: direct + locale-wrapped post shapes,
+ * interleaved text/images, and post images combined with cached group media.
+ */
+
+const BOT_OPEN_ID = 'ou_bot_self';
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as any;
+
+function makeDispatcher(
+  onMessage: (m: IncomingMessage) => void,
+  opts: { botOpenId?: string } = {},
+) {
+  const config = { groupNoMention: false } as any;
+  return createEventDispatcher(config, silentLogger, onMessage, opts.botOpenId);
+}
+
+interface InvokeOpts {
+  msgId: string;
+  chatId: string;
+  userId: string;
+  msgType: 'text' | 'post' | 'image' | 'file';
+  content: unknown;
+  chatType?: 'p2p' | 'group';
+  mentions?: Array<{ id: { open_id: string } }>;
+}
+
+/** Feed one im.message.receive_v1 event (schema 2.0) through the dispatcher. */
+function invokeMessage(dispatcher: any, opts: InvokeOpts) {
+  return dispatcher.invoke(
+    {
+      schema: '2.0',
+      header: { event_type: 'im.message.receive_v1' },
+      event: {
+        sender: { sender_id: { open_id: opts.userId } },
+        message: {
+          message_id: opts.msgId,
+          chat_id: opts.chatId,
+          chat_type: opts.chatType ?? 'p2p',
+          message_type: opts.msgType,
+          content: JSON.stringify(opts.content),
+          ...(opts.mentions ? { mentions: opts.mentions } : {}),
+        },
+      },
+    },
+    { needCheck: false },
+  );
+}
+
+/** One paragraph of post body: text -> image -> text -> image variants below. */
+const TWO_IMAGE_BODY = {
+  title: 'Title',
+  content: [
+    [{ tag: 'text', text: 'look: ' }, { tag: 'img', image_key: 'k_a' }],
+  ],
+};
+
+describe('post shapes: direct and locale-wrapped', () => {
+  it('direct shape (no locale wrapper) extracts title, text and [Image 1] anchor', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m));
+
+    await invokeMessage(d, {
+      msgId: 'om_direct', chatId: 'oc_direct', userId: 'ou_u',
+      msgType: 'post', content: TWO_IMAGE_BODY,
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toBe('Title\nlook: [Image 1]');
+    expect(received[0].imageKey).toBe('k_a');
+    expect(received[0].extraMedia).toBeUndefined();
+  });
+
+  it('locale-wrapped shape (zh_cn) extracts identically to the direct shape', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m));
+
+    await invokeMessage(d, {
+      msgId: 'om_locale', chatId: 'oc_locale', userId: 'ou_u',
+      msgType: 'post', content: { zh_cn: TWO_IMAGE_BODY },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toBe('Title\nlook: [Image 1]');
+    expect(received[0].imageKey).toBe('k_a');
+  });
+
+  it('locale wrapper skips malformed locale values and uses the first with a content array', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m));
+
+    await invokeMessage(d, {
+      msgId: 'om_mixed', chatId: 'oc_mixed', userId: 'ou_u',
+      msgType: 'post',
+      content: { en_us: 'bogus', ja_jp: { title: 'no content array' }, zh_cn: TWO_IMAGE_BODY },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toBe('Title\nlook: [Image 1]');
+    expect(received[0].imageKey).toBe('k_a');
+  });
+});
+
+describe('interleaved text/images', () => {
+  it('text→image→text→image keeps placeholders in position and imageKeys in the same order', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m));
+
+    await invokeMessage(d, {
+      msgId: 'om_inter', chatId: 'oc_inter', userId: 'ou_u',
+      msgType: 'post',
+      content: {
+        content: [
+          [{ tag: 'text', text: '第一段说明。' }],
+          [{ tag: 'img', image_key: 'k_first' }],
+          [{ tag: 'text', text: '第二段说明。' }],
+          [{ tag: 'img', image_key: 'k_second' }],
+        ],
+      },
+    });
+
+    expect(received).toHaveLength(1);
+    const m = received[0];
+    expect(m.text).toBe('第一段说明。\n[Image 1]\n第二段说明。\n[Image 2]');
+    // First image rides as imageKey ([Image 1]); the rest follow as extraMedia
+    // in placeholder order ([Image 2], ...).
+    expect(m.imageKey).toBe('k_first');
+    expect(m.extraMedia).toEqual([{ messageId: 'om_inter', imageKey: 'k_second' }]);
+  });
+
+  it('inline mix in one paragraph stays on one line, link (a) text included', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m));
+
+    await invokeMessage(d, {
+      msgId: 'om_inline', chatId: 'oc_inline', userId: 'ou_u',
+      msgType: 'post',
+      content: {
+        content: [[
+          { tag: 'text', text: 'A' },
+          { tag: 'img', image_key: 'k1' },
+          { tag: 'a', text: 'link' },
+          { tag: 'img', image_key: 'k2' },
+        ]],
+      },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toBe('A[Image 1]link[Image 2]');
+    expect(received[0].imageKey).toBe('k1');
+    expect(received[0].extraMedia).toEqual([{ messageId: 'om_inline', imageKey: 'k2' }]);
+  });
+
+  it('image-only post yields placeholder-only text (not the bare-image default prompt)', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m));
+
+    await invokeMessage(d, {
+      msgId: 'om_imgonly', chatId: 'oc_imgonly', userId: 'ou_u',
+      msgType: 'post',
+      content: { content: [[{ tag: 'img', image_key: 'k_only' }]] },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toBe('[Image 1]');
+    expect(received[0].imageKey).toBe('k_only');
+  });
+
+  it('plain-text post passes through with no placeholders and no imageKey', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m));
+
+    await invokeMessage(d, {
+      msgId: 'om_plain', chatId: 'oc_plain', userId: 'ou_u',
+      msgType: 'post',
+      content: { content: [[{ tag: 'text', text: 'just words' }]] },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toBe('just words');
+    expect(received[0].imageKey).toBeUndefined();
+    expect(received[0].extraMedia).toBeUndefined();
+  });
+});
+
+describe('post images combined with cached group media', () => {
+  it('cached media appends after post extras; anchors stay post-owned; cache clears once attached', async () => {
+    const received: IncomingMessage[] = [];
+    const d = makeDispatcher(m => received.push(m), { botOpenId: BOT_OPEN_ID });
+    const chatId = 'oc_cache_combo';
+    const userId = 'ou_cache_user';
+
+    // Un-mentioned group media goes into the pending cache, not to onMessage.
+    await invokeMessage(d, {
+      msgId: 'om_cached_img', chatId, userId,
+      msgType: 'image', chatType: 'group',
+      content: { image_key: 'k_cached_img' },
+    });
+    await invokeMessage(d, {
+      msgId: 'om_cached_file', chatId, userId,
+      msgType: 'file', chatType: 'group',
+      content: { file_key: 'k_cached_file', file_name: 'report.pdf' },
+    });
+    expect(received).toHaveLength(0);
+
+    // @bot post with two inline images: post extras must precede cached media,
+    // because [Image N] anchors in the text belong to the post's own images.
+    await invokeMessage(d, {
+      msgId: 'om_post', chatId, userId,
+      msgType: 'post', chatType: 'group',
+      mentions: [{ id: { open_id: BOT_OPEN_ID } }],
+      content: {
+        content: [
+          [{ tag: 'text', text: '对比这两张：' }],
+          [{ tag: 'img', image_key: 'k_p1' }],
+          [{ tag: 'img', image_key: 'k_p2' }],
+        ],
+      },
+    });
+
+    expect(received).toHaveLength(1);
+    const m = received[0];
+    expect(m.text).toBe('对比这两张：\n[Image 1]\n[Image 2]');
+    expect(m.text).not.toContain('[Image 3]'); // cached media never claims an anchor
+    expect(m.imageKey).toBe('k_p1');
+    expect(m.extraMedia).toEqual([
+      { messageId: 'om_post', imageKey: 'k_p2' },
+      { messageId: 'om_cached_img', imageKey: 'k_cached_img', fileKey: undefined, fileName: undefined },
+      { messageId: 'om_cached_file', imageKey: undefined, fileKey: 'k_cached_file', fileName: 'report.pdf' },
+    ]);
+
+    // Cache must be consumed: the next mentioned post carries only its own extras.
+    await invokeMessage(d, {
+      msgId: 'om_post2', chatId, userId,
+      msgType: 'post', chatType: 'group',
+      mentions: [{ id: { open_id: BOT_OPEN_ID } }],
+      content: { content: [[{ tag: 'text', text: '再看一张' }, { tag: 'img', image_key: 'k_p3' }]] },
+    });
+    expect(received).toHaveLength(2);
+    expect(received[1].imageKey).toBe('k_p3');
+    expect(received[1].extraMedia).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Feishu post (rich text) messages with interleaved text + images previously collapsed all images to the end of the prompt, so the agent lost the order in which images appeared between paragraphs.
- This PR rewrites the post parser to a single pass that emits `[Image N]` placeholders inline in the text and returns the matching image keys in the same order.
- Downstream, `message-bridge` now labels each downloaded file as `[Image 1 saved at: ...]`, `[Image 2 saved at: ...]`, ..., aligned with the in-text anchors — the agent can finally tell which placeholder maps to which file path.

## Why
Users on Feishu paste docs/screenshots that mix `text → image → text → image`. Before, the agent saw all text first and all images last, with no ordering information. Asking "what's in the second image?" worked only by luck.

## Test plan
- [x] `npm run build` — green
- [x] `npm test` — 310 passed
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unchanged)
- [x] Manual: sent a Feishu post with `[图1] 文字A [图2] 文字B` interleaved, agent correctly reads each image via its `[Image N saved at: ...]` path and answers about "first" vs "second" image separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)