### PR TITLE
fix(feishu): recover channels after network changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ BOTS_CONFIG=./bots.json
 # Feishu Bot Configuration (single-bot mode — used when BOTS_CONFIG is not set)
 # FEISHU_APP_ID=your_app_id
 # FEISHU_APP_SECRET=your_app_secret
+# METABOT_FEISHU_WS_PING_TIMEOUT_SEC=20
+# METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS=15000
 
 # Telegram Bot Configuration (single-bot mode — can run alongside Feishu bot)
 # TELEGRAM_BOT_TOKEN=

--- a/bin/metabot
+++ b/bin/metabot
@@ -503,6 +503,22 @@ def http_json(url, token=None, timeout=4):
     except Exception as e:
         return {"ok": False, "status": None, "json": None, "bodyPreview": str(e)}
 
+def channel_summary(status_json):
+    if not isinstance(status_json, dict):
+        return None
+    channels = status_json.get("channels")
+    if not isinstance(channels, dict):
+        return None
+    items = channels.get("items") if isinstance(channels.get("items"), list) else []
+    return {
+        "total": int(channels.get("total") or 0),
+        "connected": int(channels.get("connected") or 0),
+        "reconnecting": int(channels.get("reconnecting") or 0),
+        "idle": int(channels.get("idle") or 0),
+        "failed": int(channels.get("failed") or 0),
+        "items": items,
+    }
+
 def check(name, ok, code=None, diagnosis="", recommendedAction="", canAutoFix=False, data=None):
     severity = "ok" if ok else "warn"
     item = {
@@ -582,6 +598,16 @@ check("bridge_health", bridge_health["ok"], "bridge_health_failed" if not bridge
       "Check PM2 status, API_PORT/API_SECRET, and logs/error.log.",
       False,
       {"url": metabot_url, "status": bridge_health["status"], "response": bridge_health["json"] or bridge_health["bodyPreview"]})
+
+bridge_status = http_json(f"{metabot_url.rstrip('/')}/api/status", api_secret)
+channels = channel_summary(bridge_status["json"])
+channels_ok = bool(channels is not None) and channels["failed"] == 0 and channels["reconnecting"] == 0 and channels["connected"] == channels["total"]
+check("channel_connections", channels_ok,
+      "ok" if channels_ok else ("channel_connections_unhealthy" if channels is not None else "channel_status_unavailable"),
+      "Lark/Feishu channel connections are healthy." if channels_ok else "One or more Lark/Feishu channels are disconnected, reconnecting, or unavailable.",
+      "Check the local network/proxy and configured Lark/Feishu WebSocket state in /api/status; MetaBot should reconnect automatically.",
+      False,
+      channels or {"status": bridge_status["status"]})
 
 core_url = env("METABOT_CORE_URL", "http://localhost:9200").rstrip("/")
 core_token_present = bool(env("METABOT_CORE_TOKEN") or (Path.home() / ".metabot-core" / "token").exists())
@@ -744,7 +770,9 @@ check("teamclaude", team_ok, "teamclaude_not_configured_or_invalid" if not team_
       False,
       team_data)
 
-report["ok"] = all(c.get("ok") for c in checks if c["name"] in ("metabot_home", "pm2_runtime", "bridge_health"))
+report["ok"] = all(c.get("ok") for c in checks if c["name"] in (
+    "metabot_home", "pm2_runtime", "bridge_health", "channel_connections"
+))
 report["summary"] = {
     "ok": sum(1 for c in checks if c["ok"]),
     "warn": sum(1 for c in checks if not c["ok"]),

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -13,6 +13,8 @@ All configuration is via `.env` file or system environment variables. Copy `.env
 | `API_SECRET` | — | Bearer token auth for API and MetaMemory. Generate one with `openssl rand -hex 32` |
 | `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
 | `METABOT_LOCAL_ADDRESS` | — | Bind all Feishu sockets (REST + wss long-connection) to this local source IP, forcing source-based routing past VPN smart split-tunneling (e.g. a corporate VPN hijacking `*.feishu.cn` into a dead tunnel). Unset = default route |
+| `METABOT_FEISHU_WS_PING_TIMEOUT_SEC` | `20` | Pong watchdog for the Feishu WebSocket. Safe range: 5–300 seconds |
+| `METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS` | `15000` | Timeout for a Feishu WebSocket connect/reconnect handshake. Safe range: 1000–120000 ms |
 | `METABOT_PUBLIC_DISTRIBUTION` | — | metabot-core server flag. The `/cli/*` and `/install/*` install endpoints are token-gated by default; set to `1` (or `true`) to serve them anonymously. Only enable when you intentionally self-distribute and your build embeds no secrets |
 
 ## Claude Code

--- a/docs/configuration/environment-variables.zh.md
+++ b/docs/configuration/environment-variables.zh.md
@@ -13,6 +13,8 @@
 | `API_SECRET` | — | Bearer Token 认证 |
 | `LOG_LEVEL` | `info` | 日志级别（debug, info, warn, error） |
 | `METABOT_LOCAL_ADDRESS` | — | 所有飞书 socket（REST + wss 长连接）绑定到该本机源 IP，触发 source-based routing 绕过 VPN 智能分流（如某些企业 VPN 把 `*.feishu.cn` 劫持进失效隧道）。不设则走默认路由 |
+| `METABOT_FEISHU_WS_PING_TIMEOUT_SEC` | `20` | 飞书 WebSocket 的 Pong 看门狗，安全范围 5–300 秒 |
+| `METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS` | `15000` | 飞书 WebSocket 建连/重连握手超时，安全范围 1000–120000 毫秒 |
 
 ## Claude Code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metabot",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metabot",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "workspaces": [
         "packages/cli",
         "packages/cli-core",
@@ -18,7 +18,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.154",
         "@anthropic-ai/sdk": "^0.100.0",
-        "@larksuiteoapi/node-sdk": "^1.58.0",
+        "@larksuiteoapi/node-sdk": "^1.64.0",
         "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
         "@types/ws": "^8.18.0",
         "@volcengine/openapi": "^1.36.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metabot",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "metabotEdition": "personal",
   "description": "MetaBot — Bridge service connecting IM bots (Feishu/Lark, Telegram) to Claude Code Agent SDK",
   "main": "dist/index.js",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.154",
     "@anthropic-ai/sdk": "^0.100.0",
-    "@larksuiteoapi/node-sdk": "^1.58.0",
+    "@larksuiteoapi/node-sdk": "^1.64.0",
     "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
     "@types/ws": "^8.18.0",
     "@volcengine/openapi": "^1.36.0",

--- a/src/api/bot-registry.ts
+++ b/src/api/bot-registry.ts
@@ -12,6 +12,22 @@ export interface RegisteredBot {
   sender: IMessageSender;
   /** Feishu SDK client (only for feishu platform bots). */
   feishuClient?: lark.Client;
+  /** Live external channel state, when the platform adapter exposes it. */
+  connectionStatus?: () => ChannelConnectionStatus;
+}
+
+export type ChannelConnectionState = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'failed';
+
+export interface ChannelConnectionStatus {
+  state: ChannelConnectionState;
+  lastConnectTime?: number;
+  nextConnectTime?: number;
+  reconnectAttempts: number;
+}
+
+export interface BotChannelStatus extends ChannelConnectionStatus {
+  name: string;
+  platform: RegisteredBot['platform'];
 }
 
 /** Public DTO returned by list() — no secrets or internal refs. */
@@ -81,6 +97,18 @@ export class BotRegistry {
   /** Return all registered bots with full internal info (bridge, sender, etc.) */
   listRegistered(): RegisteredBot[] {
     return Array.from(this.bots.values());
+  }
+
+  /** Authenticated diagnostics for external channel connections. */
+  listChannelStatuses(): BotChannelStatus[] {
+    return Array.from(this.bots.values()).flatMap((bot) => {
+      if (!bot.connectionStatus) return [];
+      try {
+        return [{ name: bot.name, platform: bot.platform, ...bot.connectionStatus() }];
+      } catch {
+        return [{ name: bot.name, platform: bot.platform, state: 'failed', reconnectAttempts: 0 }];
+      }
+    });
   }
 
   list(): BotInfo[] {

--- a/src/api/http-server.ts
+++ b/src/api/http-server.ts
@@ -4,7 +4,7 @@ import type * as lark from '@larksuiteoapi/node-sdk';
 import type { Logger } from '../utils/logger.js';
 import { loadAppConfig } from '../config.js';
 import type { AgentTeamConfig } from '../agent-teams/team-store.js';
-import type { BotRegistry } from './bot-registry.js';
+import type { BotChannelStatus, BotRegistry } from './bot-registry.js';
 import type { TaskScheduler } from '../scheduler/task-scheduler.js';
 import type { DocSync } from '../sync/doc-sync.js';
 import type { PeerManager } from './peer-manager.js';
@@ -65,6 +65,19 @@ const startTime = Date.now();
 (globalThis as any).__metabot_start_time = startTime;
 
 const WHOAMI_VERIFY_TIMEOUT_MS = 5_000;
+
+export function summarizeChannelStatuses(channelStatuses: BotChannelStatus[]) {
+  return {
+    total: channelStatuses.length,
+    connected: channelStatuses.filter((channel) => channel.state === 'connected').length,
+    reconnecting: channelStatuses.filter(
+      (channel) => channel.state === 'connecting' || channel.state === 'reconnecting',
+    ).length,
+    idle: channelStatuses.filter((channel) => channel.state === 'idle').length,
+    failed: channelStatuses.filter((channel) => channel.state === 'failed').length,
+    items: channelStatuses,
+  };
+}
 
 /**
  * Routes that accept the dual-auth gate: local secret OR a Bearer that
@@ -319,6 +332,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
       // gated by the auth check above (local secret or cross-verified Bearer).
       if (method === 'GET' && url === '/api/status') {
         const peerStatuses = peerManager?.getPeerStatuses() ?? [];
+        const channelStatuses = registry.listChannelStatuses();
 
         // Process memory (MB). rss = total resident set, heapUsed = V8 heap in use.
         const mem = process.memoryUsage();
@@ -350,6 +364,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
           recurringTasks: scheduler.recurringTaskCount(),
           memory: { rssMb: toMb(mem.rss), heapUsedMb: toMb(mem.heapUsed) },
           executors: { total: executorTotal, active: executorActive },
+          channels: summarizeChannelStatuses(channelStatuses),
           rateLimit: { trackedIps: rateLimiter.size() },
         });
         return;

--- a/src/feishu/ws-recovery.ts
+++ b/src/feishu/ws-recovery.ts
@@ -1,0 +1,45 @@
+export const DEFAULT_FEISHU_WS_PING_TIMEOUT_SEC = 20;
+export const DEFAULT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS = 15_000;
+
+const MIN_PING_TIMEOUT_SEC = 5;
+const MAX_PING_TIMEOUT_SEC = 300;
+const MIN_HANDSHAKE_TIMEOUT_MS = 1_000;
+const MAX_HANDSHAKE_TIMEOUT_MS = 120_000;
+
+export interface FeishuWsRecoveryOptions {
+  autoReconnect: true;
+  handshakeTimeoutMs: number;
+  wsConfig: { pingTimeout: number };
+}
+
+function boundedInteger(raw: string | undefined, fallback: number, min: number, max: number): number {
+  if (!raw?.trim()) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) return fallback;
+  return value;
+}
+
+/**
+ * Enable the liveness controls provided by the public Feishu/Lark SDK.
+ * A pong watchdog terminates half-open sockets after a network switch, while
+ * the handshake timeout prevents reconnects waiting forever on a stale path.
+ */
+export function resolveFeishuWsRecoveryOptions(env: NodeJS.ProcessEnv = process.env): FeishuWsRecoveryOptions {
+  return {
+    autoReconnect: true,
+    handshakeTimeoutMs: boundedInteger(
+      env.METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS,
+      DEFAULT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS,
+      MIN_HANDSHAKE_TIMEOUT_MS,
+      MAX_HANDSHAKE_TIMEOUT_MS,
+    ),
+    wsConfig: {
+      pingTimeout: boundedInteger(
+        env.METABOT_FEISHU_WS_PING_TIMEOUT_SEC,
+        DEFAULT_FEISHU_WS_PING_TIMEOUT_SEC,
+        MIN_PING_TIMEOUT_SEC,
+        MAX_PING_TIMEOUT_SEC,
+      ),
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { createLogger, type Logger } from './utils/logger.js';
 import { createEventDispatcher } from './feishu/event-handler.js';
 import { MessageSender } from './feishu/message-sender.js';
 import { FeishuSenderAdapter } from './feishu/feishu-sender-adapter.js';
+import { resolveFeishuWsRecoveryOptions } from './feishu/ws-recovery.js';
 import { MessageBridge } from './bridge/message-bridge.js';
 import { loadRestartBreadcrumb } from './bridge/restart-notice.js';
 import type { IMessageSender } from './bridge/message-sender.interface.js';
@@ -114,18 +115,31 @@ async function startFeishuBot(botConfig: BotConfig, logger: Logger, localAgent?:
     },
   );
 
-  // Create WebSocket client
+  // Create WebSocket client with bounded liveness/reconnect controls.
+  const wsRecovery = resolveFeishuWsRecoveryOptions();
   const wsClient = new lark.WSClient({
     appId: botConfig.feishu.appId,
     appSecret: botConfig.feishu.appSecret,
     loggerLevel: lark.LoggerLevel.info,
     agent: localAgent,
+    ...wsRecovery,
+    onReady: () => botLogger.info('Feishu WebSocket connected'),
+    onReconnecting: () => botLogger.warn('Feishu WebSocket disconnected; reconnecting'),
+    onReconnected: () => botLogger.info('Feishu WebSocket reconnected'),
+    onError: (err) => botLogger.error({ err: err.message }, 'Feishu WebSocket recovery failed'),
   });
+  botLogger.info(
+    {
+      pingTimeoutSec: wsRecovery.wsConfig.pingTimeout,
+      handshakeTimeoutMs: wsRecovery.handshakeTimeoutMs,
+    },
+    'Feishu WebSocket recovery enabled',
+  );
 
   // Start WebSocket connection with event dispatcher
   await wsClient.start({ eventDispatcher: dispatcher });
 
-  botLogger.info('Feishu bot is running');
+  botLogger.info('Feishu bot channel initialized');
   botLogger.info({
     defaultWorkingDirectory: botConfig.claude.defaultWorkingDirectory,
     maxTurns: botConfig.claude.maxTurns ?? 'unlimited',
@@ -243,6 +257,7 @@ async function main() {
       bridge: handle.bridge,
       sender: handle.sender,
       feishuClient: handle.feishuClient,
+      connectionStatus: () => handle.wsClient.getConnectionStatus(),
     });
   }
 

--- a/tests/feishu-ws-recovery.test.ts
+++ b/tests/feishu-ws-recovery.test.ts
@@ -1,0 +1,97 @@
+import * as lark from '@larksuiteoapi/node-sdk';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS,
+  DEFAULT_FEISHU_WS_PING_TIMEOUT_SEC,
+  resolveFeishuWsRecoveryOptions,
+} from '../src/feishu/ws-recovery.js';
+import { BotRegistry } from '../src/api/bot-registry.js';
+
+afterEach(() => vi.useRealTimers());
+
+describe('Feishu WebSocket network-switch recovery', () => {
+  it('enables bounded liveness and handshake recovery by default', () => {
+    expect(resolveFeishuWsRecoveryOptions({})).toEqual({
+      autoReconnect: true,
+      handshakeTimeoutMs: DEFAULT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS,
+      wsConfig: { pingTimeout: DEFAULT_FEISHU_WS_PING_TIMEOUT_SEC },
+    });
+  });
+
+  it('accepts safe overrides and rejects invalid values', () => {
+    expect(resolveFeishuWsRecoveryOptions({
+      METABOT_FEISHU_WS_PING_TIMEOUT_SEC: '35',
+      METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS: '25000',
+    })).toMatchObject({ handshakeTimeoutMs: 25_000, wsConfig: { pingTimeout: 35 } });
+
+    expect(resolveFeishuWsRecoveryOptions({
+      METABOT_FEISHU_WS_PING_TIMEOUT_SEC: '0',
+      METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS: 'not-a-number',
+    })).toMatchObject({
+      handshakeTimeoutMs: DEFAULT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS,
+      wsConfig: { pingTimeout: DEFAULT_FEISHU_WS_PING_TIMEOUT_SEC },
+    });
+  });
+
+  it('terminates a half-open SDK socket when the pong watchdog expires', async () => {
+    vi.useFakeTimers();
+    const terminate = vi.fn();
+    const client = new lark.WSClient({
+      appId: 'cli_0123456789abcdef',
+      appSecret: 'test-only',
+      loggerLevel: lark.LoggerLevel.error,
+      ...resolveFeishuWsRecoveryOptions({}),
+    });
+    const internals = client as unknown as {
+      wsConfig: { setWSInstance(value: { terminate: () => void }): void };
+      armLiveness(): void;
+    };
+    internals.wsConfig.setWSInstance({ terminate });
+
+    internals.armLiveness();
+    await vi.advanceTimersByTimeAsync(DEFAULT_FEISHU_WS_PING_TIMEOUT_SEC * 1_000);
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces live channel state without exposing credentials', () => {
+    const registry = new BotRegistry();
+    registry.register({
+      name: 'personal-bot',
+      platform: 'feishu',
+      config: { claude: { defaultWorkingDirectory: '/tmp' } } as never,
+      bridge: {} as never,
+      sender: {} as never,
+      connectionStatus: () => ({
+        state: 'reconnecting',
+        reconnectAttempts: 2,
+        lastConnectTime: 123,
+        nextConnectTime: 456,
+      }),
+    });
+
+    expect(registry.listChannelStatuses()).toEqual([{
+      name: 'personal-bot',
+      platform: 'feishu',
+      state: 'reconnecting',
+      reconnectAttempts: 2,
+      lastConnectTime: 123,
+      nextConnectTime: 456,
+    }]);
+  });
+
+  it('fails closed when a channel status provider throws', () => {
+    const registry = new BotRegistry();
+    registry.register({
+      name: 'broken',
+      platform: 'feishu',
+      config: { claude: { defaultWorkingDirectory: '/tmp' } } as never,
+      bridge: {} as never,
+      sender: {} as never,
+      connectionStatus: () => { throw new Error('status unavailable'); },
+    });
+
+    expect(registry.listChannelStatuses()).toEqual([
+      { name: 'broken', platform: 'feishu', state: 'failed', reconnectAttempts: 0 },
+    ]);
+  });
+});

--- a/tests/http-server-cross-verify.test.ts
+++ b/tests/http-server-cross-verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isCrossVerifyRoute } from '../src/api/http-server.js';
+import { isCrossVerifyRoute, summarizeChannelStatuses } from '../src/api/http-server.js';
 
 describe('isCrossVerifyRoute', () => {
   it('accepts the talk RPC routes', () => {
@@ -41,5 +41,37 @@ describe('isCrossVerifyRoute', () => {
     expect(isCrossVerifyRoute('POST', '/api/schedule')).toBe(false);
     expect(isCrossVerifyRoute('GET', '/api/core-chat/runs')).toBe(false);
     expect(isCrossVerifyRoute('POST', '/api/core-chat/runs/run-123/events')).toBe(false);
+  });
+});
+
+describe('authenticated channel status aggregation', () => {
+  it('counts connected, reconnecting, idle, and failed channels', () => {
+    const items = [
+      { name: 'ready', platform: 'feishu' as const, state: 'connected' as const, reconnectAttempts: 0 },
+      { name: 'starting', platform: 'feishu' as const, state: 'connecting' as const, reconnectAttempts: 1 },
+      { name: 'retrying', platform: 'feishu' as const, state: 'reconnecting' as const, reconnectAttempts: 2 },
+      { name: 'idle', platform: 'feishu' as const, state: 'idle' as const, reconnectAttempts: 0 },
+      { name: 'failed', platform: 'feishu' as const, state: 'failed' as const, reconnectAttempts: 3 },
+    ];
+
+    expect(summarizeChannelStatuses(items)).toEqual({
+      total: 5,
+      connected: 1,
+      reconnecting: 2,
+      idle: 1,
+      failed: 1,
+      items,
+    });
+  });
+
+  it('treats a Web-only personal install as an empty healthy inventory', () => {
+    expect(summarizeChannelStatuses([])).toEqual({
+      total: 0,
+      connected: 0,
+      reconnecting: 0,
+      idle: 0,
+      failed: 0,
+      items: [],
+    });
   });
 });

--- a/tests/metabot-update.test.ts
+++ b/tests/metabot-update.test.ts
@@ -87,6 +87,10 @@ describe('metabot doctor command', () => {
 
   it('checks Codex agent feature readiness', () => {
     const source = fs.readFileSync(METABOT_BIN, 'utf-8');
+    expect(source).toContain('def channel_summary(status_json):');
+    expect(source).toContain('check("channel_connections"');
+    expect(source).toContain('"ok" if channels_ok else');
+    expect(source).toContain('"bridge_health", "channel_connections"');
     expect(source).toContain('parse_codex_feature_list');
     expect(source).toContain('codex_agent_features');
     expect(source).toContain('"multi_agent"');


### PR DESCRIPTION
## Summary

- enable bounded Feishu/Lark WebSocket pong-watchdog, handshake timeout, and SDK auto-reconnect behavior
- expose credential-free channel state through authenticated `/api/status`
- make `metabot doctor` report healthy channel code correctly and elevate disconnected channels to top-level WARN
- require the public SDK version that provides connection status and recovery APIs

## Verification

- 1080 tests pass
- focused channel/doctor/status tests: 18 pass
- typecheck, lint, and full build pass

## OSS boundary

This uses only the public Lark SDK. No Feilian, internal domain/VPN, enterprise identity, or private service dependency is included. The repeated-steer card fix was intentionally deferred because OSS does not yet contain its steering/app-server foundation.