### PR TITLE
feat: add WeCom (企业微信) smart bot via AIP long connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ BOTS_CONFIG=./bots.json
 # Telegram Bot Configuration (single-bot mode — can run alongside Feishu bot)
 # TELEGRAM_BOT_TOKEN=
 
+# WeCom (企业微信) Smart-bot — AIP WebSocket long-connection mode (single-bot mode)
+# Get botId/secret from the WeCom admin console (智能机器人 → 接收消息 → 长连接).
+# WECOM_BOT_ID=
+# WECOM_BOT_SECRET=
+# WECOM_WS_URL=                 # Optional custom URL for privately-deployed WeCom
+
 # =============================================================================
 # Claude Code Configuration
 # ANTHROPIC_BASE_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,18 @@ mb skills remove <name>                    # Unpublish
 
 Sessions are keyed by `chatId` (not `userId`), so each group chat and DM gets its own independent session, working directory, and conversation history. Group chats with exactly 2 members (1 user + 1 bot) are treated like DMs — no @mention required. This lets users "fork" a bot by creating multiple small group chats, each with its own session. The member count is cached for 5 minutes to avoid excessive API calls.
 
+### WeCom (企业微信) Smart Bot
+
+Enterprise WeChat (WeCom) integration via the **智能机器人 AIP WebSocket long connection** (`wss://openws.work.weixin.qq.com`). Built on the official [`@wecom/aibot-node-sdk`](https://github.com/WecomTeam/aibot-node-sdk), which handles authentication (`aibot_subscribe` with botId + secret), heartbeat, exponential-backoff reconnection, AES-256-CBC media decryption, and chunked media upload. **This is distinct from the personal-WeChat iLink integration** (`src/wechat/`); WeCom is a separate platform under `src/wecom/`.
+
+**Key modules:**
+- **`src/wecom/wecom-bot.ts`** — `startWecomBot()` creates the SDK `WSClient`, wires `message.*` / `event.enter_chat` events, maps WeCom callback frames to the platform-agnostic `IncomingMessage`, binds the incoming frame to the sender (for streaming reply routing by `req_id`), and routes through the shared `MessageBridge`.
+- **`src/wecom/wecom-sender.ts`** — `WecomSender implements IMessageSender`. Maps the bridge's `sendCard → updateCard* → final` lifecycle onto WeCom streaming replies (`aibot_respond_msg` with a shared `stream.id`, full-content replacement, terminal frame sets `finish=true`). Streaming replies are tied to the incoming message's `req_id`; command responses / notices / output files use the active-push channel (`aibot_send_msg`). Sets `skipCompletionNotice = true` and folds stats into the final stream content.
+
+**Streaming model**: A reply is bound to the `req_id` of the incoming message frame, so each user message → one stream. Intermediate updates use `replyStreamNonBlocking` (skips when a prior ack is pending); the pending-question and terminal frames use blocking `replyStream`. Note the WeCom stream must complete within ~10 minutes; the terminal update falls back to active push if no frame is available.
+
+**Config**: Single-bot mode via `WECOM_BOT_ID` / `WECOM_BOT_SECRET` (`WECOM_WS_URL` optional for private deployment); multi-bot mode via `wecomBots` in `bots.json` (`wecomBotId`, `wecomSecret`, `wecomWsUrl`). Get the botId/secret from the WeCom admin console under 智能机器人 → 接收消息 → 长连接.
+
 ### Web Platform
 
 A full-featured React SPA served at `/web/` with real-time WebSocket streaming. No external CSS framework — hand-crafted "Midnight Luxe" design system.
@@ -191,6 +203,8 @@ Per-bot config fields (JSON array entries):
 - **`allowedTools`** — Claude tools whitelist (defaults to env var or `Read,Edit,Write,Glob,Grep,Bash`)
 - **`maxTurns`** / **`maxBudgetUsd`** / **`model`** — Claude execution limits (defaults from env vars)
 - **`outputsBaseDir`** — Base directory for output files
+
+The `bots.json` object supports multiple platform arrays: `feishuBots`, `telegramBots`, `wechatBots` (personal WeChat / iLink), `wecomBots` (企业微信 / WeCom long connection), and `webBots` (Web UI only, no IM credentials). All can coexist in one process.
 
 When `BOTS_CONFIG` is set, `FEISHU_APP_ID` / `FEISHU_APP_SECRET` env vars are ignored. Other env vars (`CLAUDE_MAX_TURNS`, `LOG_LEVEL`, etc.) still serve as defaults for any bot field not specified in JSON.
 

--- a/bots.example.json
+++ b/bots.example.json
@@ -38,6 +38,15 @@
       "defaultWorkingDirectory": "/home/user/project"
     }
   ],
