### PR TITLE
fix(chat): enforce two-party direct-message invariant

### DIFF
--- a/packages/server/src/chat/chat-store.ts
+++ b/packages/server/src/chat/chat-store.ts
@@ -307,6 +307,9 @@ export class ChatStore {
       { kind: 'user', ref: input.createdBy, displayName: input.createdBy },
       ...input.participants,
     ]);
+    if (input.kind === 'dm' && participants.length !== 2) {
+      throw Object.assign(new Error('dm_participant_count_invalid'), { statusCode: 400 });
+    }
     const title = normalizeTitle(input.title, input.kind, participants, input.createdBy);
 
     const insert = this.db.transaction(() => {
@@ -337,6 +340,7 @@ export class ChatStore {
         JOIN chat_participants a
           ON a.conversation_id = c.id AND a.kind = 'agent' AND a.ref = ?
        WHERE c.kind = 'dm'
+         AND (SELECT COUNT(*) FROM chat_participants p WHERE p.conversation_id = c.id) = 2
        ORDER BY c.updated_at DESC
        LIMIT 1
     `).get(userRef, agentRef) as RawConversationRow | undefined;
@@ -372,6 +376,7 @@ export class ChatStore {
         JOIN chat_participants o
           ON o.conversation_id = c.id AND o.kind = 'user' AND o.ref = ?
        WHERE c.kind = 'dm'
+         AND (SELECT COUNT(*) FROM chat_participants p WHERE p.conversation_id = c.id) = 2
        ORDER BY c.updated_at DESC
        LIMIT 1
     `).get(normalizedUser, normalizedOther) as RawConversationRow | undefined;
@@ -448,11 +453,14 @@ export class ChatStore {
     participant: { kind: ChatParticipantKind; ref: string; displayName?: string },
   ): ChatParticipant {
     this.assertParticipant(conversationId, 'user', actorUserRef);
-    const conv = this.db.prepare('SELECT created_by FROM chat_conversations WHERE id = ?')
-      .get(conversationId) as { created_by: string } | undefined;
+    const conv = this.db.prepare('SELECT kind, created_by FROM chat_conversations WHERE id = ?')
+      .get(conversationId) as { kind: ChatConversationKind; created_by: string } | undefined;
     if (!conv) throw new ChatNotFoundError(conversationId);
     if (conv.created_by !== actorUserRef) {
       throw Object.assign(new Error('chat_owner_required'), { statusCode: 403 });
+    }
+    if (conv.kind === 'dm') {
+      throw Object.assign(new Error('dm_participants_immutable'), { statusCode: 409 });
     }
     const now = new Date().toISOString();
     this.db.prepare(`

--- a/packages/server/tests/chat-routes.test.ts
+++ b/packages/server/tests/chat-routes.test.ts
@@ -312,6 +312,34 @@ describe('chat routes', () => {
     expect(allowed.status).toBe(201);
   });
 
+  it('rejects invalid DM membership changes with stable errors', async () => {
+    kit = await startTestServer('chat-dm-membership', { uiAllowedEmails: ['@xvirobotics.com'] });
+
+    const invalid = await webJson(kit, 'POST', '/api/chat/conversations', ALICE, {
+      kind: 'dm',
+      participants: [
+        { kind: 'user', ref: BOB },
+        { kind: 'user', ref: 'eve@xvirobotics.com' },
+      ],
+    });
+    expect(invalid.status).toBe(400);
+    expect(JSON.parse(invalid.body).error).toBe('dm_participant_count_invalid');
+
+    const dm = await webJson(kit, 'POST', '/api/chat/conversations/user-dm', ALICE, {
+      userRef: BOB,
+    });
+    expect(dm.status).toBe(200);
+    const add = await webJson(
+      kit,
+      'POST',
+      `/api/chat/conversations/${JSON.parse(dm.body).id}/participants`,
+      ALICE,
+      { kind: 'user', ref: 'eve@xvirobotics.com' },
+    );
+    expect(add.status).toBe(409);
+    expect(JSON.parse(add.body).error).toBe('dm_participants_immutable');
+  });
+
   it('normalizes user participants to lowercase email refs', async () => {
     kit = await startTestServer('chat-user-normalize', { uiAllowedEmails: ['@xvirobotics.com'] });
     const created = await webJson(kit, 'POST', '/api/chat/conversations', ALICE, {

--- a/packages/server/tests/chat-store.test.ts
+++ b/packages/server/tests/chat-store.test.ts
@@ -110,6 +110,82 @@ describe('ChatStore', () => {
     ]);
   });
 
+  it('requires DMs to contain exactly two participants', () => {
+    kit = makeKit('chat-store-dm-participant-count');
+    const store = new ChatStore(kit.db, kit.logger);
+
+    expect(() => store.createConversation({
+      kind: 'dm',
+      createdBy: 'alice@xvirobotics.com',
+      participants: [
+        { kind: 'user', ref: 'bob@xvirobotics.com' },
+        { kind: 'agent', ref: 'metabot' },
+      ],
+    })).toThrow('dm_participant_count_invalid');
+  });
+
+  it('does not add participants to an existing DM', () => {
+    kit = makeKit('chat-store-dm-immutable');
+    const store = new ChatStore(kit.db, kit.logger);
+    const dm = store.createConversation({
+      kind: 'dm',
+      createdBy: 'alice@xvirobotics.com',
+      participants: [{ kind: 'agent', ref: 'metabot' }],
+    });
+
+    expect(() => store.addParticipant(
+      dm.id,
+      'alice@xvirobotics.com',
+      { kind: 'user', ref: 'eve@xvirobotics.com' },
+    )).toThrow('dm_participants_immutable');
+    expect(store.listParticipants(dm.id, 'alice@xvirobotics.com')).toHaveLength(2);
+  });
+
+  it('does not reuse legacy three-participant DMs', () => {
+    kit = makeKit('chat-store-legacy-dm');
+    const store = new ChatStore(kit.db, kit.logger);
+    const legacyAgentDm = store.createConversation({
+      kind: 'group',
+      createdBy: 'alice@xvirobotics.com',
+      participants: [
+        { kind: 'user', ref: 'eve@xvirobotics.com' },
+        { kind: 'agent', ref: 'metabot' },
+      ],
+    });
+    const legacyUserDm = store.createConversation({
+      kind: 'group',
+      createdBy: 'alice@xvirobotics.com',
+      participants: [
+        { kind: 'user', ref: 'bob@xvirobotics.com' },
+        { kind: 'user', ref: 'eve@xvirobotics.com' },
+      ],
+    });
+    kit.db.prepare("UPDATE chat_conversations SET kind = 'dm' WHERE id IN (?, ?)")
+      .run(legacyAgentDm.id, legacyUserDm.id);
+
+    const agentDm = store.findOrCreateAgentDm({
+      userRef: 'alice@xvirobotics.com',
+      agentRef: 'metabot',
+    });
+    const userDm = store.findOrCreateUserDm({
+      userRef: 'alice@xvirobotics.com',
+      otherUserRef: 'bob@xvirobotics.com',
+    });
+
+    expect(agentDm.id).not.toBe(legacyAgentDm.id);
+    expect(userDm.id).not.toBe(legacyUserDm.id);
+    expect(agentDm.participants).toHaveLength(2);
+    expect(userDm.participants).toHaveLength(2);
+    expect(store.findOrCreateAgentDm({
+      userRef: 'alice@xvirobotics.com',
+      agentRef: 'metabot',
+    }).id).toBe(agentDm.id);
+    expect(store.findOrCreateUserDm({
+      userRef: 'alice@xvirobotics.com',
+      otherUserRef: 'bob@xvirobotics.com',
+    }).id).toBe(userDm.id);
+  });
+
   it('persists idempotent run events and writes complete output as assistant message', () => {
     kit = makeKit('chat-store-runs');
     const store = new ChatStore(kit.db, kit.logger);

--- a/packages/web-ui/src/routes/chat.tsx
+++ b/packages/web-ui/src/routes/chat.tsx
@@ -1241,15 +1241,17 @@ export function Chat() {
                 ))}
               </div>
             </div>
-            <details className="chat-thread-settings">
-              <summary>Manage participants</summary>
-              <ParticipantManager
-                selected={selected}
-                agents={availableAgents}
-                userSuggestions={users}
-                onChanged={(conv) => void participantChanged(conv)}
-              />
-            </details>
+            {selected.kind === 'group' && (
+              <details className="chat-thread-settings">
+                <summary>Manage participants</summary>
+                <ParticipantManager
+                  selected={selected}
+                  agents={availableAgents}
+                  userSuggestions={users}
+                  onChanged={(conv) => void participantChanged(conv)}
+                />
+              </details>
+            )}
             <div className="chat-timeline">
               {!messages && <div className="state"><span className="cursor">loading</span></div>}
               {messages && messages.length === 0 && (


### PR DESCRIPTION
## Summary

- Enforce exactly two normalized participants for direct-message conversations.
- Make DM membership immutable after creation.
- Prevent legacy multi-party DMs from being reused by user or agent DM lookup.
- Hide the participant-management control for DMs while preserving it for groups.

## Problem

Generic DM creation accepted arbitrary participant counts, while DM lookup only checked that the requested pair was present. A pre-planted third participant could therefore remain in a conversation later returned by `findOrCreateAgentDm` or `findOrCreateUserDm`.

## Fix

The invariant now lives at the store boundary:

- DM creation rejects normalized participant sets whose size is not exactly two.
- `addParticipant` returns a stable conflict for DMs.
- Both DM lookup queries require an exact participant count of two.
- The central Web UI only renders participant management for group conversations.

## Scope

This PR does not change group behavior, ACLs, or the database schema. It does not delete or migrate legacy multi-party rows; those rows simply stop being selected as canonical DMs.

## Risk

Low. The change only rejects invalid DM membership states, stops legacy multi-party rows from being selected as canonical DMs, and hides a control that can no longer succeed. Group conversations and existing stored rows are unchanged.

## Validation

- New regression tests failed before the fix and pass after it.
- Targeted chat tests: 24/24 passed.
- Server tests excluding the existing macOS packaging baseline failure: 352/352 passed.
- Server build passed.
- Server lint passed with 0 errors and 3 pre-existing warnings.
- Central Web UI build passed.