### PR TITLE
fix(skills): cap decompressed reference bundle size

### DIFF
--- a/packages/server/src/skills/skill-routes.ts
+++ b/packages/server/src/skills/skill-routes.ts
@@ -10,8 +10,16 @@ export interface RouteResult {
   body: unknown;
 }
 
+const MAX_REFERENCES_DECOMPRESSED_BYTES = 10 * 1024 * 1024;
+
 function err(status: number, error: string): RouteResult {
   return { status, body: { error } };
+}
+
+function isBufferTooLargeError(error: unknown): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === 'ERR_BUFFER_TOO_LARGE';
 }
 
 export function listSkills(store: SkillStore, cred: Credential): RouteResult {
@@ -88,10 +96,12 @@ export function getSkillReferences(store: SkillStore, name: string, cred: Creden
   if (!content?.referencesTar) return err(404, 'no_references');
   let parsed: { files?: unknown };
   try {
-    parsed = JSON.parse(zlib.gunzipSync(content.referencesTar).toString('utf8')) as {
-      files?: unknown;
-    };
-  } catch {
+    const unpacked = zlib.gunzipSync(content.referencesTar, {
+      maxOutputLength: MAX_REFERENCES_DECOMPRESSED_BYTES,
+    });
+    parsed = JSON.parse(unpacked.toString('utf8')) as { files?: unknown };
+  } catch (error) {
+    if (isBufferTooLargeError(error)) return err(413, 'references_too_large');
     return err(500, 'references_corrupt');
   }
   if (!Array.isArray(parsed.files)) return err(500, 'references_corrupt');

--- a/packages/server/tests/skill-references-route.test.ts
+++ b/packages/server/tests/skill-references-route.test.ts
@@ -79,4 +79,50 @@ describe('GET /api/skills/:name/references', () => {
     expect(refs.status).toBe(404);
     expect(refs.body.error).toBe('skill_not_found');
   });
+
+  it('rejects references that expand beyond the decompressed size limit', async () => {
+    kit = await startTestServer('skill-refs-too-large');
+
+    const issue = await call(kit.baseUrl, 'POST', '/admin/credentials/issue', kit.adminToken, {
+      botName: 'refs-bot', ownerName: 'refs-owner', role: 'member', publishSkill: true,
+    });
+    const memberToken = issue.body.token as string;
+
+    // Highly compressible input keeps the request fixture small while crossing
+    // the 10 MiB decompressed-output boundary by a single byte.
+    const referencesTar = zlib
+      .gzipSync(Buffer.alloc(10 * 1024 * 1024 + 1))
+      .toString('base64');
+    const pub = await call(kit.baseUrl, 'POST', '/api/skills/oversized-refs/publish', memberToken, {
+      skillMd: `---\nname: oversized-refs\ndescription: oversized refs\n---\nbody`,
+      referencesTar,
+      visibility: 'published',
+    });
+    expect(pub.status).toBe(201);
+
+    const refs = await call(kit.baseUrl, 'GET', '/api/skills/oversized-refs/references', memberToken);
+    expect(refs.status).toBe(413);
+    expect(refs.body.error).toBe('references_too_large');
+  });
+
+  it('keeps reporting malformed gzip payloads as corrupt references', async () => {
+    kit = await startTestServer('skill-refs-corrupt');
+
+    const issue = await call(kit.baseUrl, 'POST', '/admin/credentials/issue', kit.adminToken, {
+      botName: 'refs-bot', ownerName: 'refs-owner', role: 'member', publishSkill: true,
+    });
+    const memberToken = issue.body.token as string;
+    const referencesTar = Buffer.from('not a gzip payload').toString('base64');
+
+    const pub = await call(kit.baseUrl, 'POST', '/api/skills/corrupt-refs/publish', memberToken, {
+      skillMd: `---\nname: corrupt-refs\ndescription: corrupt refs\n---\nbody`,
+      referencesTar,
+      visibility: 'published',
+    });
+    expect(pub.status).toBe(201);
+
+    const refs = await call(kit.baseUrl, 'GET', '/api/skills/corrupt-refs/references', memberToken);
+    expect(refs.status).toBe(500);
+    expect(refs.body.error).toBe('references_corrupt');
+  });
 });


### PR DESCRIPTION
## Summary

- Cap decompressed Skill reference bundles at 10 MiB.
- Return a stable `413 references_too_large` response when the cap is exceeded.
- Preserve the existing `500 references_corrupt` behavior for malformed gzip or JSON content.

## Problem

The publish endpoint limits the compressed HTTP body, but the references read path used synchronous `gunzipSync` without an output limit. A small, highly compressible bundle from any authenticated publisher could expand to a much larger allocation and block or exhaust the server process.

## Fix

Pass `maxOutputLength: 10 MiB` to `gunzipSync` and map Node `ERR_BUFFER_TOO_LARGE` to a dedicated route error. Normal bundles at or below the limit keep their current response shape.

## Scope

This PR does not change the publish protocol, database schema, storage format, or add configuration. It intentionally keeps the existing synchronous read path and applies one explicit safety bound.

## Risk

Low. Bundles at or below 10 MiB keep the existing response shape. Only oversized decompressed content now receives a dedicated 413 response; malformed content retains its previous error behavior.

## Validation

- Oversized high-compression and malformed-gzip regressions added.
- Targeted Skill references tests: 5/5 passed.
- Server tests excluding the existing macOS packaging baseline failure: 350/350 passed.
- Server build passed.
- Root lint passed with 0 errors and 8 pre-existing warnings.
- Node 20 and Node 22 both report the capped path as `ERR_BUFFER_TOO_LARGE`.