### PR TITLE
fix(bridge): 回合开始清空发送暂存目录，避免重发上一轮产物

### DIFF
--- a/src/bridge/outputs-manager.ts
+++ b/src/bridge/outputs-manager.ts
@@ -25,7 +25,7 @@ export class OutputsManager {
     private logger: Logger,
   ) {}
 
-  /** Create a fresh per-chat outputs directory, preserving recent files. */
+  /** Create a fresh (empty) per-chat outputs directory for the upcoming turn. */
   prepareDir(chatId: string): string {
     const root = path.resolve(this.baseDir);
     const dir = resolveWithinRoot(root, chatId);
@@ -40,19 +40,17 @@ export class OutputsManager {
       this.pendingCleanups.delete(dir);
     }
 
-    // Only remove files older than RETENTION_MS, keep recent ones
+    // Start the turn with an empty send dir. Any file still here is a leftover
+    // from a previous turn (already delivered); keeping it would make this turn
+    // re-send it — the duplicate-image bug. Turns are serialized per chat, so
+    // nothing here belongs to an in-flight turn — safe to remove all files.
     try {
       if (fs.existsSync(dir)) {
-        const now = Date.now();
         const entries = fs.readdirSync(dir, { withFileTypes: true });
         for (const entry of entries) {
           if (!entry.isFile()) continue;
-          const filePath = path.join(dir, entry.name);
           try {
-            const stat = fs.statSync(filePath);
-            if (now - stat.mtimeMs > RETENTION_MS) {
-              fs.unlinkSync(filePath);
-            }
+            fs.unlinkSync(path.join(dir, entry.name));
           } catch { /* ignore individual file errors */ }
         }
       } else {

--- a/tests/outputs-manager.test.ts
+++ b/tests/outputs-manager.test.ts
@@ -35,12 +35,12 @@ describe('OutputsManager', () => {
       expect(dir).toBe(path.join(tmpDir, 'chat-123'));
     });
 
-    it('keeps recent files in existing directory', () => {
+    it('clears leftover files from previous turn', () => {
       const dir = manager.prepareDir('chat-123');
       fs.writeFileSync(path.join(dir, 'recent.txt'), 'recent content');
       const dir2 = manager.prepareDir('chat-123');
-      // Recent files should be preserved (within retention window)
-      expect(fs.readdirSync(dir2)).toContain('recent.txt');
+      // Leftovers were already delivered last turn; keeping them would re-send
+      expect(fs.readdirSync(dir2)).not.toContain('recent.txt');
     });
 
     it('removes old files beyond retention window', () => {


### PR DESCRIPTION
## 问题
`sendOutputFiles` 会把 per-chat 发送暂存目录里的所有文件全部发出，而 `prepareDir` 在回合开始时只清理超过 RETENTION_MS（5 分钟）的旧文件。用户收到产物后 5 分钟内再发任意一句话，上一轮已投递的文件仍留在目录里，会连同新内容一起被重复发送。实测同一图片被连续重发 5 次。

## 修复
回合在同一 chat 内是串行的，回合开始时目录里的文件只可能是上一轮已投递的残留 → `prepareDir` 改为清空目录中全部文件。`cleanup()` 的 RETENTION_MS 延迟清理行为不变，与 #333 引入的 `resolveWithinRoot` 校验兼容（校验在前、清空在后）。

## 测试
- 更新 `prepareDir` 单测断言（上一轮残留应被清空）
- `vitest run` 全量 611 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
