### PR TITLE
fix(bridge): 任务结束只清理系统临时目录里的下载，保留 downloadsDir 持久文件

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import type { BotConfigBase } from '../config.js';
 import type { Logger } from '../utils/logger.js';
@@ -163,6 +164,16 @@ export interface ActivityEventData {
   durationMs?: number;
   errorMessage?: string;
   timestamp: number;
+}
+
+/**
+ * Whether a downloaded file lives in the system temp dir and should be
+ * removed once the task finishes. Files downloaded into a bot-configured
+ * persistent downloadsDir (e.g. <project>/inputs) must survive the task so
+ * the user can refer back to them in later messages without re-uploading.
+ */
+export function isTransientDownload(filePath: string): boolean {
+  return filePath.startsWith(os.tmpdir() + path.sep);
 }
 
 export class MessageBridge {
@@ -2474,14 +2485,17 @@ export class MessageBridge {
         metrics.setGauge('metabot_active_tasks', this.runningTasks.size);
         this.processQueue(chatId);
       }
-      if (imagePath) {
+      // Only remove downloads that live in the system temp dir; files saved
+      // into a persistent downloadsDir must survive the task (see
+      // isTransientDownload).
+      if (imagePath && isTransientDownload(imagePath)) {
         try { fs.unlinkSync(imagePath); } catch { /* ignore */ }
       }
-      if (filePath) {
+      if (filePath && isTransientDownload(filePath)) {
         try { fs.unlinkSync(filePath); } catch { /* ignore */ }
       }
       for (const p of extraPaths) {
-        try { fs.unlinkSync(p); } catch { /* ignore */ }
+        if (isTransientDownload(p)) { try { fs.unlinkSync(p); } catch { /* ignore */ } }
       }
       try { this.outputsManager.cleanup(outputsDir); } catch { /* ignore */ }
     }

--- a/tests/download-cleanup.test.ts
+++ b/tests/download-cleanup.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { isTransientDownload } from '../src/bridge/message-bridge.js';
+
+describe('isTransientDownload', () => {
+  it('marks files under the system temp dir as transient', () => {
+    expect(isTransientDownload(path.join(os.tmpdir(), 'metabot-dl', 'photo.png'))).toBe(true);
+  });
+
+  it('keeps files downloaded into a persistent project directory', () => {
+    const persistent = path.join(os.homedir(), 'projects', 'mybot', 'inputs', 'report.pdf');
+    expect(isTransientDownload(persistent)).toBe(false);
+  });
+
+  it('does not match sibling paths that merely share the temp dir string prefix', () => {
+    expect(isTransientDownload(`${os.tmpdir()}-extra${path.sep}file.txt`)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 问题
任务结束的 finally 块会把本回合下载的图片/文件全部 `unlink`。对配置了 `downloadsDir`（如 `<project>/inputs`）的 bot，用户上传的文件刚落进持久目录就被任务收尾删掉，之后用户说「再用一下那个文件」时本地已不存在，只能重新上传。

## 修复
清理仅针对位于系统 temp 目录（`os.tmpdir()`）下的下载（新增 `isTransientDownload`，带路径分隔符防前缀碰撞）；落在持久目录里的文件保留。

## 测试
- 新增 `tests/download-cleanup.test.ts`（temp 判定 / 持久目录保留 / 前缀碰撞不误判）
- `vitest run` 全量 614 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
