### PR TITLE
fix(installer): persist the selected engine for every bot platform

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -826,12 +826,13 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
       const engine = process.argv[5];
       const bot = {
         name: process.argv[1],
+        engine,
         feishuAppId: process.argv[2],
         feishuAppSecret: process.argv[3],
         defaultWorkingDirectory: process.argv[4],
       };
-      if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
-      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
+      if (engine === 'kimi') { bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$BOT_NAME" "$FEISHU_APP_ID" "$FEISHU_APP_SECRET" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -843,11 +844,12 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
       const engine = process.argv[4];
       const bot = {
         name: process.argv[1],
+        engine,
         telegramBotToken: process.argv[2],
         defaultWorkingDirectory: process.argv[3],
       };
-      if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
-      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
+      if (engine === 'kimi') { bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$TG_NAME" "$TELEGRAM_BOT_TOKEN" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -860,10 +862,11 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
       const engine = process.argv[3];
       const bot = {
         name: process.argv[1],
+        engine,
         defaultWorkingDirectory: process.argv[2],
       };
-      if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
-      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
+      if (engine === 'kimi') { bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$WX_NAME" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi

--- a/tests/install-engine-selection.test.ts
+++ b/tests/install-engine-selection.test.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const INSTALL_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf-8');
+
+function extractGenerator(variable: string): string {
+  const marker = `${variable}=$(node -e "`;
+  const start = INSTALL_SOURCE.indexOf(marker);
+  if (start === -1) throw new Error(`Missing ${variable} generator in install.sh`);
+
+  const bodyStart = start + marker.length;
+  const bodyEnd = INSTALL_SOURCE.indexOf('\n    " ', bodyStart);
+  if (bodyEnd === -1) throw new Error(`Missing end of ${variable} generator in install.sh`);
+  return INSTALL_SOURCE.slice(bodyStart, bodyEnd);
+}
+
+const platforms = [
+  {
+    name: 'Feishu',
+    generator: extractGenerator('FEISHU_BOTS_JSON'),
+    args: ['bot', 'cli_test', 'secret', '/workspace'],
+  },
+  {
+    name: 'Telegram',
+    generator: extractGenerator('TELEGRAM_BOTS_JSON'),
+    args: ['bot', 'telegram-token', '/workspace'],
+  },
+  {
+    name: 'WeChat',
+    generator: extractGenerator('WECHAT_BOTS_JSON'),
+    args: ['bot', '/workspace'],
+  },
+] as const;
+
+function generateBot(generator: string, args: readonly string[], engine: string): Record<string, unknown> {
+  const output = execFileSync(process.execPath, ['-e', generator, ...args, engine], { encoding: 'utf-8' });
+  return JSON.parse(output)[0] as Record<string, unknown>;
+}
+
+describe('interactive installer engine selection', () => {
+  for (const platform of platforms) {
+    it(`${platform.name} persists Claude explicitly`, () => {
+      const bot = generateBot(platform.generator, platform.args, 'claude');
+
+      expect(bot.engine).toBe('claude');
+      expect(bot.kimi).toBeUndefined();
+      expect(bot.codex).toBeUndefined();
+    });
+
+    it(`${platform.name} preserves Kimi defaults`, () => {
+      const bot = generateBot(platform.generator, platform.args, 'kimi');
+
+      expect(bot.engine).toBe('kimi');
+      expect(bot.kimi).toEqual({ thinking: true });
+      expect(bot.codex).toBeUndefined();
+    });
+
+    it(`${platform.name} preserves Codex defaults`, () => {
+      const bot = generateBot(platform.generator, platform.args, 'codex');
+
+      expect(bot.engine).toBe('codex');
+      expect(bot.codex).toEqual({ approvalPolicy: 'never', sandbox: 'workspace-write' });
+      expect(bot.kimi).toBeUndefined();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Always persist the selected engine in generated Feishu, Telegram, and WeChat bot entries.
- Preserve the existing Kimi thinking and Codex approval/sandbox defaults.
- Add executable regression coverage for all three platforms and all three engines.

## Problem

The interactive installer defaults `BOT_ENGINE` to Claude, but generated `bots.json` entries only persisted `engine` for Kimi and Codex. Since the runtime fallback is now Codex, a user who selected and authenticated Claude could silently launch the wrong engine.

## Fix

Each inline JSON generator now writes the resolved `engine` directly into the bot object. Engine-specific settings remain conditional and unchanged.

## Scope

This PR does not change runtime engine defaults, the interactive prompts, download authentication, update behavior, or platform packaging.

## Risk

Low. This makes the installer existing user choice explicit in generated configuration. Kimi and Codex platform-specific defaults remain unchanged, and the runtime fallback is not modified.

## Validation

- Added 9 regression cases that execute the installer's actual JSON generators across 3 platforms x 3 engines.
- Before the fix, all 3 Claude cases failed while the Kimi/Codex cases passed.
- After the fix, all 9/9 cases pass.
- `bash -n install.sh` passed.
- Root lint passed with 0 errors and 8 pre-existing warnings.
- Full local build/test reached only the existing macOS `pack-metabot.sh` baseline failure; all preceding build stages and 1,035 executed tests passed.