### PR TITLE
fix(security): prevent managed file path traversal

### DIFF
--- a/src/api/routes/file-routes.ts
+++ b/src/api/routes/file-routes.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import type * as http from 'node:http';
 import { jsonResponse, escapeHtml, wrapPreviewHtml } from './helpers.js';
 import type { RouteContext } from './types.js';
+import { resolveWithinRoot } from '../../utils/managed-path.js';
 
 export async function handleFileRoutes(
   ctx: RouteContext,
@@ -39,11 +40,19 @@ export async function handleFileRoutes(
     const originalName = urlObj.searchParams.get('filename') || 'upload';
     const chatId = urlObj.searchParams.get('chatId') || 'web';
 
-    const uploadDir = path.join(os.tmpdir(), 'metabot-uploads', chatId);
-    fs.mkdirSync(uploadDir, { recursive: true });
-
+    const uploadsRoot = path.resolve(path.join(os.tmpdir(), 'metabot-uploads'));
+    const uploadDir = resolveWithinRoot(uploadsRoot, chatId);
+    if (!uploadDir || uploadDir === uploadsRoot) {
+      jsonResponse(res, 400, { error: 'Invalid chatId' });
+      return true;
+    }
     const safeName = originalName.replace(/[^a-zA-Z0-9._\-\u4e00-\u9fff]/g, '_');
-    const filePath = path.join(uploadDir, safeName);
+    const filePath = resolveWithinRoot(uploadDir, safeName);
+    if (!filePath || filePath === uploadDir) {
+      jsonResponse(res, 400, { error: 'Invalid filename' });
+      return true;
+    }
+    fs.mkdirSync(uploadDir, { recursive: true });
     fs.writeFileSync(filePath, buffer);
 
     logger.info({ chatId, filename: safeName, size: buffer.length }, 'File uploaded');
@@ -54,10 +63,10 @@ export async function handleFileRoutes(
   // GET /api/files/preview/<chatId>/<filename> — convert docx/xlsx to HTML
   if (method === 'GET' && url.startsWith('/api/files/preview/')) {
     const filePart = decodeURIComponent(url.slice('/api/files/preview/'.length).split('?')[0]);
-    const fullPath = path.resolve(path.join(os.tmpdir(), 'metabot-uploads', filePart));
     const uploadsRoot = path.resolve(path.join(os.tmpdir(), 'metabot-uploads'));
+    const fullPath = resolveWithinRoot(uploadsRoot, filePart);
 
-    if (!fullPath.startsWith(uploadsRoot)) {
+    if (!fullPath) {
       res.writeHead(403, { 'Content-Type': 'text/plain' });
       res.end('Forbidden');
       return true;
@@ -125,10 +134,10 @@ export async function handleFileRoutes(
   // GET /api/files/<chatId>/<filename> — serve uploaded files
   if (method === 'GET' && url.startsWith('/api/files/')) {
     const filePart = decodeURIComponent(url.slice('/api/files/'.length).split('?')[0]);
-    const fullPath = path.resolve(path.join(os.tmpdir(), 'metabot-uploads', filePart));
     const uploadsRoot = path.resolve(path.join(os.tmpdir(), 'metabot-uploads'));
+    const fullPath = resolveWithinRoot(uploadsRoot, filePart);
 
-    if (!fullPath.startsWith(uploadsRoot)) {
+    if (!fullPath) {
       res.writeHead(403, { 'Content-Type': 'text/plain' });
       res.end('Forbidden');
       return true;

--- a/src/bridge/outputs-manager.ts
+++ b/src/bridge/outputs-manager.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Logger } from '../utils/logger.js';
+import { resolveWithinRoot } from '../utils/managed-path.js';
 
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.tiff']);
 
@@ -26,7 +27,11 @@ export class OutputsManager {
 
   /** Create a fresh per-chat outputs directory, preserving recent files. */
   prepareDir(chatId: string): string {
-    const dir = path.join(this.baseDir, chatId);
+    const root = path.resolve(this.baseDir);
+    const dir = resolveWithinRoot(root, chatId);
+    if (!dir || dir === root) {
+      throw new Error('Output path is outside the outputs root');
+    }
 
     // Cancel any pending deferred cleanup for this directory
     const pending = this.pendingCleanups.get(dir);
@@ -65,6 +70,14 @@ export class OutputsManager {
   /** Scan the outputs directory and return metadata for each file found. */
   scanOutputs(outputsDir: string): OutputFile[] {
     const results: OutputFile[] = [];
+    const root = path.resolve(this.baseDir);
+    const managedDir = resolveWithinRoot(root, outputsDir);
+    if (!managedDir || managedDir === root) {
+      this.logger.warn({ outputsDir }, 'Refusing to scan outside the outputs root');
+      return results;
+    }
+    outputsDir = managedDir;
+
     try {
       if (!fs.existsSync(outputsDir)) return results;
       const entries = fs.readdirSync(outputsDir, { withFileTypes: true });
@@ -90,6 +103,14 @@ export class OutputsManager {
 
   /** Schedule deferred cleanup of the outputs directory after RETENTION_MS. */
   cleanup(outputsDir: string): void {
+    const root = path.resolve(this.baseDir);
+    const managedDir = resolveWithinRoot(root, outputsDir);
+    if (!managedDir || managedDir === root) {
+      this.logger.warn({ outputsDir }, 'Refusing to clean up outside the outputs root');
+      return;
+    }
+    outputsDir = managedDir;
+
     // Cancel any existing timer for this dir
     const existing = this.pendingCleanups.get(outputsDir);
     if (existing) clearTimeout(existing);

--- a/src/utils/managed-path.ts
+++ b/src/utils/managed-path.ts
@@ -1,0 +1,14 @@
+import * as path from 'node:path';
+
+/** Resolve a path only when it stays inside the managed root. */
+export function resolveWithinRoot(root: string, ...parts: string[]): string | undefined {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, ...parts);
+  const relative = path.relative(resolvedRoot, resolvedPath);
+
+  if (relative === '') return resolvedPath;
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    return undefined;
+  }
+  return resolvedPath;
+}

--- a/src/web/ws-server.ts
+++ b/src/web/ws-server.ts
@@ -12,6 +12,7 @@ import { ChatSubscriptionManager } from './chat-subscriptions.js';
 import { GroupManager, type ChatGroup } from './group-manager.js';
 import { StreamingASRSession, createStreamingASRSession, isStreamingASRAvailable } from '../api/streaming-asr.js';
 import type { SessionRegistry, SessionRecord, SessionMessage } from '../session/session-registry.js';
+import { resolveWithinRoot } from '../utils/managed-path.js';
 
 // ─── Timing-safe secret comparison ─────────────────────────────────────────
 
@@ -539,11 +540,20 @@ async function handleChat(
       onOutputFiles: (files) => {
         if (ws.readyState !== WebSocket.OPEN) return;
         // Copy output files to uploads dir so they're accessible via /api/files/
-        const uploadsDir = path.join(os.tmpdir(), 'metabot-uploads', chatId);
+        const uploadsRoot = path.resolve(path.join(os.tmpdir(), 'metabot-uploads'));
+        const uploadsDir = resolveWithinRoot(uploadsRoot, chatId);
+        if (!uploadsDir || uploadsDir === uploadsRoot) {
+          logger.warn({ chatId }, 'Refusing to copy output files outside the uploads root');
+          return;
+        }
         fs.mkdirSync(uploadsDir, { recursive: true });
         for (const file of files) {
           try {
-            const destPath = path.join(uploadsDir, file.fileName);
+            const destPath = resolveWithinRoot(uploadsDir, file.fileName);
+            if (!destPath || destPath === uploadsDir) {
+              logger.warn({ file: file.fileName }, 'Refusing to copy output file outside the chat uploads directory');
+              continue;
+            }
             fs.copyFileSync(file.filePath, destPath);
             const ext = file.extension.replace('.', '');
             const mimeMap: Record<string, string> = {

--- a/tests/file-routes.test.ts
+++ b/tests/file-routes.test.ts
@@ -1,0 +1,121 @@
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleFileRoutes } from '../src/api/routes/file-routes.js';
+import type { RouteContext } from '../src/api/routes/types.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as any;
+
+function makeReq(body = ''): any {
+  const req = new EventEmitter() as any;
+  req.headers = { host: 'localhost' };
+  req.destroy = vi.fn();
+  process.nextTick(() => {
+    if (body) req.emit('data', Buffer.from(body));
+    req.emit('end');
+  });
+  return req;
+}
+
+function makeRes(): any {
+  return {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: Buffer.alloc(0),
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+    },
+    end(body?: string | Buffer) {
+      this.body = Buffer.isBuffer(body) ? body : Buffer.from(body || '');
+    },
+    json() {
+      return JSON.parse(this.body.toString('utf8'));
+    },
+  };
+}
+
+describe('handleFileRoutes managed paths', () => {
+  const uploadsRoot = path.join(os.tmpdir(), 'metabot-uploads');
+  let siblingDir: string;
+  let chatId: string;
+
+  const ctx = { logger } as RouteContext;
+
+  beforeEach(() => {
+    siblingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metabot-uploads-outside-'));
+    chatId = `file-routes-${path.basename(siblingDir)}`;
+  });
+
+  afterEach(() => {
+    fs.rmSync(siblingDir, { recursive: true, force: true });
+    fs.rmSync(path.join(uploadsRoot, chatId), { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('rejects upload chat IDs that escape the uploads root', async () => {
+    const escapedChatId = `../${path.basename(siblingDir)}`;
+    const res = makeRes();
+
+    const handled = await handleFileRoutes(
+      ctx,
+      makeReq('attacker-controlled'),
+      res,
+      'POST',
+      `/api/upload?filename=written.txt&chatId=${encodeURIComponent(escapedChatId)}`,
+    );
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(fs.existsSync(path.join(siblingDir, 'written.txt'))).toBe(false);
+  });
+
+  it('rejects file reads from a sibling directory with the same path prefix', async () => {
+    fs.writeFileSync(path.join(siblingDir, 'secret.txt'), 'outside secret');
+    const filePart = `../${path.basename(siblingDir)}/secret.txt`;
+    const res = makeRes();
+
+    await handleFileRoutes(ctx, makeReq(), res, 'GET', `/api/files/${encodeURIComponent(filePart)}`);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.toString('utf8')).toBe('Forbidden');
+  });
+
+  it('rejects preview reads from a sibling directory with the same path prefix', async () => {
+    fs.writeFileSync(path.join(siblingDir, 'secret.docx'), 'outside secret');
+    const filePart = `../${path.basename(siblingDir)}/secret.docx`;
+    const res = makeRes();
+
+    await handleFileRoutes(ctx, makeReq(), res, 'GET', `/api/files/preview/${encodeURIComponent(filePart)}`);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.toString('utf8')).toBe('Forbidden');
+  });
+
+  it('keeps legitimate upload and file reads working', async () => {
+    const uploadRes = makeRes();
+    await handleFileRoutes(
+      ctx,
+      makeReq('hello'),
+      uploadRes,
+      'POST',
+      `/api/upload?filename=hello.txt&chatId=${encodeURIComponent(chatId)}`,
+    );
+
+    expect(uploadRes.statusCode).toBe(200);
+    expect(uploadRes.json()).toMatchObject({ filename: 'hello.txt', size: 5 });
+
+    const readRes = makeRes();
+    await handleFileRoutes(ctx, makeReq(), readRes, 'GET', `/api/files/${encodeURIComponent(chatId)}/hello.txt`);
+
+    expect(readRes.statusCode).toBe(200);
+    expect(readRes.body.toString('utf8')).toBe('hello');
+  });
+});

--- a/tests/outputs-manager.test.ts
+++ b/tests/outputs-manager.test.ts
@@ -12,16 +12,20 @@ const mockLogger = {
 } as any;
 
 describe('OutputsManager', () => {
+  let testRoot: string;
   let tmpDir: string;
   let manager: OutputsManager;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metabot-test-'));
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'metabot-test-'));
+    tmpDir = path.join(testRoot, 'outputs');
+    fs.mkdirSync(tmpDir);
     manager = new OutputsManager(tmpDir, mockLogger);
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.useRealTimers();
+    fs.rmSync(testRoot, { recursive: true, force: true });
   });
 
   describe('prepareDir', () => {
@@ -49,11 +53,35 @@ describe('OutputsManager', () => {
       const dir2 = manager.prepareDir('chat-123');
       expect(fs.readdirSync(dir2)).not.toContain('old.txt');
     });
+
+    it('rejects chat IDs that escape the outputs root', () => {
+      const outsideDir = path.join(testRoot, 'outside');
+      fs.mkdirSync(outsideDir);
+      const outsideFile = path.join(outsideDir, 'old.txt');
+      fs.writeFileSync(outsideFile, 'must remain');
+      const oldTime = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(outsideFile, oldTime, oldTime);
+
+      expect(() => manager.prepareDir('../outside')).toThrow(/outside the outputs root/i);
+      expect(fs.readFileSync(outsideFile, 'utf8')).toBe('must remain');
+    });
+
+    it('rejects chat IDs that resolve to the outputs root itself', () => {
+      expect(() => manager.prepareDir('.')).toThrow(/outside the outputs root/i);
+    });
   });
 
   describe('scanOutputs', () => {
     it('returns empty for non-existent directory', () => {
       expect(manager.scanOutputs('/nonexistent')).toEqual([]);
+    });
+
+    it('does not scan files outside the outputs root', () => {
+      const outsideDir = path.join(testRoot, 'outside');
+      fs.mkdirSync(outsideDir);
+      fs.writeFileSync(path.join(outsideDir, 'secret.txt'), 'must not be returned');
+
+      expect(manager.scanOutputs(outsideDir)).toEqual([]);
     });
 
     it('detects image files', () => {
@@ -122,6 +150,18 @@ describe('OutputsManager', () => {
 
     it('handles non-existent directory gracefully', () => {
       expect(() => manager.cleanup('/nonexistent/path')).not.toThrow();
+    });
+
+    it('does not schedule cleanup outside the outputs root', () => {
+      vi.useFakeTimers();
+      const outsideDir = path.join(testRoot, 'outside');
+      fs.mkdirSync(outsideDir);
+      fs.writeFileSync(path.join(outsideDir, 'keep.txt'), 'must remain');
+
+      manager.cleanup(outsideDir);
+      vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+
+      expect(fs.readFileSync(path.join(outsideDir, 'keep.txt'), 'utf8')).toBe('must remain');
     });
   });
 


### PR DESCRIPTION
## Problem

Several file paths derived from client-controlled values were not constrained to their managed roots:

- upload chat IDs could escape the temporary uploads directory
- file and preview reads used a string-prefix check that accepted sibling directories with the same prefix
- output scanning and deferred cleanup accepted arbitrary paths, so cleanup could recursively remove an external directory
- WebSocket output copying repeated the unsafe chat ID path construction

## Root cause

The affected paths used path joining or string-prefix checks instead of a path-aware containment check. A sibling such as metabot-uploads-outside passes startsWith(metabot-uploads), while .. segments can escape joined directories.

## Fix

- add one shared resolveWithinRoot helper based on path.resolve/path.relative
- reject upload chat IDs and filenames that resolve to the upload root or outside it
- require file download and preview targets to remain inside the uploads root
- require output scan/cleanup targets and WebSocket copy destinations to remain strict managed subdirectories
- add regression coverage for traversal, same-prefix bypass, external cleanup, and the valid upload/read flow

This intentionally does not change the /api/files authentication model, introduce signed URLs, or restructure file storage. Existing valid chat IDs keep the same paths and responses.

## Risk

Low. Only paths resolving to a managed root itself or outside it are newly rejected. Valid paths use the same on-disk locations. No migration is required.

## Verification

- npm run build:bridge
- targeted Vitest suite: 69 tests passed
- npm run lint: 0 errors (8 pre-existing warnings)
- npm run build: TypeScript, both Vite apps, and CLI packaging pass; the unmodified macOS pack-metabot.sh still hits its known EXTRA_TAR_ARGS unbound-variable issue
- npm test: 1,034 tests pass; the command fails only when the unmodified pack-metabot suite cannot find the tarball omitted by that same packaging issue