### PR TITLE
fix(feishu): 按 message_id 去重 webhook 消息事件，防止重投递被重复处理

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/haoyan/metabot/node_modules

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -75,30 +75,58 @@ function clearCachedMedia(chatId: string, userId: string): void {
 const PROCESSED_MSG_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const PROCESSED_MSG_MAX_ENTRIES = 500;
 
+export interface MessageDeduper {
+  /** True when messageId was already seen within the TTL; records it otherwise. */
+  isDuplicate(messageId: string): boolean;
+  /**
+   * Forget a messageId after a failed processing attempt, so a Feishu
+   * redelivery of the same event gets a fresh attempt instead of being
+   * dropped as a duplicate.
+   */
+  release(messageId: string): void;
+}
+
 /**
- * Create a per-dispatcher message dedup checker. Per-dispatcher (rather than
+ * Create a per-dispatcher message deduper. Per-dispatcher (rather than
  * module-level) state so that two bots receiving events for the same
  * message_id (e.g. one group message @-mentioning both bots) don't suppress
- * each other. Returns true when messageId was already seen within the TTL,
- * and records it otherwise.
+ * each other.
+ *
+ * Memory is hard-bounded: `maxEntries` is an invariant, not a cleanup hint.
+ * On insert when the map is full, expired entries are swept first; if still
+ * full, the oldest entries are evicted regardless of TTL. Entries are deleted
+ * before re-insert on expiry, so Map iteration order stays first-seen order
+ * and "oldest" is well-defined. Evicting a live entry trades a sliver of
+ * dedup coverage (an extremely late redelivery of an evicted id would be
+ * reprocessed) for a guaranteed memory ceiling.
  */
 export function createMessageDeduper(
   ttlMs: number = PROCESSED_MSG_TTL_MS,
   maxEntries: number = PROCESSED_MSG_MAX_ENTRIES,
-): (messageId: string) => boolean {
+): MessageDeduper {
   const seen = new Map<string, number>(); // messageId -> first-seen ts
-  return (messageId) => {
-    const now = Date.now();
-    // Opportunistic cleanup of stale entries to bound memory
-    if (seen.size > maxEntries) {
-      for (const [id, ts] of seen) {
-        if (now - ts > ttlMs) seen.delete(id);
+  return {
+    isDuplicate(messageId) {
+      const now = Date.now();
+      const ts = seen.get(messageId);
+      if (ts !== undefined && now - ts < ttlMs) return true;
+      if (ts !== undefined) seen.delete(messageId); // expired: re-insert below so recency order holds
+      if (seen.size >= maxEntries) {
+        for (const [id, t] of seen) {
+          if (now - t >= ttlMs) seen.delete(id);
+        }
+        while (seen.size >= maxEntries) {
+          const oldest = seen.keys().next().value;
+          if (oldest === undefined) break;
+          seen.delete(oldest);
+        }
       }
-    }
-    const ts = seen.get(messageId);
-    if (ts !== undefined && now - ts < ttlMs) return true;
-    seen.set(messageId, now);
-    return false;
+      seen.set(messageId, now);
+      return false;
+    },
+    release(messageId) {
+      seen.delete(messageId);
+    },
   };
 }
 
@@ -228,7 +256,7 @@ export function createEventDispatcher(
   onGroupReplyModeNotice?: GroupReplyModeNoticeHandler,
 ): lark.EventDispatcher {
   const dispatcher = new lark.EventDispatcher({});
-  const isDuplicateMessage = createMessageDeduper();
+  const messageDeduper = createMessageDeduper();
 
   // Register the card action trigger handler (fired when a user clicks a button
   // on an interactive card). The lark SDK types omit this event so we cast.
@@ -268,6 +296,9 @@ export function createEventDispatcher(
 
   dispatcher.register({
     'im.message.receive_v1': async (data: any) => {
+      // Set once this delivery is recorded in the deduper; released in the
+      // catch below so a failed attempt doesn't suppress the redelivery.
+      let inflightMessageId: string | undefined;
       try {
         const event = data;
         const message = event.message;
@@ -292,11 +323,14 @@ export function createEventDispatcher(
         const messageId = message.message_id;
 
         // Drop redelivered events: Feishu retries delivery when the ack is
-        // slow, and a retry must not become a second task.
-        if (messageId && isDuplicateMessage(messageId)) {
+        // slow, and a retry must not become a second task. Intentional drops
+        // further down (not @mentioned, empty text, ...) keep the mark — they
+        // are terminal decisions and a redelivery must be dropped the same way.
+        if (messageId && messageDeduper.isDuplicate(messageId)) {
           logger.debug({ messageId, msgType }, 'Duplicate message delivery ignored');
           return;
         }
+        inflightMessageId = messageId;
 
         const mentions = message.mentions;
 
@@ -481,6 +515,10 @@ export function createEventDispatcher(
 
         onMessage({ messageId, chatId, chatType, userId, text, imageKey, fileKey, fileName, extraMedia });
       } catch (err) {
+        // The message never reached a successful hand-off: forget the dedup
+        // mark so a Feishu redelivery gets processed instead of being dropped
+        // as a duplicate (otherwise a transient failure loses the message).
+        if (inflightMessageId) messageDeduper.release(inflightMessageId);
         logger.error({ err }, 'Error handling message event');
       }
     },

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -68,6 +68,40 @@ function clearCachedMedia(chatId: string, userId: string): void {
   pendingMediaCache.delete(cacheMediaKey(chatId, userId));
 }
 
+// Feishu delivers webhook events at-least-once: when the handler is slow to
+// ack (e.g. a long-running task or media download), the same message event is
+// redelivered. Track recently seen message_ids so retries are dropped instead
+// of being processed as new messages.
+const PROCESSED_MSG_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const PROCESSED_MSG_MAX_ENTRIES = 500;
+
+/**
+ * Create a per-dispatcher message dedup checker. Per-dispatcher (rather than
+ * module-level) state so that two bots receiving events for the same
+ * message_id (e.g. one group message @-mentioning both bots) don't suppress
+ * each other. Returns true when messageId was already seen within the TTL,
+ * and records it otherwise.
+ */
+export function createMessageDeduper(
+  ttlMs: number = PROCESSED_MSG_TTL_MS,
+  maxEntries: number = PROCESSED_MSG_MAX_ENTRIES,
+): (messageId: string) => boolean {
+  const seen = new Map<string, number>(); // messageId -> first-seen ts
+  return (messageId) => {
+    const now = Date.now();
+    // Opportunistic cleanup of stale entries to bound memory
+    if (seen.size > maxEntries) {
+      for (const [id, ts] of seen) {
+        if (now - ts > ttlMs) seen.delete(id);
+      }
+    }
+    const ts = seen.get(messageId);
+    if (ts !== undefined && now - ts < ttlMs) return true;
+    seen.set(messageId, now);
+    return false;
+  };
+}
+
 async function isPrivateLikeGroup(chatId: string, sender: MessageSender): Promise<boolean> {
   const cached = memberCountCache.get(chatId);
   if (cached && Date.now() - cached.ts < MEMBER_COUNT_CACHE_TTL_MS) {
@@ -194,6 +228,7 @@ export function createEventDispatcher(
   onGroupReplyModeNotice?: GroupReplyModeNoticeHandler,
 ): lark.EventDispatcher {
   const dispatcher = new lark.EventDispatcher({});
+  const isDuplicateMessage = createMessageDeduper();
 
   // Register the card action trigger handler (fired when a user clicks a button
   // on an interactive card). The lark SDK types omit this event so we cast.
@@ -255,6 +290,14 @@ export function createEventDispatcher(
         const chatId = message.chat_id;
         const chatType = message.chat_type;
         const messageId = message.message_id;
+
+        // Drop redelivered events: Feishu retries delivery when the ack is
+        // slow, and a retry must not become a second task.
+        if (messageId && isDuplicateMessage(messageId)) {
+          logger.debug({ messageId, msgType }, 'Duplicate message delivery ignored');
+          return;
+        }
+
         const mentions = message.mentions;
 
         let commandText = '';

--- a/tests/feishu-message-dedup.test.ts
+++ b/tests/feishu-message-dedup.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createMessageDeduper } from '../src/feishu/event-handler.js';
+import { createEventDispatcher, createMessageDeduper } from '../src/feishu/event-handler.js';
+import type { IncomingMessage } from '../src/types.js';
 
 describe('createMessageDeduper', () => {
   afterEach(() => {
@@ -7,17 +8,17 @@ describe('createMessageDeduper', () => {
   });
 
   it('passes a first delivery and drops an immediate retry', () => {
-    const isDuplicate = createMessageDeduper();
-    expect(isDuplicate('om_1')).toBe(false);
-    expect(isDuplicate('om_1')).toBe(true);
+    const deduper = createMessageDeduper();
+    expect(deduper.isDuplicate('om_1')).toBe(false);
+    expect(deduper.isDuplicate('om_1')).toBe(true);
   });
 
   it('tracks message ids independently', () => {
-    const isDuplicate = createMessageDeduper();
-    expect(isDuplicate('om_1')).toBe(false);
-    expect(isDuplicate('om_2')).toBe(false);
-    expect(isDuplicate('om_1')).toBe(true);
-    expect(isDuplicate('om_2')).toBe(true);
+    const deduper = createMessageDeduper();
+    expect(deduper.isDuplicate('om_1')).toBe(false);
+    expect(deduper.isDuplicate('om_2')).toBe(false);
+    expect(deduper.isDuplicate('om_1')).toBe(true);
+    expect(deduper.isDuplicate('om_2')).toBe(true);
   });
 
   it('keeps dedupers independent across dispatchers (one per bot)', () => {
@@ -25,18 +26,132 @@ describe('createMessageDeduper', () => {
     // message_id; one bot's delivery must not suppress the other's.
     const botA = createMessageDeduper();
     const botB = createMessageDeduper();
-    expect(botA('om_shared')).toBe(false);
-    expect(botB('om_shared')).toBe(false);
+    expect(botA.isDuplicate('om_shared')).toBe(false);
+    expect(botB.isDuplicate('om_shared')).toBe(false);
   });
 
   it('forgets a message id after the TTL', () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
-    const isDuplicate = createMessageDeduper(1000);
-    expect(isDuplicate('om_1')).toBe(false);
+    const deduper = createMessageDeduper(1000);
+    expect(deduper.isDuplicate('om_1')).toBe(false);
     vi.setSystemTime(500);
-    expect(isDuplicate('om_1')).toBe(true);
+    expect(deduper.isDuplicate('om_1')).toBe(true);
     vi.setSystemTime(1100);
-    expect(isDuplicate('om_1')).toBe(false);
+    expect(deduper.isDuplicate('om_1')).toBe(false);
+  });
+
+  it('enforces maxEntries as a hard cap, evicting oldest first', () => {
+    const deduper = createMessageDeduper(60_000, 3);
+    deduper.isDuplicate('om_1');
+    deduper.isDuplicate('om_2');
+    deduper.isDuplicate('om_3');
+    // Nothing has expired; inserting a 4th id must evict the oldest (om_1),
+    // not grow past the cap.
+    deduper.isDuplicate('om_4');
+    expect(deduper.isDuplicate('om_4')).toBe(true); // newest still tracked
+    expect(deduper.isDuplicate('om_2')).toBe(true); // survivor still tracked
+    expect(deduper.isDuplicate('om_1')).toBe(false); // evicted → treated as new
+  });
+
+  it('sweeps expired entries before evicting live ones when full', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const deduper = createMessageDeduper(1000, 2);
+    deduper.isDuplicate('om_old');
+    vi.setSystemTime(1500); // om_old expired
+    deduper.isDuplicate('om_a');
+    deduper.isDuplicate('om_b'); // full: expired om_old swept, om_a must survive
+    expect(deduper.isDuplicate('om_a')).toBe(true);
+    expect(deduper.isDuplicate('om_b')).toBe(true);
+  });
+
+  it('release() forgets an id so its redelivery is processed again', () => {
+    const deduper = createMessageDeduper();
+    expect(deduper.isDuplicate('om_1')).toBe(false);
+    deduper.release('om_1');
+    expect(deduper.isDuplicate('om_1')).toBe(false);
+    expect(deduper.isDuplicate('om_1')).toBe(true); // re-recorded normally
+  });
+});
+
+// --- Dispatcher-level coverage: duplicate delivery and retry-after-failure ---
+// Events go through the public dispatcher entry (no internals), mirroring
+// tests/post-image-text-ordering.test.ts.
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as any;
+
+function makeDispatcher(onMessage: (m: IncomingMessage) => void) {
+  const config = { groupNoMention: false } as any;
+  return createEventDispatcher(config, silentLogger, onMessage);
+}
+
+/** Feed one p2p text im.message.receive_v1 event (schema 2.0) through the dispatcher. */
+function invokeText(dispatcher: any, msgId: string, text = 'hello') {
+  return dispatcher.invoke(
+    {
+      schema: '2.0',
+      header: { event_type: 'im.message.receive_v1' },
+      event: {
+        sender: { sender_id: { open_id: 'ou_user' } },
+        message: {
+          message_id: msgId,
+          chat_id: 'oc_chat',
+          chat_type: 'p2p',
+          message_type: 'text',
+          content: JSON.stringify({ text }),
+        },
+      },
+    },
+    { needCheck: false },
+  );
+}
+
+describe('dispatcher dedup: duplicate delivery', () => {
+  it('processes a message once when Feishu redelivers it', async () => {
+    const received: IncomingMessage[] = [];
+    const dispatcher = makeDispatcher(m => received.push(m));
+    await invokeText(dispatcher, 'om_1');
+    await invokeText(dispatcher, 'om_1'); // at-least-once redelivery
+    expect(received).toHaveLength(1);
+    expect(received[0].messageId).toBe('om_1');
+  });
+
+  it('still processes distinct messages', async () => {
+    const received: IncomingMessage[] = [];
+    const dispatcher = makeDispatcher(m => received.push(m));
+    await invokeText(dispatcher, 'om_1');
+    await invokeText(dispatcher, 'om_2');
+    expect(received.map(m => m.messageId)).toEqual(['om_1', 'om_2']);
+  });
+});
+
+describe('dispatcher dedup: retry after downstream failure', () => {
+  it('processes the redelivery when the first attempt failed downstream', async () => {
+    let calls = 0;
+    const dispatcher = makeDispatcher(() => {
+      calls++;
+      if (calls === 1) throw new Error('downstream boom');
+    });
+    await invokeText(dispatcher, 'om_1'); // fails; in-flight mark must be released
+    await invokeText(dispatcher, 'om_1'); // redelivery gets a fresh attempt
+    expect(calls).toBe(2);
+  });
+
+  it('dedups again after a failed-then-successful delivery', async () => {
+    let calls = 0;
+    const dispatcher = makeDispatcher(() => {
+      calls++;
+      if (calls === 1) throw new Error('downstream boom');
+    });
+    await invokeText(dispatcher, 'om_1'); // attempt 1: fails, released
+    await invokeText(dispatcher, 'om_1'); // attempt 2: succeeds, re-marked
+    await invokeText(dispatcher, 'om_1'); // attempt 3: duplicate, dropped
+    expect(calls).toBe(2);
   });
 });

--- a/tests/feishu-message-dedup.test.ts
+++ b/tests/feishu-message-dedup.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createMessageDeduper } from '../src/feishu/event-handler.js';
+
+describe('createMessageDeduper', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('passes a first delivery and drops an immediate retry', () => {
+    const isDuplicate = createMessageDeduper();
+    expect(isDuplicate('om_1')).toBe(false);
+    expect(isDuplicate('om_1')).toBe(true);
+  });
+
+  it('tracks message ids independently', () => {
+    const isDuplicate = createMessageDeduper();
+    expect(isDuplicate('om_1')).toBe(false);
+    expect(isDuplicate('om_2')).toBe(false);
+    expect(isDuplicate('om_1')).toBe(true);
+    expect(isDuplicate('om_2')).toBe(true);
+  });
+
+  it('keeps dedupers independent across dispatchers (one per bot)', () => {
+    // Two bots in the same group each receive an event for the same
+    // message_id; one bot's delivery must not suppress the other's.
+    const botA = createMessageDeduper();
+    const botB = createMessageDeduper();
+    expect(botA('om_shared')).toBe(false);
+    expect(botB('om_shared')).toBe(false);
+  });
+
+  it('forgets a message id after the TTL', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const isDuplicate = createMessageDeduper(1000);
+    expect(isDuplicate('om_1')).toBe(false);
+    vi.setSystemTime(500);
+    expect(isDuplicate('om_1')).toBe(true);
+    vi.setSystemTime(1100);
+    expect(isDuplicate('om_1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 问题
飞书 webhook 是 at-least-once 投递：处理端 ack 慢时（长任务、媒体下载）同一条消息事件会被重投递。当前消息入口没有任何去重，重试被当成新消息又排一个任务，用户收到重复回复。

## 修复
消息事件入口按 `message_id` 做 10 分钟 TTL 去重（`createMessageDeduper`）。去重器为**每个 dispatcher 一个实例**而非模块级共享——两个 bot 在同一群、一条消息同时 @ 两个 bot 时，双方会收到相同 message_id 的各自事件，共享去重表会互相误杀。

## 测试
- 新增 `tests/feishu-message-dedup.test.ts`（首投/重试、多 id 独立、跨 dispatcher 独立、TTL 过期）
- `vitest run` 全量 615 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