+  "wecomBots": [
+    {
+      "name": "wecom-assistant",
+      "description": "企业微信智能机器人（AIP 长连接模式）",
+      "wecomBotId": "aibxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "wecomSecret": "your-wecom-bot-secret",
+      "defaultWorkingDirectory": "/home/user/project"
+    }
+  ],
   "peers": [
     {
       "name": "alice",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@larksuiteoapi/node-sdk": "^1.58.0",
         "@types/ws": "^8.18.0",
         "@volcengine/openapi": "^1.36.0",
+        "@wecom/aibot-node-sdk": "^1.0.7",
         "better-sqlite3": "^12.6.2",
         "cron-parser": "^5.5.0",
         "dotenv": "^16.4.0",
@@ -2045,6 +2046,17 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@wecom/aibot-node-sdk": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@wecom/aibot-node-sdk/-/aibot-node-sdk-1.0.7.tgz",
+      "integrity": "sha512-51w+sTqunry6GD3HFvmuh0gArMSJDFE418vyvR1wMJHj1N6DaFuGD3HuaY2fazZs3mb9FWeQFX3+vU5t0Qhwmw==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.7",
+        "eventemitter3": "^5.0.1",
+        "ws": "^8.16.0"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -3188,6 +3200,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@larksuiteoapi/node-sdk": "^1.58.0",
     "@types/ws": "^8.18.0",
     "@volcengine/openapi": "^1.36.0",
+    "@wecom/aibot-node-sdk": "^1.0.7",
     "better-sqlite3": "^12.6.2",
     "cron-parser": "^5.5.0",
     "dotenv": "^16.4.0",

--- a/src/api/bot-registry.ts
+++ b/src/api/bot-registry.ts
@@ -5,7 +5,7 @@ import type { IMessageSender } from '../bridge/message-sender.interface.js';
 
 export interface RegisteredBot {
   name: string;
-  platform: 'feishu' | 'telegram' | 'web' | 'wechat';
+  platform: 'feishu' | 'telegram' | 'web' | 'wechat' | 'wecom';
   config: BotConfigBase;
   bridge: MessageBridge;
   sender: IMessageSender;
@@ -50,7 +50,7 @@ export class BotRegistry {
 
   get(name: string): RegisteredBot | undefined {
     // Try platform-qualified keys first
-    for (const prefix of ['feishu', 'telegram', 'web', 'wechat']) {
+    for (const prefix of ['feishu', 'telegram', 'web', 'wechat', 'wecom']) {
       const bot = this.bots.get(`${prefix}:${name}`);
       if (bot) return bot;
     }
@@ -69,7 +69,7 @@ export class BotRegistry {
 
   deregister(name: string): boolean {
     // Try all platform-qualified keys
-    for (const prefix of ['feishu', 'telegram', 'web', 'wechat']) {
+    for (const prefix of ['feishu', 'telegram', 'web', 'wechat', 'wecom']) {
       if (this.bots.delete(`${prefix}:${name}`)) return true;
     }
     return false;

--- a/src/api/bots-config-writer.ts
+++ b/src/api/bots-config-writer.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { BotsJsonNewFormat, FeishuBotJsonEntry, TelegramBotJsonEntry, WebBotJsonEntry, WechatBotJsonEntry } from '../config.js';
+import type { BotsJsonNewFormat, FeishuBotJsonEntry, TelegramBotJsonEntry, WebBotJsonEntry, WechatBotJsonEntry, WecomBotJsonEntry } from '../config.js';
 
 export function readBotsConfig(configPath: string): BotsJsonNewFormat {
   const raw = fs.readFileSync(configPath, 'utf-8');
@@ -28,13 +28,14 @@ function allBotNames(config: BotsJsonNewFormat): string[] {
     ...(config.telegramBots || []).map((b) => b.name),
     ...(config.webBots || []).map((b) => b.name),
     ...(config.wechatBots || []).map((b) => b.name),
+    ...(config.wecomBots || []).map((b) => b.name),
   ];
 }
 
 export function addBot(
   configPath: string,
-  platform: 'feishu' | 'telegram' | 'web' | 'wechat',
-  entry: FeishuBotJsonEntry | TelegramBotJsonEntry | WebBotJsonEntry | WechatBotJsonEntry,
+  platform: 'feishu' | 'telegram' | 'web' | 'wechat' | 'wecom',
+  entry: FeishuBotJsonEntry | TelegramBotJsonEntry | WebBotJsonEntry | WechatBotJsonEntry | WecomBotJsonEntry,
 ): void {
   const config = readBotsConfig(configPath);
 
@@ -49,14 +50,15 @@ export function addBot(
   } else if (platform === 'telegram') {
     if (!config.telegramBots) config.telegramBots = [];
     config.telegramBots.push(entry as TelegramBotJsonEntry);
+  } else if (platform === 'web') {
+    if (!config.webBots) config.webBots = [];
+    config.webBots.push(entry as WebBotJsonEntry);
+  } else if (platform === 'wecom') {
+    if (!config.wecomBots) config.wecomBots = [];
+    config.wecomBots.push(entry as WecomBotJsonEntry);
   } else {
-    if (platform === 'web') {
-      if (!config.webBots) config.webBots = [];
-      config.webBots.push(entry as WebBotJsonEntry);
-    } else {
-      if (!config.wechatBots) config.wechatBots = [];
-      config.wechatBots.push(entry as WechatBotJsonEntry);
-    }
+    if (!config.wechatBots) config.wechatBots = [];
+    config.wechatBots.push(entry as WechatBotJsonEntry);
   }
 
   writeBotsConfig(configPath, config);
@@ -65,7 +67,7 @@ export function addBot(
 export function removeBot(configPath: string, name: string): boolean {
   const config = readBotsConfig(configPath);
 
-  const totalBots = (config.feishuBots?.length || 0) + (config.telegramBots?.length || 0) + (config.webBots?.length || 0) + (config.wechatBots?.length || 0);
+  const totalBots = (config.feishuBots?.length || 0) + (config.telegramBots?.length || 0) + (config.webBots?.length || 0) + (config.wechatBots?.length || 0) + (config.wecomBots?.length || 0);
 
   // Find and remove from feishu
   if (config.feishuBots) {
@@ -110,6 +112,16 @@ export function removeBot(configPath: string, name: string): boolean {
     }
   }
 
+  if (config.wecomBots) {
+    const idx = config.wecomBots.findIndex((b) => b.name === name);
+    if (idx !== -1) {
+      if (totalBots <= 1) throw new Error('Cannot remove the last bot');
+      config.wecomBots.splice(idx, 1);
+      writeBotsConfig(configPath, config);
+      return true;
+    }
+  }
+
   return false;
 }
 
@@ -122,6 +134,7 @@ export function updateBot(configPath: string, name: string, updates: Record<stri
     config.telegramBots,
     config.webBots,
     config.wechatBots,
+    config.wecomBots,
   ];
   for (const bots of platforms) {
     if (!bots) continue;
@@ -147,7 +160,7 @@ export function updateBot(configPath: string, name: string, updates: Record<stri
 export function getBotEntry(
   configPath: string,
   name: string,
-): { platform: 'feishu' | 'telegram' | 'web' | 'wechat'; entry: FeishuBotJsonEntry | TelegramBotJsonEntry | WebBotJsonEntry | WechatBotJsonEntry } | null {
+): { platform: 'feishu' | 'telegram' | 'web' | 'wechat' | 'wecom'; entry: FeishuBotJsonEntry | TelegramBotJsonEntry | WebBotJsonEntry | WechatBotJsonEntry | WecomBotJsonEntry } | null {
   const config = readBotsConfig(configPath);
 
   const feishu = config.feishuBots?.find((b) => b.name === name);
@@ -161,6 +174,9 @@ export function getBotEntry(
 
   const wechat = config.wechatBots?.find((b) => b.name === name);
   if (wechat) return { platform: 'wechat', entry: wechat };
+
+  const wecom = config.wecomBots?.find((b) => b.name === name);
+  if (wecom) return { platform: 'wecom', entry: wecom };
 
   return null;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,22 @@ export interface WechatBotConfig extends BotConfigBase {
   };
 }
 
+/**
+ * WeCom (企业微信) smart-bot config — AIP WebSocket long-connection mode.
+ * Distinct from `WechatBotConfig` (personal WeChat via iLink): this targets the
+ * Enterprise WeChat 智能机器人 long-connection channel (`@wecom/aibot-node-sdk`).
+ */
+export interface WecomBotConfig extends BotConfigBase {
+  wecom: {
+    /** Bot ID from the WeCom admin console. */
+    botId: string;
+    /** Bot Secret (long-connection credential) from the WeCom admin console. */
+    secret: string;
+    /** Optional custom WebSocket URL for privately-deployed WeCom (defaults to wss://openws.work.weixin.qq.com). */
+    wsUrl?: string;
+  };
+}
+
 export interface PeerConfig {
   name: string;
   url: string;
@@ -60,6 +76,7 @@ export interface AppConfig {
   telegramBots: TelegramBotConfig[];
   webBots: BotConfigBase[];
   wechatBots: WechatBotConfig[];
+  wecomBots: WecomBotConfig[];
   /** Dedicated Feishu service app for wiki sync & doc reader (independent of chat bots). */
   feishuService?: {
     appId: string;
@@ -234,6 +251,49 @@ function wechatBotFromJson(entry: WechatBotJsonEntry): WechatBotConfig {
   };
 }
 
+// --- WeCom (企业微信) JSON entry (used in bots.json) ---
+
+export interface WecomBotJsonEntry {
+  name: string;
+  description?: string;
+  specialties?: string[];
+  icon?: string;
+  maxConcurrentTasks?: number;
+  budgetLimitDaily?: number;
+  ttsVoice?: string;
+  /** WeCom bot ID from the admin console. */
+  wecomBotId: string;
+  /** WeCom bot Secret (long-connection credential). */
+  wecomSecret: string;
+  /** Optional custom WebSocket URL for privately-deployed WeCom. */
+  wecomWsUrl?: string;
+  defaultWorkingDirectory: string;
+  maxTurns?: number;
+  maxBudgetUsd?: number;
+  model?: string;
+  apiKey?: string;
+  outputsBaseDir?: string;
+  downloadsDir?: string;
+}
+
+function wecomBotFromJson(entry: WecomBotJsonEntry): WecomBotConfig {
+  return {
+    name: entry.name,
+    ...(entry.description ? { description: entry.description } : {}),
+    ...(entry.specialties?.length ? { specialties: entry.specialties } : {}),
+    ...(entry.icon ? { icon: entry.icon } : {}),
+    ...(entry.maxConcurrentTasks != null ? { maxConcurrentTasks: entry.maxConcurrentTasks } : {}),
+    ...(entry.budgetLimitDaily != null ? { budgetLimitDaily: entry.budgetLimitDaily } : {}),
+    ...(entry.ttsVoice ? { ttsVoice: entry.ttsVoice } : {}),
+    wecom: {
+      botId: entry.wecomBotId,
+      secret: entry.wecomSecret,
+      ...(entry.wecomWsUrl ? { wsUrl: entry.wecomWsUrl } : {}),
+    },
+    claude: buildClaudeConfig(entry),
+  };
+}
+
 // --- Shared Claude config builder ---
 
 function buildClaudeConfig(entry: {
@@ -313,6 +373,26 @@ function wechatBotFromEnv(): WechatBotConfig {
   };
 }
 
+function wecomBotFromEnv(): WecomBotConfig {
+  return {
+    name: 'wecom-default',
+    wecom: {
+      botId: required('WECOM_BOT_ID'),
+      secret: required('WECOM_BOT_SECRET'),
+      ...(process.env.WECOM_WS_URL ? { wsUrl: process.env.WECOM_WS_URL } : {}),
+    },
+    claude: {
+      defaultWorkingDirectory: expandUserPath(required('CLAUDE_DEFAULT_WORKING_DIRECTORY')),
+      maxTurns: process.env.CLAUDE_MAX_TURNS ? parseInt(process.env.CLAUDE_MAX_TURNS, 10) : undefined,
+      maxBudgetUsd: process.env.CLAUDE_MAX_BUDGET_USD ? parseFloat(process.env.CLAUDE_MAX_BUDGET_USD) : undefined,
+      model: process.env.CLAUDE_MODEL || 'claude-opus-4-6',
+      apiKey: undefined,
+      outputsBaseDir: expandUserPath(process.env.OUTPUTS_BASE_DIR || path.join(os.tmpdir(), `metabot-outputs-${os.userInfo().username}`)),
+      downloadsDir: expandUserPath(process.env.DOWNLOADS_DIR || path.join(os.tmpdir(), `metabot-downloads-${os.userInfo().username}`)),
+    },
+  };
+}
+
 // --- New bots.json format ---
 
 export interface PeerJsonEntry {
@@ -326,6 +406,7 @@ export interface BotsJsonNewFormat {
   telegramBots?: TelegramBotJsonEntry[];
   webBots?: WebBotJsonEntry[];
   wechatBots?: WechatBotJsonEntry[];
+  wecomBots?: WecomBotJsonEntry[];
   peers?: PeerJsonEntry[];
 }
 
@@ -336,6 +417,7 @@ export function loadAppConfig(): AppConfig {
   let telegramBots: TelegramBotConfig[] = [];
   let webBots: BotConfigBase[] = [];
   let wechatBots: WechatBotConfig[] = [];
+  let wecomBots: WecomBotConfig[] = [];
   let parsedConfig: unknown;
 
   if (botsConfigPath) {
@@ -365,7 +447,10 @@ export function loadAppConfig(): AppConfig {
       if (cfg.wechatBots) {
         wechatBots = cfg.wechatBots.map(wechatBotFromJson);
       }
-      if (feishuBots.length === 0 && telegramBots.length === 0 && webBots.length === 0 && wechatBots.length === 0) {
+      if (cfg.wecomBots) {
+        wecomBots = cfg.wecomBots.map(wecomBotFromJson);
+      }
+      if (feishuBots.length === 0 && telegramBots.length === 0 && webBots.length === 0 && wechatBots.length === 0 && wecomBots.length === 0) {
         throw new Error(`BOTS_CONFIG file must define at least one bot: ${resolved}`);
       }
     } else {
@@ -382,8 +467,11 @@ export function loadAppConfig(): AppConfig {
     if (process.env.WECHAT_BOT_TOKEN || process.env.WECHAT_ILINK_ENABLED === 'true') {
       wechatBots = [wechatBotFromEnv()];
     }
-    if (feishuBots.length === 0 && telegramBots.length === 0 && wechatBots.length === 0) {
-      throw new Error('No bot configured. Set FEISHU_APP_ID/FEISHU_APP_SECRET, TELEGRAM_BOT_TOKEN, or WECHAT_ILINK_ENABLED=true, or use BOTS_CONFIG for multi-bot mode.');
+    if (process.env.WECOM_BOT_ID) {
+      wecomBots = [wecomBotFromEnv()];
+    }
+    if (feishuBots.length === 0 && telegramBots.length === 0 && wechatBots.length === 0 && wecomBots.length === 0) {
+      throw new Error('No bot configured. Set FEISHU_APP_ID/FEISHU_APP_SECRET, TELEGRAM_BOT_TOKEN, WECOM_BOT_ID/WECOM_BOT_SECRET, or WECHAT_ILINK_ENABLED=true, or use BOTS_CONFIG for multi-bot mode.');
     }
   }
 
@@ -447,6 +535,7 @@ export function loadAppConfig(): AppConfig {
     telegramBots,
     webBots,
     wechatBots,
+    wecomBots,
     feishuService,
     log: {
       level: process.env.LOG_LEVEL || 'info',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import type { IMessageSender } from './bridge/message-sender.interface.js';
 import type { BotConfigBase } from './config.js';
 import { startTelegramBot } from './telegram/telegram-bot.js';
 import { startWechatBot } from './wechat/wechat-bot.js';
+import { startWecomBot } from './wecom/wecom-bot.js';
 import { BotRegistry } from './api/bot-registry.js';
 import { NullSender } from './web/null-sender.js';
 import { PeerManager } from './api/peer-manager.js';
@@ -100,7 +101,8 @@ async function main() {
   const feishuCount = appConfig.feishuBots.length;
   const telegramCount = appConfig.telegramBots.length;
   const wechatCount = appConfig.wechatBots.length;
-  logger.info({ feishuBots: feishuCount, telegramBots: telegramCount, wechatBots: wechatCount, memoryServerUrl: appConfig.memoryServerUrl }, 'Starting MetaBot bridge...');
+  const wecomCount = appConfig.wecomBots.length;
+  logger.info({ feishuBots: feishuCount, telegramBots: telegramCount, wechatBots: wechatCount, wecomBots: wecomCount, memoryServerUrl: appConfig.memoryServerUrl }, 'Starting MetaBot bridge...');
 
   // Create bot registry
   const registry = new BotRegistry();
@@ -131,6 +133,15 @@ async function main() {
       (bot) => startWechatBot(bot, logger, appConfig.memoryServerUrl, appConfig.memory.secret || undefined),
       logger,
       'wechat',
+    )
+    : [];
+
+  const wecomHandles = wecomCount > 0
+    ? await startBotsSafely(
+      appConfig.wecomBots,
+      (bot) => startWecomBot(bot, logger, appConfig.memoryServerUrl, appConfig.memory.secret || undefined),
+      logger,
+      'wecom',
     )
     : [];
 
@@ -174,11 +185,22 @@ async function main() {
     });
   }
 
+  for (const handle of wecomHandles) {
+    registry.register({
+      name: handle.name,
+      platform: 'wecom',
+      config: handle.config,
+      bridge: handle.bridge,
+      sender: handle.sender,
+    });
+  }
+
   const allNames = [
     ...feishuHandles.map((h) => h.name),
     ...telegramHandles.map((h) => h.name),
     ...appConfig.webBots.map((b) => b.name),
     ...wechatHandles.map((h) => h.name),
+    ...wecomHandles.map((h) => h.name),
   ];
   logger.info({ bots: allNames }, 'All bots started');
 
@@ -305,6 +327,10 @@ async function main() {
       handle.bridge.destroy();
       handle.stop();
     }
+    for (const handle of wecomHandles) {
+      handle.bridge.destroy();
+      handle.stop();
+    }
     process.exit(0);
   };
 
@@ -316,7 +342,7 @@ async function startBotsSafely<TConfig extends BotConfigBase, THandle>(
   bots: TConfig[],
   starter: (bot: TConfig) => Promise<THandle>,
   logger: Logger,
-  platform: 'feishu' | 'telegram' | 'wechat',
+  platform: 'feishu' | 'telegram' | 'wechat' | 'wecom',
 ): Promise<THandle[]> {
   const results = await Promise.allSettled(bots.map((bot) => starter(bot)));
   const handles: THandle[] = [];

--- a/src/wecom/wecom-bot.ts
+++ b/src/wecom/wecom-bot.ts
@@ -1,0 +1,230 @@
+import { WSClient } from '@wecom/aibot-node-sdk';
+import type { WsFrame, Logger as SdkLogger } from '@wecom/aibot-node-sdk';
+import type { WecomBotConfig, BotConfigBase } from '../config.js';
+import type { Logger } from '../utils/logger.js';
+import type { IMessageSender } from '../bridge/message-sender.interface.js';
+import type { IncomingMessage } from '../types.js';
+import { WecomSender, encodeMediaRef } from './wecom-sender.js';
+import { MessageBridge } from '../bridge/message-bridge.js';
+
+export interface WecomBotHandle {
+  name: string;
+  bridge: MessageBridge;
+  client: WSClient;
+  config: BotConfigBase;
+  sender: IMessageSender;
+  stop(): void;
+}
+
+const DEFAULT_IMAGE_TEXT = '请分析这张图片';
+const DEFAULT_FILE_TEXT = '请分析这个文件';
+const DEFAULT_VIDEO_TEXT = '请分析这个视频';
+const DEFAULT_VOICE_TEXT = '请分析这条语音消息';
+const AUTH_WAIT_MS = 15_000;
+
+/**
+ * Start a WeCom (企业微信) smart bot over the AIP WebSocket long connection.
+ *
+ * Uses the official `@wecom/aibot-node-sdk`, which handles authentication, heartbeat,
+ * exponential-backoff reconnection and AES file decryption. Incoming messages are
+ * mapped to the platform-agnostic {@link IncomingMessage} and routed through the same
+ * {@link MessageBridge} as Feishu/Telegram; streaming replies are handled by
+ * {@link WecomSender}.
+ */
+export async function startWecomBot(
+  config: WecomBotConfig,
+  logger: Logger,
+  memoryServerUrl: string,
+  memorySecret?: string,
+): Promise<WecomBotHandle> {
+  const botLogger = logger.child({ bot: config.name });
+
+  botLogger.info('Starting WeCom (企业微信) bot...');
+
+  const client = new WSClient({
+    botId: config.wecom.botId,
+    secret: config.wecom.secret,
+    ...(config.wecom.wsUrl ? { wsUrl: config.wecom.wsUrl } : {}),
+    logger: makeSdkLogger(botLogger),
+  });
+
+  const sender = new WecomSender(client, botLogger);
+  const bridge = new MessageBridge(config, botLogger, sender, memoryServerUrl, memorySecret);
+
+  // Connection lifecycle logging.
+  client.on('connected', () => botLogger.info('WeCom WebSocket connected'));
+  client.on('authenticated', () => botLogger.info('WeCom bot authenticated'));
+  client.on('disconnected', (reason: string) => botLogger.warn({ reason }, 'WeCom connection closed'));
+  client.on('reconnecting', (attempt: number) => botLogger.info({ attempt }, 'WeCom reconnecting'));
+  client.on('error', (err: Error) => botLogger.error({ err: err?.message || err }, 'WeCom client error'));
+
+  // Single dispatcher for all message types: map → bind frame → hand to bridge.
+  const dispatch = (frame: WsFrame): void => {
+    const msg = mapToIncomingMessage(frame);
+    if (!msg) return;
+    sender.bindFrame(msg.chatId, frame);
+    bridge.handleMessage(msg).catch((err) => {
+      botLogger.error({ err, msg }, 'Unhandled error in WeCom message bridge');
+    });
+  };
+  client.on('message.text', dispatch);
+  client.on('message.image', dispatch);
+  client.on('message.file', dispatch);
+  client.on('message.voice', dispatch);
+  client.on('message.video', dispatch);
+  client.on('message.mixed', dispatch);
+
+  // Greet the user on their first enter-chat event of the day.
+  client.on('event.enter_chat', (frame: WsFrame) => {
+    client
+      .replyWelcome(frame, { msgtype: 'text', text: { content: welcomeText(config) } })
+      .catch((err) => botLogger.debug({ err }, 'WeCom welcome reply failed'));
+  });
+
+  client.connect();
+
+  // Wait for authentication so startup logs are accurate, but never hang forever —
+  // the SDK keeps retrying in the background if auth is delayed.
+  await waitForAuth(client, AUTH_WAIT_MS, botLogger);
+
+  botLogger.info(
+    {
+      defaultWorkingDirectory: config.claude.defaultWorkingDirectory,
+      maxTurns: config.claude.maxTurns ?? 'unlimited',
+      maxBudgetUsd: config.claude.maxBudgetUsd ?? 'unlimited',
+    },
+    'WeCom bot is running',
+  );
+
+  return {
+    name: config.name,
+    bridge,
+    client,
+    config,
+    sender,
+    stop() {
+      client.disconnect();
+    },
+  };
+}
+
+/** Map a WeCom callback frame to the platform-agnostic IncomingMessage. */
+function mapToIncomingMessage(frame: WsFrame): IncomingMessage | undefined {
+  const body = frame.body;
+  if (!body || !body.from?.userid) return undefined;
+
+  const chatType = body.chattype === 'group' ? 'group' : 'private';
+  // Single chat replies/pushes target the user's userid; group chats target the chatid.
+  const chatId = chatType === 'group' ? body.chatid || body.from.userid : body.from.userid;
+
+  const msg: IncomingMessage = {
+    messageId: body.msgid || `${chatId}:${body.create_time || Date.now()}`,
+    chatId,
+    chatType,
+    userId: body.from.userid,
+    text: '',
+  };
+
+  switch (body.msgtype) {
+    case 'text':
+      msg.text = (body.text?.content || '').trim();
+      break;
+
+    case 'image':
+      if (body.image?.url) {
+        msg.imageKey = encodeMediaRef(body.image.aeskey, body.image.url);
+        msg.text = DEFAULT_IMAGE_TEXT;
+      }
+      break;
+
+    case 'voice':
+      // Voice is already transcribed to text by WeCom.
+      msg.text = (body.voice?.content || '').trim() || DEFAULT_VOICE_TEXT;
+      break;
+
+    case 'file':
+      if (body.file?.url) {
+        msg.fileKey = encodeMediaRef(body.file.aeskey, body.file.url);
+        msg.fileName = body.file.filename || 'file';
+        msg.text = DEFAULT_FILE_TEXT;
+      }
+      break;
+
+    case 'video':
+      if (body.video?.url) {
+        msg.fileKey = encodeMediaRef(body.video.aeskey, body.video.url);
+        msg.fileName = 'video.mp4';
+        msg.text = DEFAULT_VIDEO_TEXT;
+      }
+      break;
+
+    case 'mixed': {
+      const items: Array<{ msgtype: string; text?: { content: string }; image?: { url: string; aeskey?: string } }> =
+        body.mixed?.msg_item || [];
+      const texts: string[] = [];
+      const images: Array<{ url: string; aeskey?: string }> = [];
+      for (const item of items) {
+        if (item.msgtype === 'text' && item.text?.content) texts.push(item.text.content);
+        else if (item.msgtype === 'image' && item.image?.url) images.push(item.image);
+      }
+      msg.text = texts.join('\n').trim();
+      if (images.length > 0) {
+        msg.imageKey = encodeMediaRef(images[0].aeskey, images[0].url);
+        if (!msg.text) msg.text = DEFAULT_IMAGE_TEXT;
+        if (images.length > 1) {
+          msg.extraMedia = images.slice(1).map((im, i) => ({
+            messageId: `${msg.messageId}:${i + 1}`,
+            imageKey: encodeMediaRef(im.aeskey, im.url),
+          }));
+        }
+      }
+      break;
+    }
+
+    default:
+      return undefined;
+  }
+
+  if (!msg.text && !msg.imageKey && !msg.fileKey) return undefined;
+  return msg;
+}
+
+/** Welcome message for the enter-chat event. */
+function welcomeText(config: WecomBotConfig): string {
+  if (config.description) return config.description;
+  return '您好！我是接入 Claude Code 的智能助手，有什么可以帮您的吗？';
+}
+
+/** Resolve once the bot authenticates, or after a timeout (SDK keeps retrying either way). */
+function waitForAuth(client: WSClient, timeoutMs: number, logger: Logger): Promise<void> {
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      if (!done) {
+        logger.warn('WeCom authentication not confirmed within timeout; continuing (SDK will keep retrying)');
+        finish();
+      }
+    }, timeoutMs);
+    client.once('authenticated', finish);
+  });
+}
+
+/** Adapt the pino logger to the SDK Logger interface; SDK info is demoted to debug to reduce noise. */
+function makeSdkLogger(logger: Logger): SdkLogger {
+  const toMsg = (message: string, args: unknown[]): string =>
+    args.length === 0
+      ? String(message)
+      : `${message} ${args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}`;
+  return {
+    debug: (message: string, ...args: unknown[]) => logger.debug(toMsg(message, args)),
+    info: (message: string, ...args: unknown[]) => logger.debug(toMsg(message, args)),
+    warn: (message: string, ...args: unknown[]) => logger.warn(toMsg(message, args)),
+    error: (message: string, ...args: unknown[]) => logger.error(toMsg(message, args)),
+  };
+}

--- a/src/wecom/wecom-sender.ts
+++ b/src/wecom/wecom-sender.ts
@@ -1,0 +1,306 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { WSClient, WsFrameHeaders } from '@wecom/aibot-node-sdk';
+import type { IMessageSender } from '../bridge/message-sender.interface.js';
+import type { CardState, CardStatus } from '../types.js';
+import type { Logger } from '../utils/logger.js';
+
+/** WeCom stream content hard limit is 20480 bytes; keep a safe margin. */
+const STREAM_MAX_CHARS = 8000;
+/** Active-push markdown messages are chunked to avoid WeCom length limits. */
+const MARKDOWN_MAX_CHARS = 3500;
+/** How long to keep a finished stream mapping around (for late retries). */
+const STREAM_TTL_MS = 60_000;
+
+const STATUS_HINT: Record<CardStatus, string> = {
+  thinking: '🤔 正在思考...',
+  running: '🔧 正在处理...',
+  complete: '',
+  error: '',
+  waiting_for_input: '',
+};
+
+interface StreamEntry {
+  /** Original incoming frame (carries req_id). Undefined falls back to active push. */
+  frame: WsFrameHeaders | undefined;
+  streamId: string;
+  chatId: string;
+  /** Set once a finish=true frame was sent successfully (idempotency for retries). */
+  finished: boolean;
+}
+
+/**
+ * WeCom (企业微信) implementation of {@link IMessageSender}.
+ *
+ * Maps the bridge's `sendCard → updateCard* → final updateCard` lifecycle onto the
+ * WeCom long-connection streaming reply protocol (`aibot_respond_msg` with a shared
+ * `stream.id`): the first reply opens the stream, intermediate replies refresh its
+ * content (full replacement, not delta), and the terminal reply closes it with
+ * `finish=true`. Streaming replies are bound to the req_id of the incoming message
+ * frame, so the bot binds each frame via {@link WecomSender.bindFrame} before
+ * dispatching to the bridge.
+ *
+ * Command responses, notices, plan content and output files are delivered via the
+ * active-push channel (`aibot_send_msg`), which is not tied to an incoming frame.
+ */
+export class WecomSender implements IMessageSender {
+  /** The terminal stream frame already carries the full response — skip the extra notice. */
+  skipCompletionNotice = true;
+
+  /** messageId → stream mapping. */
+  private streams = new Map<string, StreamEntry>();
+  /** chatId → most recent incoming frame, captured at sendCard time. */
+  private boundFrames = new Map<string, WsFrameHeaders>();
+
+  constructor(
+    private client: WSClient,
+    private logger: Logger,
+  ) {}
+
+  /**
+   * Associate the latest incoming frame with a chat so the next streaming reply can
+   * reuse its req_id. Called by the bot dispatcher right before `bridge.handleMessage`.
+   */
+  bindFrame(chatId: string, frame: WsFrameHeaders): void {
+    this.boundFrames.set(chatId, frame);
+  }
+
+  async sendCard(chatId: string, state: CardState): Promise<string | undefined> {
+    const frame = this.boundFrames.get(chatId);
+    const streamId = generateStreamId();
+    const messageId = `wecom:${chatId}:${streamId}`;
+    this.streams.set(messageId, { frame, streamId, chatId, finished: false });
+
+    if (!frame) {
+      this.logger.warn({ chatId }, 'WeCom sendCard without a bound frame; will fall back to active push');
+      return messageId;
+    }
+
+    // Best-effort initial stream frame so the user sees immediate feedback.
+    // Fire-and-forget so task startup isn't blocked on the ack round-trip.
+    this.client.replyStream(frame, streamId, renderStreamContent(state), false).catch((err) => {
+      this.logger.debug({ err, chatId }, 'WeCom initial stream reply failed (will retry on update)');
+    });
+    return messageId;
+  }
+
+  async updateCard(messageId: string, state: CardState): Promise<void> {
+    const entry = this.streams.get(messageId);
+    if (!entry) {
+      this.logger.warn({ messageId }, 'Cannot update unknown WeCom stream');
+      return;
+    }
+
+    const content = renderStreamContent(state);
+    const terminal = state.status === 'complete' || state.status === 'error';
+
+    // Terminal: close the stream. Let errors propagate so MessageBridge.sendFinalCard
+    // can retry; on success mark finished so retries become no-ops.
+    if (terminal) {
+      if (entry.finished) return;
+      if (entry.frame) {
+        await this.client.replyStream(entry.frame, entry.streamId, content, true);
+      } else {
+        await this.activePush(entry.chatId, content);
+      }
+      entry.finished = true;
+      setTimeout(() => this.streams.delete(messageId), STREAM_TTL_MS);
+      return;
+    }
+
+    if (!entry.frame) return; // no channel for live updates without a frame
+
+    // Pending question must be delivered reliably → blocking reply.
+    if (state.status === 'waiting_for_input') {
+      try {
+        await this.client.replyStream(entry.frame, entry.streamId, content, false);
+      } catch (err) {
+        this.logger.debug({ err, messageId }, 'WeCom question stream update failed');
+      }
+      return;
+    }
+
+    // Intermediate progress → non-blocking (skips if a prior ack is still pending,
+    // preventing throttled progress frames from queuing up).
+    try {
+      await this.client.replyStreamNonBlocking(entry.frame, entry.streamId, content, false);
+    } catch (err) {
+      this.logger.debug({ err, messageId }, 'WeCom intermediate stream update failed');
+    }
+  }
+
+  async sendTextNotice(chatId: string, title: string, content: string, _color?: string): Promise<void> {
+    await this.sendText(chatId, `**${title}**\n\n${content}`);
+  }
+
+  async sendText(chatId: string, text: string): Promise<void> {
+    try {
+      await this.activePush(chatId, text);
+    } catch (err) {
+      this.logger.error({ err, chatId }, 'Failed to send WeCom text');
+    }
+  }
+
+  async sendImageFile(chatId: string, filePath: string): Promise<boolean> {
+    try {
+      const buffer = await fs.readFile(filePath);
+      const result = await this.client.uploadMedia(buffer, { type: 'image', filename: path.basename(filePath) });
+      await this.client.sendMediaMessage(chatId, 'image', result.media_id);
+      return true;
+    } catch (err) {
+      this.logger.error({ err, chatId, filePath }, 'Failed to send WeCom image');
+      return false;
+    }
+  }
+
+  async sendLocalFile(chatId: string, filePath: string, fileName: string): Promise<boolean> {
+    try {
+      const buffer = await fs.readFile(filePath);
+      const result = await this.client.uploadMedia(buffer, { type: 'file', filename: fileName });
+      await this.client.sendMediaMessage(chatId, 'file', result.media_id);
+      return true;
+    } catch (err) {
+      this.logger.error({ err, chatId, filePath }, 'Failed to send WeCom file');
+      return false;
+    }
+  }
+
+  async downloadImage(_messageId: string, imageKey: string, savePath: string): Promise<boolean> {
+    return this.downloadMedia(imageKey, savePath);
+  }
+
+  async downloadFile(_messageId: string, fileKey: string, savePath: string): Promise<boolean> {
+    return this.downloadMedia(fileKey, savePath);
+  }
+
+  private async downloadMedia(ref: string, savePath: string): Promise<boolean> {
+    const { url, aesKey } = decodeMediaRef(ref);
+    if (!url) return false;
+    try {
+      const { buffer } = await this.client.downloadFile(url, aesKey);
+      await fs.writeFile(savePath, buffer);
+      return true;
+    } catch (err) {
+      this.logger.error({ err, savePath }, 'Failed to download WeCom media');
+      return false;
+    }
+  }
+
+  /** Push one or more markdown messages to a chat via the active-send channel. */
+  private async activePush(chatId: string, markdown: string): Promise<void> {
+    for (const chunk of splitText(markdown, MARKDOWN_MAX_CHARS)) {
+      await this.client.sendMessage(chatId, { msgtype: 'markdown', markdown: { content: chunk } });
+    }
+  }
+}
+
+/** Encode a media reference as `aesKey|url` for later download (aesKey never contains `|`). */
+export function encodeMediaRef(aesKey: string | undefined, url: string): string {
+  return `${aesKey || ''}|${url}`;
+}
+
+/** Decode an `aesKey|url` media reference. */
+function decodeMediaRef(ref: string): { aesKey: string | undefined; url: string } {
+  const i = ref.indexOf('|');
+  if (i < 0) return { aesKey: undefined, url: ref };
+  const aesKey = ref.slice(0, i);
+  return { aesKey: aesKey || undefined, url: ref.slice(i + 1) };
+}
+
+/** Generate a unique stream id (`stream_{timestamp}_{random}`). */
+function generateStreamId(): string {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `stream_${Date.now()}_${random}`;
+}
+
+/**
+ * Render a CardState into Markdown for the WeCom stream bubble.
+ * Each call produces the full content (WeCom replaces, not appends).
+ */
+function renderStreamContent(state: CardState): string {
+  const parts: string[] = [];
+
+  // Tool-call progress (only while not yet complete).
+  if (state.toolCalls.length > 0 && state.status !== 'complete') {
+    for (const t of state.toolCalls.slice(-8)) {
+      const icon = t.status === 'done' ? '✅' : '⏳';
+      const detail = t.detail && t.detail.length > 100 ? t.detail.slice(0, 100) + '…' : t.detail;
+      parts.push(`${icon} ${t.name}${detail ? ' `' + detail + '`' : ''}`);
+    }
+    parts.push('');
+  }
+
+  // Main response text (or a status hint while still empty).
+  if (state.responseText) {
+    parts.push(state.responseText);
+  } else {
+    const hint = STATUS_HINT[state.status];
+    if (hint) parts.push(hint);
+  }
+
+  // Pending question.
+  if (state.pendingQuestion) {
+    parts.push('', '⚠️ 需要你的选择：');
+    for (const q of state.pendingQuestion.questions) {
+      parts.push('', `**${q.header}** ${q.question}`);
+      q.options.forEach((opt, i) => {
+        parts.push(`${i + 1}. ${opt.label} — ${opt.description}`);
+      });
+      parts.push(`${q.options.length + 1}. 其他（输入自定义回答）`);
+    }
+    parts.push('', '_回复数字选择，或直接输入自定义答案_');
+  }
+
+  // Error message.
+  if (state.status === 'error' && state.errorMessage) {
+    if (state.responseText) parts.push('');
+    parts.push(`❌ ${state.errorMessage}`);
+  }
+
+  // Stats footer on terminal states (replaces the skipped completion notice).
+  if (state.status === 'complete' || state.status === 'error') {
+    const stats = renderStats(state);
+    if (stats) parts.push('', `> ${stats}`);
+  }
+
+  let content = parts.join('\n').trim();
+  if (!content) content = '...'; // WeCom rejects empty stream content
+  if (content.length > STREAM_MAX_CHARS) {
+    const half = Math.floor(STREAM_MAX_CHARS / 2) - 20;
+    content = content.slice(0, half) + '\n\n…（内容过长已截断）…\n\n' + content.slice(-half);
+  }
+  return content;
+}
+
+/** Compact one-line stats: model · duration · cost · context usage. */
+function renderStats(state: CardState): string {
+  const parts: string[] = [];
+  if (state.model) parts.push(state.model.replace(/^claude-/, ''));
+  if (state.durationMs !== undefined) parts.push(`${(state.durationMs / 1000).toFixed(1)}s`);
+  const cost = state.sessionCostUsd ?? state.costUsd;
+  if (cost) parts.push(`$${cost.toFixed(3)}`);
+  if (state.totalTokens && state.contextWindow) {
+    const pct = Math.round((state.totalTokens / state.contextWindow) * 100);
+    const tokensK = state.totalTokens >= 1000 ? `${(state.totalTokens / 1000).toFixed(1)}k` : `${state.totalTokens}`;
+    parts.push(`${tokensK}/${Math.round(state.contextWindow / 1000)}k (${pct}%)`);
+  }
+  return parts.join(' · ');
+}
+
+/** Split long text on newline boundaries, never exceeding maxLen per chunk. */
+function splitText(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+    let splitAt = remaining.lastIndexOf('\n', maxLen);
+    if (splitAt < maxLen * 0.3) splitAt = maxLen;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).replace(/^\n/, '');
+  }
+  return chunks;
+}


### PR DESCRIPTION
## 概述

新增**企业微信（WeCom）智能机器人**对接，基于「智能机器人 AIP WebSocket 长连接」（`wss://openws.work.weixin.qq.com`），使用官方 `@wecom/aibot-node-sdk`。与现有的个人微信 iLink 对接（`src/wechat/`）是**相互独立的两个平台**，互不影响。

## 改动

- **`src/wecom/wecom-bot.ts`** — `startWecomBot()`：创建 SDK `WSClient`，监听 `message.*` / `event.enter_chat`，把企业微信回调帧映射为平台无关的 `IncomingMessage`，绑定 frame（用于按 `req_id` 路由流式回复），接入共享的 `MessageBridge`。
- **`src/wecom/wecom-sender.ts`** — `WecomSender implements IMessageSender`：把 bridge 的 `sendCard → updateCard* → final` 生命周期映射到企业微信流式回复（`aibot_respond_msg` + 共享 `stream.id`，全量替换内容，终态置 `finish=true`）；命令回复 / 通知 / 产出文件走主动推送 `aibot_send_msg` 兜底；AES 媒体下载与分片上传由 SDK 处理。
- **`src/config.ts`** — 新增 `WecomBotConfig`，支持环境变量（`WECOM_BOT_ID` / `WECOM_BOT_SECRET` / `WECOM_WS_URL`）与 `bots.json`（`wecomBots`）两种配置方式。
- **`src/index.ts` / `src/api/bot-registry.ts` / `src/api/bots-config-writer.ts`** — 在启动、注册表、配置 CRUD 中接入新平台 `wecom`。
- **文档** — `CLAUDE.md`、`.env.example`、`bots.example.json`。

## 配置

- 单 bot（环境变量）：`WECOM_BOT_ID` / `WECOM_BOT_SECRET`（私有化部署可选 `WECOM_WS_URL`）。
- 多 bot（`bots.json`）：`wecomBots` 数组（`wecomBotId` / `wecomSecret` / `wecomWsUrl`），可与 Feishu / Telegram 等共存。

## 测试

- 用**真实企业微信机器人**验证：长连接认证成功 + 应用完整启动注册 + 在真实企业微信组织里收发对话正常。
- `tsc` / `eslint` / `prettier`（新文件）全部通过；既有测试 175 通过（8 个失败均为 Windows 上 `skill-hub-store.test.ts` 临时目录 `EPERM` 的预先存在问题，与本 PR 无关）。

## 说明

- 流式内容按 SDK 官方示例采用「全量替换」语义；超过约 10 分钟的长任务可能超出流式窗口，终态会自动回退到主动推送以保证送达。
- 群聊场景依赖企业微信服务端的 @机器人 过滤（收到回调即处理）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
