### PR TITLE
feat: modernize Codex and Kimi Code support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,17 @@ on:
 
 jobs:
   check:
+    # Keep the historical required-check contexts stable while advancing the
+    # actual Node runtimes enforced by branch protection.
+    name: check (${{ matrix.context }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.19.0, 24]
+        include:
+          - context: 20
+            node-version: 22.19.0
+          - context: 22
+            node-version: 24
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22.19.0, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.19.0
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.19.0
           cache: npm
 
       - run: npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ git clone https://github.com/xvirobotics/metabot.git
 cd metabot
 
 # 2. Install dependencies
-npm install
+npm ci --include=dev
 
 # 3. Copy environment config
 cp .env.example .env
@@ -23,17 +23,23 @@ npm run build
 npm run dev
 ```
 
-**Prerequisites:** Node.js 20+, Claude Code CLI installed.
+**Prerequisites:** Node.js >= 22.19 and Git. Install and authenticate only the
+engine needed for engine-specific work: Codex CLI, Kimi Code 0.27+, or the
+Claude Code compatibility CLI. Documentation and most unit tests do not
+require an authenticated engine.
 
 ## Project Structure
 
 ```
 src/
   bridge/        # Message routing & task management
-  claude/        # Claude Agent SDK integration
+  engines/       # Codex, Kimi Code, and Claude compatibility adapters
   feishu/        # Feishu API client & card builder
+  telegram/      # Telegram integration
+  wechat/        # WeChat/ClawBot integration
   memory/        # Memory server client
   utils/         # Logger, helpers
+packages/        # Personal Core, Web UI, CLI, and shared packages
 ```
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -2,597 +2,206 @@
 
 # 🤖 MetaBot
 
-### 在飞书 / Telegram / 微信上用手机控制 Claude Code、Kimi Code 或 Codex CLI
+### 从飞书/Lark、Telegram、微信或 Web 使用 Codex 和 Kimi Code
 
-*写代码 · 管 Agent · 自动化一切*
-
-<p>
-  <a href="https://github.com/xvirobotics/metabot"><img src="https://img.shields.io/badge/GitHub-Repo-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="License"></a>
-</p>
+*可自托管的个人 Agent 工作台；Claude Code 作为兼容引擎继续保留。*
 
 <p>
-  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
-  <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
   <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Engine-Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
-  <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
-  <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
+  <a href="https://www.kimi.com/code"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge" alt="Kimi Code"></a>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Compatibility-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code 兼容"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
+  <img src="https://img.shields.io/badge/Node.js-%3E%3D22.19-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js 22.19 或更高版本">
 </p>
 
-<p>
-  <a href="https://feishu.cn"><img src="https://img.shields.io/badge/飞书_/_Lark-00D6B9?style=for-the-badge&logo=lark&logoColor=white" alt="Feishu/Lark"></a>
-  <a href="https://telegram.org"><img src="https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram"></a>
-  <a href="https://ilinkai.weixin.qq.com"><img src="https://img.shields.io/badge/微信_ClawBot-07C160?style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
-  <img src="https://img.shields.io/badge/Web_UI-61DAFB?style=for-the-badge&logo=react&logoColor=white" alt="Web UI">
-</p>
-
-**中文** · [English](README_EN.md) · [📚 文档](docs/)
+**中文** · [English](README_EN.md) · [文档站](https://xvirobotics.com/metabot/zh/)
 
 </div>
-
-> 支持 **Claude Code**、**Kimi Code** 和 **Codex CLI** 三大引擎 — 订阅 / API Key 任你选，每个 Bot 可独立选引擎。
 
 <div align="center">
 <table>
 <tr>
-  <td width="25%"><img src="resources/demo-1.png" alt="召唤 Agent Team" /></td>
-  <td width="25%"><img src="resources/demo-2.png" alt="下达任务" /></td>
-  <td width="25%"><img src="resources/demo-3.png" alt="Agent 之间持续工作" /></td>
-  <td width="25%"><img src="resources/demo-4.png" alt="PR 已合并" /></td>
+  <td width="25%"><img src="resources/demo-1.png" alt="召唤 Agent 团队" /></td>
+  <td width="25%"><img src="resources/demo-2.png" alt="分派任务" /></td>
+  <td width="25%"><img src="resources/demo-3.png" alt="查看 Agent 工作" /></td>
+  <td width="25%"><img src="resources/demo-4.png" alt="PR 合并" /></td>
 </tr>
 </table>
-<sub>飞书移动端 · 召唤团队 · 下达任务 · 实时跟进 · PR 合并</sub>
+<sub>飞书移动端 · 召唤团队 · 分派工作 · 跟进进度 · 合并 PR</sub>
 </div>
 
 ```bash
 curl -fsSL https://github.com/xvirobotics/metabot/releases/latest/download/install.sh | bash
 ```
 
-安装器会安装完整个人版（本地 Core + Web UI + Bridge + CLI），自动生成并安全保存本地 Bearer Token，再引导：工作目录 → **引擎选择（Claude / Kimi / Codex）** → 订阅登录 → IM 平台 → PM2 自动启动。控制台默认位于 `http://localhost:9200`。**5 分钟上手。**
+带签名校验的安装器约五分钟部署完整个人版：本地 Core、仅 Token 登录的 Web UI、IM Bridge、CLI、Skills 和 PM2 服务。
 
-> 自定义安装目录（默认 `~/metabot`）：把 `~/metabot` 换成你想要的路径即可，或 `METABOT_HOME=/opt/metabot bash install.sh`。Windows: `.\install.ps1 -Dir C:\opt\metabot`。
->
-> 源码开发安装：`git clone https://github.com/xvirobotics/metabot.git ~/metabot && cd ~/metabot && bash install.sh`。Release 安装与源码 checkout 使用不同更新路径，`metabot update` 会自动识别。
+## 个人版
 
----
+MetaBot 运行在你自己的机器上，不依赖企业 SSO、OIDC、VPN 或员工目录。
 
-## 🔑 自托管 & 鉴权（个人版）
+- 本地 Core 和个人控制台默认为 `http://localhost:9200`。
+- 安装器自动生成 Bearer Token，以 `0600` 权限保存到 `~/.metabot-core/token`，且不会写入日志。
+- Core 数据默认在 `~/.metabot-core/`，Bridge 状态默认在 `~/.metabot/`。
+- Release 资源解压前会验证校验和。
+- 使用 `METABOT_INSTALL_CORE=0` 仍可连接已有外部 Core。
 
-MetaBot 开箱即是**可自托管的个人版**：本地跑、单 token 鉴权、**不依赖任何 SSO / 企业登录**。
+自定义目录、源码安装、更新、Windows 状态和外部 Core 配置详见[安装文档](docs/getting-started/installation.zh.md)。
 
-- **本地优先**：`metabot-core` 默认只监听 `http://localhost:9200`，首次启动把一次性管理员 Token 写入 `~/.metabot-core/data/admin-bootstrap-token.txt`。把它粘贴到 Web 控制台登录页，也可另存为 `~/.metabot-core/token`（权限 `0600`）供 CLI 使用。数据默认落在 `~/.metabot-core/`。
-- **无需 SSO**：不需要 OAuth / OIDC / 企业 VPN。要多人或公网访问时，自行在前面挂一个反向代理（可选 oauth2-proxy）即可，应用层不强制。
-- **分发端点默认上锁**：`/cli/*`、`/install/*` 安装分发端点默认需要 token；确认你的构建不含密钥后，可设 `METABOT_PUBLIC_DISTRIBUTION=1` 放开匿名下载。
+默认安装目录为 `~/metabot`。可用
+`METABOT_HOME=/opt/metabot bash install.sh` 覆盖；源码 checkout 与 Release
+安装保留各自的更新路径，`metabot update` 不会盲目猜测。
 
----
+## 引擎
 
-## 三引擎：Claude Code ✕ Kimi Code ✕ Codex CLI 并列一等支持
+Codex 是默认引擎，Kimi Code 是一级可选引擎。Claude Code 继续保留，确保现有 Claude Bot 和工作区仍能运行。
 
-MetaBot 不是只绑定一家 — 三大顶级 AI 编码 Agent 都内置原生支持，**你的订阅直接用**。
-
-| | **Claude Code**（Anthropic） | **Kimi Code**（Moonshot） | **Codex CLI**（OpenAI） |
+| 引擎 | 接入方式 | 认证 | 当前开源版能力 |
 |---|---|---|---|
-| **订阅直连** | ✅ `claude login` OAuth | ✅ `kimi login` | ✅ `codex login`，走 ChatGPT 订阅 |
-| **API Key 兜底** | ✅ `ANTHROPIC_API_KEY` / 第三方 Anthropic 兼容端 | ✅ Moonshot API Key | ✅ `OPENAI_API_KEY` / Codex profile |
-| **上下文窗口** | 200k（Opus/Sonnet 可选 1M） | 256k（kimi-for-coding） | 400k（gpt-5.x-codex） |
-| **工具能力** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | 同上（Kimi CLI 原生 + `.claude/skills/` 自动发现） | Codex CLI 原生工具链 + `.codex/skills/` 自动发现 |
-| **自主运行模式** | `bypassPermissions` | `yoloMode`（等价） | 默认 `--sandbox danger-full-access`，避免无 user namespace 环境下的 `bwrap` 失败 |
-| **子 Agent** | `.claude/agents/*.md` 自动加载 | 仅内置 `default` / `okabe` | 暂不支持项目子 Agent；把角色/路由写进 `AGENTS.md` |
-| **工作区说明** | `CLAUDE.md` | `AGENTS.md`（安装器自动建软链） | `AGENTS.md`（Codex 官方约定） |
+| **Codex CLI** | `codex exec --json` 和 `codex exec resume` | `codex login` 或 OpenAI 兼容 API 配置 | JSONL 流式输出、工具、会话续接、`/model`、`/effort`、Bridge 管理的 Goal 和后台任务 |
+| **Kimi Code 0.27+** | Kimi Web 前端同源的官方本地 Server API | `kimi login` | 持久 Session、原子快照、问题交互、停止/续接、工具、子 Agent 和 Goal |
+| **Claude Code 兼容** | Claude CLI / Agent SDK 兼容路径 | `claude login` 或 Anthropic 兼容 API | 继续支持现有 Claude 会话、Skills 和工作区 |
 
-**配置只需一行** — 每个 Bot 独立选引擎：
-```json
-{ "name": "bulma", "engine": "kimi",   "kimi": { "thinking": true } }
-{ "name": "goku",  "engine": "claude" }
-{ "name": "vegeta", "engine": "codex", "codex": { "model": "gpt-5.4-codex" } }
+当前公开版 Codex 适配器使用 `codex exec`；Codex app-server 以及 Codex/Kimi 的飞书执行中 steering 将在后续基础链完整后开放。
+
+请在独立终端安装或登录引擎：
+
+```bash
+npm install -g @openai/codex
+codex login
+
+npm install -g @moonshot-ai/kimi-code@latest   # Kimi Code 0.27+
+kimi login
 ```
 
-Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec resume` 续接聊天会话。启动 MetaBot 前，请先执行 `codex login` 或配置好 Codex API key/profile。MetaBot 会把飞书侧的 `/<skill-name> ...` 调用统一转成 Codex 的 `$<skill-name> ...` 显式技能调用（例如安装了 `/metaschedule` 后，Codex 会收到 `$metaschedule ...`）。
+每个 Bot 在 `bots.json` 中独立选择引擎；省略时默认为 `codex`。详见[多 Bot 配置](docs/configuration/multi-bot.zh.md)和[环境变量](docs/configuration/environment-variables.zh.md)。
 
-### Codex 迁移：复用 `.claude` 配置
+各引擎继续使用自己的工作区约定：
 
-Claude/Kimi 和 Codex 的发现路径不同。MetaBot 安装、更新和 Skill Hub 安装时会自动镜像内置 skills：
-
-| 内容 | Claude / Kimi | Codex |
-|------|---------------|-------|
-| 工作区说明 | `CLAUDE.md` | `AGENTS.md` |
-| Skills | `.claude/skills/<name>/SKILL.md` | `.codex/skills/<name>/SKILL.md` |
-| 子 Agent | `.claude/agents/*.md` | 不自动加载；迁移为 `AGENTS.md` 里的角色/路由说明 |
-
-已有项目可以直接让 Codex 帮你迁移：
-
-```text
-/model codex
-请根据当前项目的 .claude 配置，为 Codex 创建对应的 .codex/skills 和 AGENTS.md：
-- 把 .claude/skills/* 镜像到 .codex/skills/*
-- 根据 CLAUDE.md 生成或更新 AGENTS.md
-- 如果存在 .claude/agents/*.md，把这些 subagent 的角色、路由表和工作流整合进 AGENTS.md
-```
-
-如果你的宿主机禁用了 unprivileged user namespace，Codex CLI 的 `workspace-write` sandbox 可能在命令执行前报 `bwrap: No permissions to create a new namespace`。MetaBot 的 Codex 默认改用 `danger-full-access` 避开这个问题；需要更强隔离时可以通过 `CODEX_SANDBOX` 或 `codex.sandbox` 显式覆盖。
-
-前端 Bot 用 Claude、后端 Bot 用 Kimi？完全可以。Agent 总线让它们互相委派任务，对面跑什么引擎对调用方透明。
-
----
-
-## 你能用它做什么
-
-- **手机写代码** — 地铁上用飞书给 Claude Code / Kimi Code / Codex CLI 发消息，它帮你改 bug、提 PR、跑测试
-- **多 Agent 协作** — 前端 Bot、后端 Bot、运维 Bot，各自独立工作空间（甚至独立引擎），通过 Agent 总线互相委派任务
-- **知识自生长** — Agent 把学到的东西存入 MetaMemory，组织每天都在变聪明，无需重新训练
-- **自动化流水线** — "每天早上9点搜 AI 新闻，总结 Top 5，存档" — 一句话搞定
-- **语音助手（Jarvis 模式）** — AirPods 说 "Hey Siri, Jarvis"，免手免屏语音控制任意 Agent
-- **自生长的组织** — 管理者 Bot 按需创建新 Agent，分配任务，安排后续跟进
-
-## 为什么选 MetaBot
-
-| | MetaBot | 直接用 Claude / Kimi / Codex CLI | Dify / Coze |
+| 内容 | Codex | Kimi Code | Claude 兼容 |
 |---|---|---|---|
-| **手机控制** | 飞书/TG/微信随时随地 | 只能在终端 | 有，但不能跑代码 |
-| **引擎选择** | Claude ✕ Kimi ✕ Codex 三引擎 | 各自单一 | 无，只能调 API |
-| **订阅直连** | 三家原生订阅都直接用 | 一次只能登一个 | 不支持订阅 |
-| **代码能力** | 完整 Agent SDK（Read/Write/Edit/Bash/MCP） | 完整 | 无 |
-| **多 Agent** | Agent 总线 + 任务委派 + 运行时创建 | 单会话 | 有，但封闭生态 |
-| **共享记忆** | MetaMemory 全文搜索 + 自动同步飞书知识库 | 无 | 无 |
-| **定时任务** | CC 原生 `CronCreate` / `/loop` 即开即用，可选 `/metaschedule` 跨重启持久化 | 仅原生 `CronCreate` / `/loop` | 有 |
-| **自主运行** | bypassPermissions / yoloMode，全自动 | 需要人工确认 | 受限于 workflow |
-| **开源** | MIT，完全可控 | CLI 开源 | 闭源 SaaS |
+| 工作区说明 | `AGENTS.md` | `AGENTS.md` | `CLAUDE.md` 兼容入口 |
+| Skills | `.codex/skills/` | `.agents/skills/` | `.claude/skills/` |
+| 订阅状态 | Codex profile | `~/.kimi-code/` | Claude credentials |
 
-## 工作原理
-
-![MetaBot 架构图](resources/metabot.png)
-
-```
-飞书/TG/微信 → IM Bridge → Engine Router ──┬─→ Claude Code Agent SDK
-                                            ├─→ Kimi Agent SDK（@moonshot-ai/kimi-agent-sdk）
-                                            └─→ Codex CLI（codex exec --json 子进程）
-                              ↕
-                    MetaMemory（共享知识库）
-                    定时调度（CC 原生 CronCreate / /loop；可选 /metaschedule 持久化）
-                    Agent 总线（跨 Bot 通信，引擎无关）
-                    Agent 工厂（可选 /metaskill，按需安装）
-```
-
-引擎层已抽象 —— Kimi 事件流和 Codex JSONL 都被翻译成 Claude 形状的 `SDKMessage`，流式卡片、工具调用追踪、MetaMemory/调度/Agent 总线在三种引擎下表现一致。
-
-## 仓库布局（Monorepo）
-
-MetaBot 从 2026-05-19 起把 `metabot-core` 合并进同一个 monorepo（npm workspaces）。Bridge 运行时仍在仓库根目录，吸收进来的中心服务侧在 `packages/` 下面：
-
-```
-metabot/                       # 仓库根 —— bridge 运行时（bot 主机用 PM2 跑）
-├── src/                       # bridge 引擎、流处理、Feishu/Telegram/微信桥接
-├── bin/                       # CLI（metabot 单一入口 / doubao-tts）
-├── web/                       # bridge 自带的浏览器 SPA
-├── packages/                  # 吸收进来的 metabot-core
-│   ├── server/                # 中心 HTTP 后端（ECS 部署单元）
-│   ├── cli/                   # `metabot <子命令>` 功能 CLI 实现
-│   ├── web-ui/                # 中心 SPA（Vite，编译后由 server/static/ 提供）
-│   ├── cli-core/              # CLI/客户端共享底层
-│   ├── metamemory/            # /api/memory 的瘦客户端
-│   ├── skill-hub/             # /api/skills 的瘦客户端
-│   └── skills/                # 默认 skill bundle 源（metabot SKILL.md）
-└── docs/                      # 全量文档
-```
-
-两半之间**只通过 HTTP `/api/*` 通信**，不允许跨包 import（由 ESLint `no-restricted-imports` + `packages/server/package.json` exports 锁双重护栏）。公开 GitHub Release 和源码 `install.sh` 默认安装完整个人版闭包，并分别以 PM2 的 `metabot-core`（9200）和 `metabot`（9100）运行；设置 `METABOT_INSTALL_CORE=0` 可保留外部 Core。独立 server 的 systemd 部署仍可走 `cd packages/server && sudo bash deploy/install.sh`。
-
-## 多端接入
-
-MetaBot 支持 4 种方式与你的 Agent 团队交互：
-
-| 客户端 | 场景 | 特色功能 |
-|--------|------|---------|
-| **飞书/Lark** | 工作场景，团队协作 | 流式交互卡片、@mention 路由、知识库自动同步 |
-| **Telegram** | 个人/国际用户 | 30 秒配置、长轮询无需公网 IP、群聊 + 私聊 |
-| **Web UI** | 浏览器端，语音对话 | 电话语音模式（VAD）、RTC 实时通话、MetaMemory 浏览器、团队看板 |
-
-| 支柱 | 组件 | 作用 |
-|------|------|------|
-| **受监督** | IM Bridge | 实时流式卡片展示每一步工具调用。人类看到 Agent 做的一切 |
-| **自我进化** | MetaMemory | 共享知识库。Agent 写入学到的东西，其他 Agent 检索引用 |
-| **Agent 组织** | Agent 总线 + CC 原生调度（可选 MetaSkill / MetaSchedule） | Agent 互相委派任务、按需创建新 Agent；用 CC 内置 `CronCreate` / `/loop` 即可定时；要跨重启可装可选 `/metaschedule` |
-
-## Web UI
-
-浏览器端全功能聊天界面，部署即可用。访问地址：`https://your-server/web/`
-
-![MetaBot Web UI](resources/web-ui.png)
-
-- **实时流式聊天** — WebSocket 推送，Markdown 渲染，工具调用展示
-- **电话语音模式** — 点击电话图标，全屏免手对话，VAD 自动检测说完
-- **RTC 实时通话** — 基于火山引擎 RTC 的双向语音/视频通话
-- **群聊模式** — 多个 Agent 在一个对话中协作，@mention 路由
-- **MetaMemory 浏览器** — 搜索和浏览共享知识库
-- **团队看板** — 查看 Agent 组织状态概览
-- **文件支持** — 上传/下载文件，内联预览
-- **明暗主题** — 跟随系统或手动切换
-
-**技术栈**：React 19 + Vite + Zustand + react-markdown
-
-> 语音功能需要 HTTPS。推荐用 Caddy 反向代理，自动管理证书。详见 [Web UI 文档](docs/features/web-ui.zh.md)。
-
-## 核心能力
-
-| 组件 | 一句话说明 |
-|------|-----------|
-| **三引擎内核** | 每个 Bot 独立选 Claude Code / Kimi Code / Codex CLI — 完整工具链（Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP），自主模式运行 |
-| **常驻会话与目标循环** | 每个会话一个常驻 Claude 进程 — `/goal` 让 Agent 在多轮之间持续自驱直到目标达成；团队成员和后台任务跨轮存活 |
-| **Agent 团队（运行时）** | 主导 Agent 并行派遣专家队友，互相路由任务、汇总结果 —— 全部在一个飞书会话中完成 |
-| **CC 原生调度** | 直接用 Claude Code 内置的 `CronCreate` / `/loop` —— 即开即用，会话内最简单 |
-| **MetaMemory** | 由 metabot-core 服务（本地自托管，默认 `http://localhost:9200`）提供的共享知识库，全文搜索；MetaBot 通过 `/api/memory/*` 读写，并可同步到飞书知识库 |
-| **IM Bridge** | 飞书、Telegram、微信（含手机端）对话任意 Agent，流式卡片 + 工具调用追踪 |
-| **Agent 总线** | Agent 通过 `metabot talk` 互相对话，运行时创建/删除 Bot |
-| **MetaSchedule（可选）** | 跨重启的服务端定时调度器，Cron + 一次性延迟，HTTP API + `metabot schedule` CLI。默认不装，按需 `cp src/skills/metaschedule/SKILL.md` 启用 |
-| **MetaSkill（可选）** | Agent 工厂。`/metaskill` 一键生成可迁移的 Agent 团队。默认不装，按需 `cp src/skills/metaskill/` 启用 |
-| **飞书 Lark CLI** | 200+ 命令覆盖文档、消息、日历、任务等 11 大业务域，19 个 AI Agent Skills |
-| **Skill Hub** | 中心化技能共享注册中心。`metabot skills` 发布、发现、安装技能，FTS5 全文搜索（由 metabot-core 提供）|
-| **Peers 联邦** | 跨实例 Bot 发现和任务路由，`metabot talk alice/backend-bot` 自动路由 |
-| **语音助手** | Jarvis 模式 — AirPods 说 "Hey Siri, Jarvis" 语音控制 Agent |
+安装器会把 MetaBot 内置 Skills 镜像到当前引擎路径，并保留用户已修改的本地 Skills。
 
 ## 快速开始
 
-### Telegram（30 秒）
+前置条件：**Node.js >= 22.19**、Git，以及至少一个引擎和一个聊天渠道的凭证。
 
-1. 找 [@BotFather](https://t.me/BotFather) → `/newbot` → 复制 token
-2. 写入 `bots.json` → 完成（长轮询，无需 Webhook）
+1. 执行上面的一行安装命令。
+2. 选择 Codex 或 Kimi Code，并在独立终端完成登录。
+3. 按引导连接飞书/Lark、Telegram 或微信。
+4. 验证服务并打开本地控制台：
 
-### 微信（灰测中）
-
-1. iPhone 微信 8.0.70+ → 设置 → 插件 → 开启 **ClawBot**
-2. 运行 `install.sh`，选 `3) WeChat ClawBot` — 扫码绑定
-3. 详见 [微信接入指南](docs/features/wechat.zh.md)
-
-### 飞书
-
-1. [open.feishu.cn](https://open.feishu.cn/) 创建应用 → 添加「机器人」能力
-2. 开通权限：`im:message`、`im:message:readonly`、`im:resource`、`im:chat:readonly`
-3. 先启动 MetaBot，再开启「长连接」+ `im.message.receive_v1` 事件
-4. 发布应用
-
-> 不需要公网 IP。飞书用 WebSocket，Telegram 和微信用长轮询。
-
-**Web UI**：启动 MetaBot 后访问 `http://localhost:9100/web/`，输入 API_SECRET 即可使用。
-
-## 示例 Prompt
-
-刚接触 MetaBot？以下是你可以直接在飞书/Telegram 中发送的真实 prompt：
-
-### MetaMemory — 持久化知识库
-
-```
-把我们刚讨论的部署方案写入 MetaMemory，放到 /projects/deployment 下面。
+```bash
+metabot status
+metabot health
 ```
 
-```
-搜索一下 MetaMemory 里有没有关于 API 设计规范的文档。
-```
+打开 `http://localhost:9200`，粘贴 `~/.metabot-core/token` 中的 Token，再选择 Bot。
 
-### 定时任务（Claude Code 原生）
+| 渠道 | 适合场景 | 配置入口 |
+|---|---|---|
+| **飞书/Lark** | 工作空间、流式卡片、文件、群聊路由 | [飞书应用配置](docs/getting-started/feishu-app-setup.zh.md) |
+| **Telegram** | 最快个人配置；不需要公网 IP | [快速配置](docs/getting-started/quick-setup.zh.md) |
+| **微信** | 通过 ClawBot 接入个人微信；目前灰测中 | [微信指南](docs/features/wechat.zh.md) |
+| **Web** | 浏览器 Chat、Core、Memory、Teams 和设置 | `http://localhost:9200` |
 
-直接用 CC 内置的 `CronCreate` 和 `/loop`，会话内即开即用：
+飞书使用长连接 WebSocket，Telegram 和微信使用长轮询，都不需要开放公网入站端口。
 
-```
-设个每天早上9点的定时任务：搜索 Hacker News 和 TechCrunch 的 AI 新闻，
-总结 Top 5，保存到 MetaMemory。
-```
+飞书群里的普通消息只路由给被准确 @ 的 Bot。群主可以用
+`@Bot /group-reply ...` 为每个 Bot、每个群选择仅 @ 或回复全部消息；裸命令
+和只 @ 其他 Bot 的命令会被忽略。仅 @ 模式下，未 @ 的文件会保留给下一条
+@Bot 指令。详见[聊天命令](docs/usage/chat-commands.zh.md#group-reply-modes)。
 
-```
-/loop 每隔 5 分钟检查一下 PR #123 的 CI 状态，跑完为止
-```
+## 最小双 Bot 配置
 
-> 想跨重启活下来、其他 Bot 也能看到/取消？装可选的 `/metaschedule` skill
-> （`cp src/skills/metaschedule/SKILL.md ~/.claude/skills/metaschedule/`），
-> 就能用 `metabot schedule cron` / HTTP API 提交到 MetaBot 服务端调度器。
-
-### Agent 团队 — 运行时协作
-
-```
-你来当主导工程师。并行派出一个前端专家和一个后端专家：
-前端负责 React UI 改造，后端加上新的 /api/reports 接口，
-你负责 review 两边的 PR，全部通过后再合并。
-```
-
-### 目标循环
-
-```
-/goal PR #123 的 CI 全绿、部署成功。
-每 10 分钟检查一次，搞定后告诉我。
-```
-
-### MetaSkill — Agent 工厂（可选）
-
-`/metaskill` 默认不装。先启用：`cp -r src/skills/metaskill ~/.claude/skills/`，然后：
-
-```
-/metaskill 给这个 React Native 项目创建一个 agent 团队 ——
-我需要一个前端专家、一个后端 API 专家、一个 code reviewer。
-```
-
-### Agent-to-Agent 协作
-
-```
-把这个 bug 委派给 backend-bot 处理："修复 /api/users/:id 的空指针异常"。
-```
-
-```
-让 frontend-bot 更新仪表盘 UI，同时让 backend-bot 加上新的 API 接口。
-两边都把进度记录到 MetaMemory。
-```
-
-### 组合工作流
-
-```
-读一下这个飞书文档 [粘贴链接]，提取产品需求，拆成任务，
-然后设一个每天下午6点的定时任务，对照需求跟踪开发进度。
-```
-
-```
-（先 cp src/skills/metaskill 到 ~/.claude/skills/ 以启用 /metaskill）
-/metaskill 创建一个 "daily-ops" agent，让它每天早上8点跑：
-检查服务健康状态、review 昨晚的错误日志、发一份运维摘要。
-```
-
-## 飞书使用技巧
-
-<details>
-<summary><strong>私聊 vs 群聊</strong></summary>
-
-| 场景 | @提及 | 说明 |
-|------|-------|------|
-| **私聊** | 不需要 | 所有消息直接发送给 Bot |
-| **1对1 群聊**（你 + Bot 两人群） | 不需要 | 自动识别为类私聊 |
-| **多人群聊** | 默认需要 @Bot | 群主可以为每个 Bot、每个群选择 `mention` 或 `all` |
-
-> **推荐**：建一个只有你和 Bot 的两人群聊。不需要每次 @Bot，又能保留群聊的好处（置顶、分类管理）。
-
-群主可以使用 `@Bot /group-reply mention`、`@Bot /group-reply all` 和
-`@Bot /group-reply status`。命令必须准确 @ 当前 Bot；裸命令和只 @ 其他 Bot
-的命令会被忽略。设置按 Bot + 群聊持久化。详见
-[聊天命令](docs/usage/chat-commands.zh.md)。
-
-</details>
-
-<details>
-<summary><strong>发送文件和图片</strong></summary>
-
-**私聊 / 两人群**：默认直接发送文件或图片，Bot 自动处理。支持多文件批量发送（2 秒内自动合并）。如果两人群被显式设为 `mention`，则仍需 @Bot。
-
-**`mention` 模式的多人群聊**：飞书限制 — 上传文件时无法同时 @Bot。解决方案：**先传后 @**
-
-1. 先在群里上传文件或图片
-2. 5 分钟内 @Bot 说「分析一下」
-3. Bot 自动把你之前上传的文件附上
-
-支持的消息类型：文本、图片（Claude 多模态）、文件（PDF/代码/文档）、富文本（Post 格式）、多文件批量。
-
-`all` 模式下，未 @ 的文件和图片会立即处理。
-
-</details>
-
-## 配置
-
-**`bots.json`** — 定义你的 Bot：
+一个 Bridge 进程的 `bots.json` 可以混用引擎和工作区：
 
 ```json
 {
-  "feishuBots": [{
-    "name": "metabot",
-    "feishuAppId": "cli_xxx",
-    "feishuAppSecret": "...",
-    "defaultWorkingDirectory": "/home/user/project"
-  }],
-  "telegramBots": [{
-    "name": "tg-bot",
-    "telegramBotToken": "123456:ABC...",
-    "defaultWorkingDirectory": "/home/user/project"
-  }]
+  "feishuBots": [
+    {
+      "name": "codex-dev",
+      "engine": "codex",
+      "feishuAppId": "cli_xxx",
+      "feishuAppSecret": "...",
+      "defaultWorkingDirectory": "/home/me/project-a"
+    },
+    {
+      "name": "kimi-reviewer",
+      "engine": "kimi",
+      "feishuAppId": "cli_yyy",
+      "feishuAppSecret": "...",
+      "defaultWorkingDirectory": "/home/me/project-b",
+      "kimi": { "thinking": true }
+    }
+  ]
 }
 ```
 
-<details>
-<summary><strong>所有 Bot 配置字段</strong></summary>
+每个 Bot 拥有独立的渠道凭证、引擎、工作区和会话，同时仍可通过 Agent Teams 和 Agent Bus 协作。
 
-| 字段 | 必填 | 默认值 | 说明 |
-|------|------|--------|------|
-| `name` | 是 | — | Bot 标识名 |
-| `defaultWorkingDirectory` | 是 | — | Claude 的工作目录 |
-| `feishuAppId` / `feishuAppSecret` | 飞书 | — | 飞书应用凭证 |
-| `telegramBotToken` | Telegram | — | Telegram Bot Token |
-| `wechatBotToken` | 微信(可选) | — | 预认证 iLink token（不填则 QR 登录） |
-| `maxTurns` / `maxBudgetUsd` | 否 | 不限 | 执行限制 |
-| `model` | 否 | SDK 默认 | Claude 模型 |
-| `apiKey` | 否 | — | Anthropic API Key（不设则从 `~/.claude/.credentials.json` 动态读取，兼容 cc-switch） |
-| `visible` | 否 | `true` | Bot 是否对其他 bot / Agent Bus 可见，可被 `metabot talk` 触达。每次 bridge bulk-register 都按 bots.json 回写（不 sticky）|
-| `memoryPublic` | 否 | `true` | `metabot memory create/mkdir` 不带 `--path` 时的默认落点：`true` = `/shared/<bot>`（其他人可读），`false` = `/users/<bot>`（私有）。显式传 `--path` 永远以传入为准。bots.json 不写则保留 `metabot memory visibility` CLI 上次设置（sticky）|
+## 包含的能力
 
-</details>
+- **移动端写代码** — 从聊天中改代码、跑测试、查看工具并跟进长任务。
+- **Agent Teams** — 创建专门队友、并行分工，保留持久的任务和运行状态。[指南](docs/features/agent-teams.zh.md)
+- **MetaMemory** — 跨会话检索知识，并可同步到飞书知识库。[指南](docs/features/metamemory.zh.md)
+- **T5T 与 Goal** — 持久项目检查点和受监督的多轮执行。[目标循环](docs/features/goal-loops.zh.md)
+- **Skill Hub** — 通过统一的 `metabot` CLI 安装和发布可复用 Skills。
+- **本地 Core 与 Web UI** — Token 鉴权的 Agents、Memory、Skills、Teams、Chat 和诊断。
+- **渠道与媒体** — 文本、富文本、图片、文件、音频、智能合并和精确 @Bot 路由。
+- **Peers、调度与语音** — 面向更大个人环境的可选能力。[功能文档](docs/)
 
-<details>
-<summary><strong>环境变量 (.env)</strong></summary>
+## 常用命令
 
-| 变量 | 默认 | 说明 |
-|------|------|------|
-| `API_PORT` | 9100 | HTTP API 端口 |
-| `API_SECRET` | — | Bearer 认证（同时保护 API 和 Web UI） |
-| `METABOT_CORE_URL` | `http://localhost:9200` | metabot-core 服务地址（MetaMemory + Skill Hub + Agents + T5T），本地自托管或填你自己的远程地址 |
-| `METABOT_CORE_TOKEN` | 读 `~/.metabot-core/token` | metabot-core Bearer Token；首次启动从 `~/.metabot-core/data/admin-bootstrap-token.txt` 获取 |
-| `WIKI_SYNC_ENABLED` | true | 启用 MetaMemory→飞书知识库同步 |
-| `WIKI_SPACE_NAME` | MetaMemory | 飞书知识库空间名称 |
-| `WIKI_SYNC_STATE_DIR` | `./data` | Wiki 同步映射 SQLite 存放目录 |
-| `VOLCENGINE_TTS_APPID` | — | 豆包语音（TTS + STT） |
-| `VOLCENGINE_TTS_ACCESS_KEY` | — | 豆包语音密钥 |
-| `METABOT_URL` | `http://localhost:9100` | MetaBot API 地址 |
-| `METABOT_PEERS` | — | Peer MetaBot 地址（逗号分隔） |
-| `LOG_LEVEL` | info | 日志级别 |
+| 命令 | 用途 |
+|---|---|
+| `/model` | 查看或切换当前引擎/模型 |
+| `/effort low\|medium\|high\|xhigh\|max\|ultra` | 设置当前 Chat 的 Codex 推理强度 |
+| `/status` | 查看当前会话和模型 |
+| `/reset` | 开始新会话 |
+| `/stop` | 停止当前任务 |
+| `/goal <条件>` | 跨轮持续工作，直到完成、阻塞或到达上限 |
+| `/background <提示>` | 在 Chat 继续使用时运行受支持的后台任务 |
+| `@Bot /group-reply mention\|all\|status` | 控制一个飞书 Bot 在一个群里的回复模式 |
+| `metabot update` | 更新并重启已安装的个人版 |
 
-</details>
+完整命令详见[聊天命令](docs/usage/chat-commands.zh.md)、[CLI 参考](docs/reference/cli-metabot.zh.md)和 [REST API](docs/reference/api.zh.md)。
 
-<details>
-<summary><strong>第三方 AI 服务商（国产模型）</strong></summary>
+## 文档
 
-支持 Kimi、DeepSeek、GLM 等 Anthropic 兼容 API：
+- 开始：[安装](docs/getting-started/installation.zh.md) · [快速配置](docs/getting-started/quick-setup.zh.md) · [故障排除](docs/troubleshooting.zh.md)
+- 配置：[多 Bot](docs/configuration/multi-bot.zh.md) · [环境变量](docs/configuration/environment-variables.zh.md) · [生产部署](docs/deployment/production.zh.md)
+- 使用：[聊天命令](docs/usage/chat-commands.zh.md) · [示例 Prompt](docs/usage/example-prompts.zh.md) · [使用场景](docs/usage/use-cases.zh.md)
+- 开发：[架构](docs/concepts/architecture.zh.md) · [项目结构](docs/development/project-structure.zh.md) · [贡献指南](CONTRIBUTING.md)
+
+## 更新与开发
+
+Release 安装从稳定 GitHub 资源更新，源码 checkout 从 Git 更新：
 
 ```bash
-ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic    # Kimi/月之暗面
-ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic   # DeepSeek
-ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic       # GLM/智谱
-ANTHROPIC_AUTH_TOKEN=你的key
+metabot update          # Package 安装
+metabot update --git    # 源码 checkout
 ```
 
-</details>
-
-<details>
-<summary><strong>cc-switch 兼容</strong></summary>
-
-兼容 [cc-switch](https://github.com/farion1231/cc-switch)、[cc-switch-cli](https://github.com/SaladDay/cc-switch-cli)、[CCS](https://github.com/kaitranntt/ccs) 等认证切换工具。用 `cc switch` 切换 API/订阅模式后，MetaBot **无需重启**即可生效。
-
-如需固定使用某个 API Key，在 `bots.json` 中设置 `apiKey` 字段。
-
-</details>
-
-<details>
-<summary><strong>安全</strong></summary>
-
-MetaBot 以 `bypassPermissions` 模式运行 Claude Code — 无交互式确认：
-
-- Claude 对工作目录有完整读写执行权限
-- 通过飞书/Telegram/微信平台设置控制访问
-- 用 `maxBudgetUsd` 限制单次花费
-- `API_SECRET` 保护 API 服务器
-- MetaMemory 由中心 metabot-core 服务托管，认证与 ACL 在中心侧统一管理
-
-</details>
-
-## 聊天命令
-
-| 命令 | 说明 |
-|------|------|
-| `/reset` | 清除会话 |
-| `/stop` | 中止当前任务 |
-| `/status` | 查看会话状态（含当前模型） |
-| `/goal <条件>` | 设置目标，Agent 跨多轮持续推进直到达成。`/goal clear` 停止 |
-| `/model` | 查看当前模型；`/model list` 查看可用模型；`/model <name>` 切换；`/model reset` 恢复默认 |
-| `/memory list` | 浏览知识库目录 |
-| `/memory search 关键词` | 搜索知识库 |
-| `/sync` | 同步 MetaMemory 到飞书知识库 |
-| `/metaskill ...` | 生成 Agent 团队、Agent 或 Skill（可选 skill，默认不装） |
-| `/help` | 帮助 |
-
-> **模型切换**：每个会话可独立设置模型，默认 `claude-fable-5`。Fable 5 使用 Claude Code 原生 1M 上下文、128k max output 和 adaptive thinking；Opus/Sonnet 仍默认保持 200k 上下文，可在模型名后加 `[1m]` 启用 1M，例如 `/model claude-opus-4-8[1m]`。
-> **Codex Skill 调用**：飞书里发的 `/<skill> ...` 在 Codex 会话下会被 MetaBot 自动改写成 `$<skill> ...`，例如 `$metaschedule ...`。
-
-<details>
-<summary><strong>API 参考</strong></summary>
-
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| `GET` | `/api/health` | 健康检查（无需认证）— 仅返回 `{ status, uptime }` |
-| `GET` | `/api/status` | 详细状态：Bot 数、peer、定时任务（需认证） |
-| `GET` | `/api/bots` | 列出 Bot（本地 + Peer） |
-| `POST` | `/api/bots` | 运行时创建 Bot |
-| `DELETE` | `/api/bots/:name` | 删除 Bot |
-| `POST` | `/api/talk` | 与 Bot 对话（自动路由到 peer） |
-| `GET` | `/api/peers` | 列出 Peer 及状态 |
-| `POST` | `/api/schedule` | 创建定时任务 |
-| `GET` | `/api/schedule` | 列出定时任务 |
-| `PATCH` | `/api/schedule/:id` | 更新定时任务 |
-| `DELETE` | `/api/schedule/:id` | 取消定时任务 |
-| `POST` | `/api/sync` | 触发 Wiki 同步 |
-| `GET` | `/api/stats` | 费用与使用统计 |
-| `GET` | `/api/metrics` | Prometheus 监控指标 |
-| `POST` | `/api/tts` | 文字转语音 |
-| `GET` | `/api/skills` | 列出技能（本地 + Peer） |
-| `GET` | `/api/skills/search?q=` | 全文搜索技能 |
-| `GET` | `/api/skills/:name` | 获取技能详情 |
-| `POST` | `/api/skills` | 发布技能 |
-| `POST` | `/api/skills/:name/install` | 安装技能到 Bot |
-| `DELETE` | `/api/skills/:name` | 删除技能 |
-
-</details>
-
-<details>
-<summary><strong>CLI 工具</strong></summary>
-
-安装器将 `metabot` 放到 `~/.local/bin/`，安装后立即可用。`metabot` 是**唯一的 CLI 入口**，三类命令：(1) bridge 进程控制（`update` / `start` / `stop` / `restart` / `logs` / `status`）；(2) bridge 守护进程 API（`bots` / `talk` / `schedule` / `peers` / `stats` / `voice` / `health`，curl 本地 `localhost:9100`）；(3) 其余（`t5t` / `agents` / `memory` / `skills`）转发给本仓库 monorepo 内 `packages/cli/bin/metabot` 提供的 metabot-core 功能 CLI。旧的 `mb`/`mm`/`mh` CLI 与 `metamemory`/`skill-hub` skill bundle 已下线（安装/更新时会自动清掉 `~/.local/bin/` 里的残留）。
+参与开发：
 
 ```bash
-# 1. MetaBot 进程管理（bin/metabot 直接处理）
-metabot update                      # 拉取最新代码，重新构建，更新 skills，重启
-metabot start / stop / restart      # PM2 管理
-metabot logs                        # 查看实时日志
-metabot status                      # PM2 进程状态
-
-# 2. bridge 守护进程 API（curl 本地 localhost:9100）
-metabot bots                        # 列出所有 Bot
-metabot talk <bot> <chatId> <prompt> # 与 Bot 对话
-metabot stats                       # 费用和使用统计
-metabot voice tts "你好世界" --play  # 文字转语音
-
-# 3. 功能子命令（转发给 metabot-core 功能 CLI）
-metabot t5t board                   # 团队日报看板
-metabot agents list                 # 对端 Bot 通讯录
-metabot memory search "部署指南"     # 共享记忆全文搜索
-metabot memory visibility           # 查看当前 bot 默认写 public 还是 private
-metabot memory visibility private   # 切到 private（默认写 /users/<bot>，仅自己可读）
-metabot skills list                 # 技能仓库（中心 Skill Hub）
-# 覆盖 metabot-core CLI 路径：export METABOT_CORE_CLI=/path/to/packages/cli/bin/metabot
-
-# 定时任务 — 推荐 CC 原生：直接在 Claude Code 里用 CronCreate / /loop。
-# 跨重启的服务端调度（metabot schedule list / cron / cancel / pause / resume）
-# 由可选 /metaschedule skill 提供，按需安装：
-#   cp src/skills/metaschedule/SKILL.md ~/.claude/skills/metaschedule/
-
-# 飞书 Lark CLI（飞书 Bot 专属）
-lark-cli docs +fetch --doc <飞书链接>
-lark-cli im +messages-send --chat-id oc_xxx --text "Hi"
-lark-cli calendar +agenda --as user
-
-# 文字转语音
-metabot voice tts "你好世界" --play
+git clone https://github.com/xvirobotics/metabot.git ~/metabot
+cd ~/metabot
+npm ci --include=dev
+npm test
 ```
 
-`metabot update` 会自动更新已安装的 `lark-cli` 和飞书/Lark skills，并同步到 bot 工作目录；新机器首次安装时仍由安装器引导是否启用飞书 skills。
+请使用 Node.js >= 22.19，并在提交 PR 前阅读[贡献指南](CONTRIBUTING.md)。
 
-CLI 支持连接远程 MetaBot 服务器，在 `~/.metabot/.env` 配置 `METABOT_URL` 即可；MetaMemory / Skill Hub / Agents / T5T 由 metabot-core 统一提供，配置 `METABOT_CORE_URL` + `METABOT_CORE_TOKEN`。个人版不依赖企业登录，Token 由本地管理员创建和轮换。
+## 安全
 
-</details>
+MetaBot Agent 可以在配置的工作区中读、写和执行代码。请妥善保管 Core 与 Bridge Token，限制 IM Bot 可见范围，仅通过自有鉴权反向代理或私有网络暴露本地端口。
 
-<details>
-<summary><strong>手动安装</strong></summary>
+## 关于与许可
 
-```bash
-git clone https://github.com/xvirobotics/metabot.git
-cd metabot && npm install
-cp bots.example.json bots.json   # 编辑 Bot 配置
-cp .env.example .env              # 编辑全局设置
-npm run dev
-```
-
-前置条件：Node.js 20+，[Claude Code CLI](https://github.com/anthropics/claude-code) 已安装并认证。
-
-</details>
-
-## 开发
-
-```bash
-npm run dev          # 热重载开发服务器（tsx）
-npm test             # 运行测试（vitest）
-npm run lint         # ESLint 检查
-npm run build        # TypeScript 编译
-```
-
-## Roadmap
-
-- [ ] 插件市场（MCP Server 一键安装）
-- [ ] 更多 IM 平台（Slack、Discord、钉钉）
-
-## 关于
-
-MetaBot 由 [XVI Robotics](https://xvirobotics.com) 打造（人形机器人大脑公司）。我们在内部用 MetaBot 把公司打造成 **Agent Native 组织** —— 一个小团队的人类，监督自我进化的 AI Agent。
-
-我们开源它，因为我们相信这是未来公司的运行方式。
-
-## License
-
-[MIT](LICENSE)
+MetaBot 由 [XVI Robotics](https://xvirobotics.com) 开发，采用 [MIT License](LICENSE) 开源。

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,596 +2,208 @@
 
 # 🤖 MetaBot
 
-### Control Claude Code, Kimi Code, or Codex CLI from your phone via Feishu / Telegram / WeChat
+### Run Codex and Kimi Code from Feishu/Lark, Telegram, WeChat, or the Web
 
-*Write code · Manage agents · Automate everything*
-
-<p>
-  <a href="https://github.com/xvirobotics/metabot"><img src="https://img.shields.io/badge/GitHub-Repo-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="License"></a>
-</p>
+*A self-hosted personal agent workspace. Claude Code remains available for compatibility.*
 
 <p>
-  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
-  <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
   <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Engine-Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
-  <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
-  <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
+  <a href="https://www.kimi.com/code"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge" alt="Kimi Code"></a>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Compatibility-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code compatibility"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
+  <img src="https://img.shields.io/badge/Node.js-%3E%3D22.19-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js 22.19 or newer">
 </p>
 
-<p>
-  <a href="https://feishu.cn"><img src="https://img.shields.io/badge/Feishu_/_Lark-00D6B9?style=for-the-badge&logo=lark&logoColor=white" alt="Feishu/Lark"></a>
-  <a href="https://telegram.org"><img src="https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram"></a>
-  <a href="https://ilinkai.weixin.qq.com"><img src="https://img.shields.io/badge/WeChat_ClawBot-07C160?style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
-  <img src="https://img.shields.io/badge/Web_UI-61DAFB?style=for-the-badge&logo=react&logoColor=white" alt="Web UI">
-</p>
-
-[中文](README.md) · **English** · [📚 Docs](docs/)
+[中文](README.md) · **English** · [Documentation](https://xvirobotics.com/metabot/)
 
 </div>
-
-> **Claude Code**, **Kimi Code**, and **Codex CLI** — three first-class engines. Subscription or API key, your choice. Each bot picks its own engine.
 
 <div align="center">
 <table>
 <tr>
   <td width="25%"><img src="resources/demo-1.png" alt="Spawn an agent team" /></td>
   <td width="25%"><img src="resources/demo-2.png" alt="Dispatch a task" /></td>
-  <td width="25%"><img src="resources/demo-3.png" alt="Agents working between turns" /></td>
+  <td width="25%"><img src="resources/demo-3.png" alt="Watch agents work" /></td>
   <td width="25%"><img src="resources/demo-4.png" alt="PR merged" /></td>
 </tr>
 </table>
-<sub>Feishu mobile · Spawn a team · Dispatch a task · Watch progress · PR merged</sub>
+<sub>Feishu mobile · Spawn a team · Dispatch work · Follow progress · Merge the PR</sub>
 </div>
 
 ```bash
 curl -fsSL https://github.com/xvirobotics/metabot/releases/latest/download/install.sh | bash
 ```
 
-The installer deploys the complete personal edition (local Core + Web UI + Bridge + CLI), generates and stores the local Bearer token without printing it, then walks you through: working directory → **engine choice (Claude / Kimi / Codex)** → subscription login → IM platform → auto-start with PM2. The console is available at `http://localhost:9200`. **5 minutes to get started.**
+The signed-checksum installer deploys the complete personal edition in about five minutes: local Core, token-only Web UI, IM Bridge, CLI, skills, and PM2 services.
 
-> Custom install directory (default `~/metabot`): clone into the directory you want, or `METABOT_HOME=/opt/metabot bash install.sh`. Windows: `.\install.ps1 -Dir C:\opt\metabot`.
->
-> For source development: `git clone https://github.com/xvirobotics/metabot.git ~/metabot && cd ~/metabot && bash install.sh`. Release installs and source checkouts use separate update paths; `metabot update` detects the right one automatically.
+## Personal Edition
 
----
+MetaBot runs on your machine and does not require corporate SSO, OIDC, a VPN, or an employee directory.
 
-## 🔑 Self-Hosted & Auth (Personal Edition)
+- The local Core and personal console default to `http://localhost:9200`.
+- The installer generates a Bearer token, stores it at `~/.metabot-core/token` with mode `0600`, and never prints it into logs.
+- Core data stays under `~/.metabot-core/`; Bridge state stays under `~/.metabot/`.
+- Release assets are checksum-verified before extraction.
+- Existing external Core deployments remain supported with `METABOT_INSTALL_CORE=0`.
 
-MetaBot is a **self-hostable personal edition** out of the box: runs locally, single-token auth, **no SSO or corporate login required**.
+See [Installation](docs/getting-started/installation.md) for custom paths, source installs, updates, Windows status, and external-Core setup.
 
-- **Local-first**: `metabot-core` listens on `http://localhost:9200` by default and writes the one-time admin token to `~/.metabot-core/data/admin-bootstrap-token.txt` on first launch. Paste it into the web console login screen, and optionally save it as `~/.metabot-core/token` (mode `0600`) for CLI use. Data lives under `~/.metabot-core/` by default.
-- **No SSO**: no OAuth / OIDC / corporate VPN needed. To expose it to other people or the public internet, put your own reverse proxy (optionally oauth2-proxy) in front — it's never required at the app layer.
-- **Distribution endpoints are locked by default**: `/cli/*` and `/install/*` require a token; once you've confirmed your build embeds no secrets, set `METABOT_PUBLIC_DISTRIBUTION=1` to allow anonymous downloads.
+The default install directory is `~/metabot`. Override it with
+`METABOT_HOME=/opt/metabot bash install.sh`; source checkouts and Release
+installs retain separate update paths so `metabot update` never guesses blindly.
 
----
+## Engines
 
-## Multi-Engine: Claude Code, Kimi Code, and Codex CLI
+Codex is the default engine. Kimi Code is a first-class alternative. Claude Code is retained so existing Claude-based bots and workspaces continue to run.
 
-MetaBot isn't locked to one vendor — all three top AI coding agents ship with native support, and **your subscription works directly**.
-
-| | **Claude Code** (Anthropic) | **Kimi Code** (Moonshot) | **Codex CLI** (OpenAI) |
+| Engine | Connects through | Authentication | Current OSS behavior |
 |---|---|---|---|
-| **Subscription login** | ✅ `claude login` OAuth | ✅ `kimi login` | ✅ `codex login` — uses your ChatGPT subscription |
-| **API key fallback** | ✅ `ANTHROPIC_API_KEY` or third-party Anthropic-compat endpoints | ✅ Moonshot API key | ✅ `OPENAI_API_KEY` / Codex profile |
-| **Context window** | 200k (1M optional on Opus/Sonnet) | 256k (kimi-for-coding) | 400k (gpt-5.x-codex) |
-| **Tools** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | Same (Kimi CLI builtin + `.claude/skills/` auto-discovery) | Codex CLI native toolchain + `.codex/skills/` auto-discovery |
-| **Autonomous mode** | `bypassPermissions` | `yoloMode` (equivalent) | Defaults to `--sandbox danger-full-access` to avoid `bwrap` failures on hosts without user namespaces |
-| **Subagents** | `.claude/agents/*.md` auto-loaded | Builtin `default` / `okabe` only | Project subagents are not auto-loaded; put role routing in `AGENTS.md` |
-| **Workspace doc** | `CLAUDE.md` | `AGENTS.md` (installer creates the symlink) | `AGENTS.md` (Codex convention) |
+| **Codex CLI** | `codex exec --json` and `codex exec resume` | `codex login` or OpenAI-compatible API configuration | JSONL streaming, tools, session resume, `/model`, `/effort`, bridge-managed goals and background tasks |
+| **Kimi Code 0.27+** | Official local Server API used by Kimi's own web frontend | `kimi login` | Durable Sessions, live snapshots, questions, stop/resume, tools, subagents, and goals |
+| **Claude Code compatibility** | Claude CLI / Agent SDK compatibility path | `claude login` or Anthropic-compatible API | Existing Claude sessions, skills, and workspaces remain usable |
 
-**One line of config** — each bot picks its engine:
-```json
-{ "name": "bulma", "engine": "kimi",   "kimi": { "thinking": true } }
-{ "name": "goku",  "engine": "claude" }
-{ "name": "vegeta", "engine": "codex", "codex": { "model": "gpt-5.5" } }
+The public Codex adapter currently uses `codex exec`; Codex app-server and Feishu mid-turn steering for Codex/Kimi remain gated on the later shared reliability foundation.
+
+Install or authenticate an engine from a standalone terminal:
+
+```bash
+npm install -g @openai/codex
+codex login
+
+npm install -g @moonshot-ai/kimi-code@latest   # Kimi Code 0.27+
+kimi login
 ```
 
-Codex support uses the local `codex exec --json` CLI and resumes chat sessions with `codex exec resume`. Authenticate once with `codex login` (or configure your Codex API key/profile) before starting MetaBot. MetaBot translates Feishu slash-skill invocations like `/<skill> ...` into Codex's explicit `$<skill> ...` skill syntax (e.g. once `/metaschedule` is installed, Codex receives `$metaschedule ...`).
+Each bot selects an engine in `bots.json`; if omitted, the engine defaults to `codex`. See [Multi-Bot Configuration](docs/configuration/multi-bot.md) and [Environment Variables](docs/configuration/environment-variables.md).
 
-### Codex Migration: Reuse `.claude` Config
+Engine workspace conventions remain native:
 
-Claude/Kimi and Codex use different discovery paths. MetaBot mirrors bundled skills during install/update and Skill Hub installs:
-
-| Content | Claude / Kimi | Codex |
-|---------|---------------|-------|
-| Workspace instructions | `CLAUDE.md` | `AGENTS.md` |
-| Skills | `.claude/skills/<name>/SKILL.md` | `.codex/skills/<name>/SKILL.md` |
-| Subagents | `.claude/agents/*.md` | Not auto-loaded; migrate roles/routes into `AGENTS.md` |
-
-For an existing project, ask Codex to migrate it:
-
-```text
-/model codex
-Use the current project's .claude config to create Codex-compatible .codex/skills and AGENTS.md:
-- mirror .claude/skills/* into .codex/skills/*
-- generate or update AGENTS.md from CLAUDE.md
-- if .claude/agents/*.md exists, merge those subagent roles, routing tables, and workflows into AGENTS.md
-```
-
-If the host disables unprivileged user namespaces, Codex CLI's `workspace-write` sandbox can fail before commands run with `bwrap: No permissions to create a new namespace`. MetaBot defaults Codex to `danger-full-access` to avoid that failure; set `CODEX_SANDBOX` or `codex.sandbox` explicitly if you want stricter isolation.
-
-Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The Agent Bus lets them delegate to each other — the calling bot doesn't need to know which engine is on the other side.
-
----
-
-## What You Can Build
-
-- **Code from your phone** — message Claude Code / Kimi Code / Codex CLI from Feishu on the subway, it fixes bugs, opens PRs, runs tests
-- **Multi-agent teams** — frontend bot, backend bot, infra bot, each in their own workspace (even their own engine), delegating via Agent Bus
-- **Self-growing knowledge** — agents save what they learn to MetaMemory, the organization gets smarter daily
-- **Automated pipelines** — "Search AI news every morning at 9am, summarize top 5, save to archive" — one sentence
-- **Voice assistant (Jarvis mode)** — "Hey Siri, Jarvis" from AirPods, hands-free voice control of any agent
-- **Self-growing organization** — a manager bot creates new agents on demand, assigns tasks, schedules follow-ups
-
-## Why MetaBot
-
-| | MetaBot | Claude / Kimi / Codex CLI (terminal) | Dify / Coze |
+| Content | Codex | Kimi Code | Claude compatibility |
 |---|---|---|---|
-| **Mobile access** | Feishu/TG/WeChat anywhere | Terminal only | Yes, but can't run code |
-| **Engine choice** | Claude ✕ Kimi ✕ Codex, three engines | One at a time | None, API calls only |
-| **Subscription login** | All three native subscriptions work directly | One at a time | Subscriptions not supported |
-| **Code capabilities** | Full Agent SDK (Read/Write/Edit/Bash/MCP) | Full | None |
-| **Multi-agent** | Agent Bus + task delegation + runtime creation | Single session | Yes, but closed ecosystem |
-| **Shared memory** | MetaMemory with FTS + auto-sync to Wiki | None | None |
-| **Scheduling** | CC-native `CronCreate` / `/loop` work out of the box; opt-in `/metaschedule` for cross-restart persistence | Native `CronCreate` / `/loop` only | Yes |
-| **Autonomous** | bypassPermissions / yoloMode, fully automated | Requires human approval | Limited to workflows |
-| **Open source** | MIT, fully controllable | CLI is open source | Closed-source SaaS |
+| Instructions | `AGENTS.md` | `AGENTS.md` | `CLAUDE.md` compatibility entry |
+| Skills | `.codex/skills/` | `.agents/skills/` | `.claude/skills/` |
+| Subscription state | Codex profile | `~/.kimi-code/` | Claude credentials |
 
-## Multi-Platform Access
-
-![MetaBot Architecture](resources/metabot.png)
-
-```
-Feishu/TG/WeChat → IM Bridge → Engine Router ──┬─→ Claude Code Agent SDK
-                                                ├─→ Kimi Agent SDK (@moonshot-ai/kimi-agent-sdk)
-                                                └─→ Codex CLI (codex exec --json subprocess)
-                                    ↕
-                         MetaMemory (shared knowledge)
-                         Scheduling (CC-native CronCreate / /loop; opt-in /metaschedule for persistence)
-                         Agent Bus (cross-bot comms, engine-agnostic)
-                         Agent Factory (opt-in /metaskill)
-```
-
-The engine layer is abstracted — Kimi's event stream and Codex's JSONL stream are both translated into Claude-shaped `SDKMessage` objects, so streaming cards, tool-call tracking, MetaMemory/Scheduler/Agent Bus behave identically across all three engines.
-
-## Monorepo Layout
-
-As of 2026-05-19, MetaBot absorbed `metabot-core` into a single npm-workspaces monorepo. The bridge runtime stays at the repo root; the central-service half lives under `packages/`:
-
-```
-metabot/                       # repo root — bridge runtime (bot hosts run this under PM2)
-├── src/                       # bridge engine, stream processing, Feishu/Telegram/WeChat bridges
-├── bin/                       # CLI (metabot single entrypoint / doubao-tts)
-├── web/                       # bridge's own browser SPA
-├── packages/                  # absorbed metabot-core
-│   ├── server/                # central HTTP backend (ECS deploy unit)
-│   ├── cli/                   # `metabot <subcommand>` feature CLI
-│   ├── web-ui/                # central SPA (Vite, served from server/static/)
-│   ├── cli-core/              # shared HTTP client building blocks
-│   ├── metamemory/            # thin client for /api/memory/*
-│   ├── skill-hub/             # thin client for /api/skills/*
-│   └── skills/                # default skill bundle source (metabot SKILL.md)
-└── docs/                      # all docs
-```
-
-The two halves communicate **only over HTTP `/api/*`** — cross-package imports are blocked by ESLint `no-restricted-imports` plus a tight `packages/server/package.json` exports lock. Public GitHub Releases and source `install.sh` now install the complete personal-edition closure and run `metabot-core` (9200) and `metabot` (9100) as separate PM2 apps. Set `METABOT_INSTALL_CORE=0` to keep an external Core. The standalone server systemd path remains available via `cd packages/server && sudo bash deploy/install.sh`.
-
-| Client | Use Case | Key Features |
-|--------|----------|-------------|
-| **Feishu/Lark** | Work, team collaboration | Streaming interactive cards, @mention routing, Wiki auto-sync |
-| **Telegram** | Personal / international | 30-second setup, long polling (no public IP), group + private chat |
-| **Web UI** | Browser, voice conversations | Phone call mode (VAD), RTC calls, MetaMemory browser, team dashboard |
-
-## Web UI
-
-| Pillar | Component | What it does |
-|--------|-----------|-------------|
-| **Supervised** | IM Bridge | Real-time streaming cards show every tool call. Humans see everything agents do |
-| **Self-Improving** | MetaMemory | Shared knowledge store. Agents write what they learn, other agents retrieve it |
-| **Agent Organization** | Agent Bus + CC-native scheduling (opt-in MetaSkill / MetaSchedule) | Agents delegate tasks and spin up new bots on demand; CC's built-in `CronCreate` / `/loop` cover scheduling, and opt-in `/metaschedule` adds cross-restart persistence |
-
-Full-featured browser-based chat interface. Access at `https://your-server/web/` after starting MetaBot.
-
-![MetaBot Web UI](resources/web-ui.png)
-
-- **Real-time streaming** -- WebSocket, Markdown rendering, tool call display
-- **Phone call mode** -- Tap phone icon for fullscreen hands-free voice conversation with VAD
-- **RTC calls** -- Two-way voice/video calls via VolcEngine RTC
-- **Group chat** -- Multiple agents in one conversation, @mention routing
-- **MetaMemory browser** -- Search and browse shared knowledge base
-- **Team dashboard** -- Agent organization overview
-- **File support** -- Upload/download with inline preview
-- **Dark/light themes** -- System-aware with manual toggle
-
-**Stack**: React 19 + Vite + Zustand + react-markdown
-
-> Voice features require HTTPS. We recommend Caddy as a reverse proxy. See [Web UI docs](docs/features/web-ui.md).
-
-## Core Components
-
-| Component | Description |
-|-----------|-------------|
-| **Triple Engine Kernel** | Each bot independently chooses Claude Code / Kimi Code / Codex CLI — full tool stack (Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP) in autonomous mode |
-| **Persistent Sessions & Goal Loops** | One Claude process per chat — `/goal` keeps the agent auto-driving across turns until a condition is met; teammates and background tasks survive between turns |
-| **Agent Teams** | A lead agent spawns specialist teammates in parallel, routes tasks between them, and aggregates results — all in one Feishu chat |
-| **CC-Native Scheduling** | Use Claude Code's built-in `CronCreate` and `/loop` directly — zero MetaBot setup, runs in-session |
-| **MetaMemory** | Shared knowledge store served by metabot-core (self-hosted locally, default `http://localhost:9200`) with full-text search; MetaBot reads/writes via `/api/memory/*` and can sync to Feishu Wiki |
-| **IM Bridge** | Chat with any agent from Feishu, Telegram, or WeChat (including mobile). Streaming cards + tool call tracking |
-| **Agent Bus** | Agents talk to each other via `metabot talk`. Create/remove bots at runtime |
-| **MetaSchedule (opt-in)** | Persistent server-side scheduler — cron + one-shot, survives restarts, exposes HTTP API + `metabot schedule` CLI. Not installed by default; enable with `cp src/skills/metaschedule/SKILL.md ~/.claude/skills/metaschedule/` |
-| **MetaSkill (opt-in)** | Agent factory. `/metaskill` generates portable agent teams. Not installed by default; enable with `cp -r src/skills/metaskill ~/.claude/skills/` |
-| **Feishu Lark CLI** | 200+ commands covering docs, messaging, calendar, tasks, and 8 more domains. 19 AI Agent Skills |
-| **Skill Hub** | Centralized skill sharing registry. `metabot skills` to publish, discover, and install skills with FTS5 search (provided by metabot-core) |
-| **Peers** | Cross-instance bot discovery and task routing. `metabot talk alice/backend-bot` routes automatically |
-| **Voice Assistant** | Jarvis mode -- "Hey Siri, Jarvis" from AirPods for hands-free agent control |
+The installer mirrors MetaBot's bundled skills into the active engine paths;
+your existing locally modified skills are preserved.
 
 ## Quick Start
 
-### Telegram (30 seconds)
+Prerequisites: **Node.js >= 22.19**, Git, and credentials for at least one engine and one chat channel.
 
-1. Message [@BotFather](https://t.me/BotFather) → `/newbot` → copy token
-2. Add to `bots.json` → done (long polling, no webhooks)
+1. Run the one-line installer above.
+2. Choose Codex or Kimi Code and complete its login in a separate terminal.
+3. Connect Feishu/Lark, Telegram, or WeChat when prompted.
+4. Verify the services and open the local console:
 
-### WeChat (gray testing)
-
-1. iPhone WeChat 8.0.70+ → Settings → Plugins → enable **ClawBot**
-2. Run `install.sh`, pick `3) WeChat ClawBot` — scan QR to bind
-3. See [WeChat Setup Guide](docs/features/wechat.md)
-
-### Feishu/Lark
-
-1. Create app at [open.feishu.cn](https://open.feishu.cn/) → add Bot capability
-2. Enable permissions: `im:message`, `im:message:readonly`, `im:resource`, `im:chat:readonly`
-3. Start MetaBot, then enable persistent connection + `im.message.receive_v1` event
-4. Publish the app
-
-> No public IP needed. Feishu uses WebSocket, Telegram and WeChat use long polling.
-
-**Web UI**: Visit `http://localhost:9100/web/` after starting MetaBot, enter your API_SECRET.
-
-## Example Prompts
-
-New to MetaBot? Here are real prompts you can send in Feishu/Telegram:
-
-### MetaMemory — Persistent Knowledge
-
-```
-Remember the deployment guide we just discussed — save it to MetaMemory
-under /projects/deployment.
+```bash
+metabot status
+metabot health
 ```
 
-```
-Search MetaMemory for our API design conventions.
-```
+Open `http://localhost:9200`, paste the token from `~/.metabot-core/token`, and select your bot.
 
-### Scheduling (Claude Code native)
+| Channel | Best for | Setup |
+|---|---|---|
+| **Feishu/Lark** | Workspaces, streaming cards, files, group routing | [Feishu App Setup](docs/getting-started/feishu-app-setup.md) |
+| **Telegram** | Fast personal setup; no public IP required | [Quick Setup](docs/getting-started/quick-setup.md) |
+| **WeChat** | Personal WeChat through ClawBot; currently gray testing | [WeChat Guide](docs/features/wechat.md) |
+| **Web** | Browser chat, Core, Memory, Teams, and settings | `http://localhost:9200` |
 
-Use CC's built-in `CronCreate` and `/loop` — zero setup, runs inside the session:
+Feishu uses a persistent WebSocket; Telegram and WeChat use long polling. None requires an inbound public port.
 
-```
-Schedule a daily task at 9am: search Hacker News and TechCrunch for AI news,
-summarize the top 5 stories, and save the summary to MetaMemory.
-```
+In Feishu groups, normal messages route to the exact bot that was @mentioned.
+The group owner can select mention-only or all-message mode per bot and group
+with `@Bot /group-reply ...`; bare commands and commands addressed to another
+bot are ignored. Unmentioned files remain available for the next @Bot prompt
+in mention-only mode. See [Chat Commands](docs/usage/chat-commands.md#group-reply-modes).
 
-```
-/loop poll PR #123's CI status every 5 minutes until it finishes.
-```
+## Minimal Dual-Bot Configuration
 
-> Need the schedule to survive MetaBot restarts and be visible to other bots?
-> Install the opt-in `/metaschedule` skill
-> (`cp src/skills/metaschedule/SKILL.md ~/.claude/skills/metaschedule/`),
-> then use `metabot schedule cron` / the HTTP API to submit jobs to MetaBot's
-> persistent scheduler.
-
-### Agent Teams — Runtime
-
-```
-Act as a lead engineer. Spawn a frontend specialist and a backend specialist
-in parallel: the frontend handles the React UI changes, the backend adds the
-new /api/reports endpoint, and you review both PRs before merging.
-```
-
-### Goal Loops
-
-```
-/goal The CI for PR #123 is green and the deploy completes successfully.
-Check every 10 minutes and report back when done.
-```
-
-### MetaSkill — Agent Factory (opt-in)
-
-`/metaskill` is not installed by default. Enable it first:
-`cp -r src/skills/metaskill ~/.claude/skills/`. Then:
-
-```
-/metaskill Create an agent team for this React Native project —
-I need a frontend specialist, a backend API specialist, and a code reviewer.
-```
-
-### Agent-to-Agent
-
-```
-Delegate this bug fix to backend-bot: "Fix the null pointer exception
-in /api/users/:id endpoint".
-```
-
-```
-Ask frontend-bot to update the dashboard UI, and at the same time
-ask backend-bot to add the new API endpoint. Both should save progress
-to MetaMemory.
-```
-
-### Combined Workflows
-
-```
-Read this Feishu doc [paste URL], extract the product requirements, break
-them into tasks, and schedule a daily standup summary at 6pm that tracks
-progress against these requirements.
-```
-
-```
-(First copy src/skills/metaskill into ~/.claude/skills/ to enable /metaskill)
-/metaskill Create a "daily-ops" agent that runs every morning at 8am:
-checks service health, reviews overnight error logs, and posts a summary.
-```
-
-## Feishu Usage Tips
-
-<details>
-<summary><strong>DM vs Group Chat</strong></summary>
-
-| Scenario | @mention | Notes |
-|----------|----------|-------|
-| **Direct message** | Not needed | All messages go to the bot |
-| **1-on-1 group** (you + bot, 2 members) | Not needed | Auto-detected as DM-like |
-| **Multi-member group** | @Bot by default | The group owner can select `mention` or `all` per bot and group |
-
-> **Tip**: Create a 2-person group with just you and the bot. No @mention needed, plus you get group features like pinning.
-
-Group owners can use `@Bot /group-reply mention`, `@Bot /group-reply all`, and
-`@Bot /group-reply status`. Commands must @ the exact bot; bare commands and
-commands addressed to another bot are ignored. Settings persist per bot and
-group. See [Chat Commands](docs/usage/chat-commands.md).
-
-</details>
-
-<details>
-<summary><strong>Sending Files & Images</strong></summary>
-
-**DM / 2-person group**: Send files or images directly — auto-processed by default. Multiple files within 2 seconds are batched. An explicit `mention` setting makes a 2-person group require @Bot.
-
-**Multi-member group in `mention` mode**: Feishu doesn't allow @mentioning while uploading. Workaround: **upload first, @mention later**
-
-1. Upload files in the group
-2. Within 5 minutes, @Bot with your instruction
-3. Bot auto-attaches your previously uploaded files
-
-Supported: text, images (Claude multimodal), files (PDF/code/docs), rich text (Post format), batch upload.
-
-In `all` mode, unmentioned files and images are processed immediately.
-
-</details>
-
-## Configuration
-
-**`bots.json`** — define your bots:
+`bots.json` can mix engines and workspaces in one Bridge process:
 
 ```json
 {
-  "feishuBots": [{
-    "name": "metabot",
-    "feishuAppId": "cli_xxx",
-    "feishuAppSecret": "...",
-    "defaultWorkingDirectory": "/home/user/project"
-  }],
-  "telegramBots": [{
-    "name": "tg-bot",
-    "telegramBotToken": "123456:ABC...",
-    "defaultWorkingDirectory": "/home/user/project"
-  }]
+  "feishuBots": [
+    {
+      "name": "codex-dev",
+      "engine": "codex",
+      "feishuAppId": "cli_xxx",
+      "feishuAppSecret": "...",
+      "defaultWorkingDirectory": "/home/me/project-a"
+    },
+    {
+      "name": "kimi-reviewer",
+      "engine": "kimi",
+      "feishuAppId": "cli_yyy",
+      "feishuAppSecret": "...",
+      "defaultWorkingDirectory": "/home/me/project-b",
+      "kimi": { "thinking": true }
+    }
+  ]
 }
 ```
 
-<details>
-<summary><strong>All bot config fields</strong></summary>
+Each bot has its own channel credentials, engine, workspace, and sessions. Bots can still collaborate through Agent Teams and the Agent Bus.
 
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `name` | Yes | — | Bot identifier |
-| `defaultWorkingDirectory` | Yes | — | Working directory for Claude |
-| `feishuAppId` / `feishuAppSecret` | Feishu | — | Feishu app credentials |
-| `telegramBotToken` | Telegram | — | Telegram bot token |
-| `wechatBotToken` | WeChat (opt) | — | Pre-authenticated iLink token (omit for QR login) |
-| `maxTurns` / `maxBudgetUsd` | No | unlimited | Execution limits |
-| `model` | No | SDK default | Claude model |
-| `apiKey` | No | — | Anthropic API key (leave unset for dynamic auth via cc-switch) |
-| `visible` | No | `true` | Whether this bot is visible to other bots / Agent Bus and reachable via `metabot talk`. Re-asserted from `bots.json` on every bridge bulk-register (not sticky) |
-| `memoryPublic` | No | `true` | Default target for `metabot memory create/mkdir` when no `--path` is given: `true` = `/shared/<bot>` (readable by everyone), `false` = `/users/<bot>` (private). Explicit `--path` always wins. Omitting the field preserves the last `metabot memory visibility` CLI toggle (sticky) |
+## What You Get
 
-</details>
+- **Mobile coding** — edit code, run tests, inspect tools, and follow long tasks from chat.
+- **Agent Teams** — spawn focused teammates, assign parallel work, and keep durable task/run state. [Guide](docs/features/agent-teams.md)
+- **MetaMemory** — searchable knowledge shared across sessions with optional Feishu Wiki sync. [Guide](docs/features/metamemory.md)
+- **T5T and goals** — durable project checkpoints plus supervised multi-turn execution. [Goal Loops](docs/features/goal-loops.md)
+- **Skill Hub** — install and publish reusable agent skills through the single `metabot` CLI.
+- **Local Core and Web UI** — token-authenticated Agents, Memory, Skills, Teams, chat, and diagnostics.
+- **Channels and media** — text, rich posts, images, files, audio, smart batching, and exact @Bot routing.
+- **Peers, scheduling, and voice** — optional capabilities for larger personal setups. [Feature docs](docs/)
 
-<details>
-<summary><strong>Environment variables (.env)</strong></summary>
+## Essential Commands
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `API_PORT` | 9100 | HTTP API port |
-| `API_SECRET` | — | Bearer token auth (protects API + Web UI). Generate one with `openssl rand -hex 32` |
-| `METABOT_CORE_URL` | `http://localhost:9200` | metabot-core service URL (MetaMemory + Skill Hub + Agents + T5T) — self-host locally or point at your own remote host |
-| `METABOT_CORE_TOKEN` | reads `~/.metabot-core/token` | Bearer token for metabot-core; obtain the first token from `~/.metabot-core/data/admin-bootstrap-token.txt` |
-| `WIKI_SYNC_ENABLED` | true | Enable MetaMemory→Wiki sync |
-| `WIKI_SPACE_NAME` | MetaMemory | Wiki space name |
-| `WIKI_SYNC_STATE_DIR` | `./data` | Directory holding the wiki-sync mapping SQLite |
-| `VOLCENGINE_TTS_APPID` | — | Doubao voice (TTS + STT) |
-| `VOLCENGINE_TTS_ACCESS_KEY` | — | Doubao voice key |
-| `METABOT_URL` | `http://localhost:9100` | MetaBot API URL. Default is local HTTP; for remote access prefer HTTPS or a private-network address |
-| `METABOT_PEERS` | — | Peer MetaBot URLs (comma-separated). Prefer HTTPS for internet-reachable peers |
-| `LOG_LEVEL` | info | Log level |
+| Command | Purpose |
+|---|---|
+| `/model` | Show or switch the current engine/model |
+| `/effort low\|medium\|high\|xhigh\|max\|ultra` | Set Codex reasoning effort for this chat |
+| `/status` | Show the current session and model |
+| `/reset` | Start a fresh session |
+| `/stop` | Stop the active task |
+| `/goal <condition>` | Keep working across turns until complete, blocked, or capped |
+| `/background <prompt>` | Run a supported background task while the chat continues |
+| `@Bot /group-reply mention\|all\|status` | Control one Feishu bot's reply mode in one group |
+| `metabot update` | Update the installed personal edition and restart it |
 
-</details>
+See [Chat Commands](docs/usage/chat-commands.md), the [CLI Reference](docs/reference/cli-metabot.md), and the [REST API](docs/reference/api.md) for the complete surfaces.
 
-<details>
-<summary><strong>Third-party AI providers</strong></summary>
+## Documentation
 
-Supports any Anthropic-compatible API:
+- Start: [Installation](docs/getting-started/installation.md) · [Quick Setup](docs/getting-started/quick-setup.md) · [Troubleshooting](docs/troubleshooting.md)
+- Configure: [Multi-Bot](docs/configuration/multi-bot.md) · [Environment Variables](docs/configuration/environment-variables.md) · [Production](docs/deployment/production.md)
+- Use: [Chat Commands](docs/usage/chat-commands.md) · [Example Prompts](docs/usage/example-prompts.md) · [Use Cases](docs/usage/use-cases.md)
+- Build: [Architecture](docs/concepts/architecture.md) · [Project Structure](docs/development/project-structure.md) · [Contributing](CONTRIBUTING.md)
+
+## Update and Development
+
+Release installs update from stable GitHub assets; source checkouts update from Git:
 
 ```bash
-ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic    # Kimi/Moonshot
-ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic   # DeepSeek
-ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic       # GLM/Zhipu
-ANTHROPIC_AUTH_TOKEN=your-key
+metabot update          # package install
+metabot update --git    # source checkout
 ```
 
-</details>
-
-<details>
-<summary><strong>cc-switch compatibility</strong></summary>
-
-Compatible with [cc-switch](https://github.com/farion1231/cc-switch), [cc-switch-cli](https://github.com/SaladDay/cc-switch-cli), [CCS](https://github.com/kaitranntt/ccs). Switching via `cc switch` takes effect **without restarting** MetaBot.
-
-To pin a specific API key, set the `apiKey` field in `bots.json`.
-
-</details>
-
-<details>
-<summary><strong>Security</strong></summary>
-
-MetaBot runs Claude Code in `bypassPermissions` mode — no interactive approval:
-
-- Claude has full read/write/execute access to the working directory
-- Control access via IM platform settings (app visibility, group membership)
-- Use `maxBudgetUsd` to cap cost per request
-- `API_SECRET` enables Bearer auth on API server
-- MetaMemory is hosted by the central metabot-core service; auth and folder ACLs are managed there
-
-</details>
-
-## Chat Commands
-
-| Command | Description |
-|---------|-------------|
-| `/reset` | Clear session |
-| `/stop` | Abort current task |
-| `/status` | Session info (includes current model) |
-| `/goal <condition>` | Set a goal the agent keeps pursuing across turns. `/goal clear` to stop |
-| `/model` | Show current engine/model; `/model list` — available engines/models; `/model claude`, `/model kimi`, or `/model codex` — switch engine; `/model <name>` — set model; `/model reset` — restore default |
-| `/memory list` | Browse knowledge tree |
-| `/memory search <query>` | Search knowledge base |
-| `/sync` | Sync MetaMemory to Feishu Wiki |
-| `/metaskill ...` | Generate agent teams, agents, or skills (opt-in skill — not installed by default) |
-| `/help` | Show help |
-
-> **Model switching**: Each session can pick its own model; default is `claude-opus-4-8`. All models default to 200k context; append `[1m]` to the model name to enable the 1M context window (supported by Opus 4.8/4.7/4.6 and Sonnet 4.6), e.g. `/model claude-opus-4-8[1m]`. OAuth/Pro-Max users must use this suffix — the SDK silently drops beta headers under that auth mode. Note: 1M is billed the same as 200k while context stays under 200K, but all tokens jump to 2× once a request crosses 200K — which is why the default stays at 200k.
-> **Codex skills**: Slash invocations like `/<skill> ...` are auto-rewritten to Codex's `$<skill> ...` form whenever the active session runs on Codex.
-
-<details>
-<summary><strong>API Reference</strong></summary>
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/health` | Health check (no auth required) — returns `{ status, uptime }` only |
-| `GET` | `/api/status` | Rich status: bots, peers, scheduled/recurring tasks (auth required) |
-| `GET` | `/api/bots` | List bots (local + peer) |
-| `POST` | `/api/bots` | Create bot at runtime |
-| `DELETE` | `/api/bots/:name` | Remove bot |
-| `POST` | `/api/talk` | Talk to a bot (auto-routes to peers) |
-| `GET` | `/api/peers` | List peers and status |
-| `POST` | `/api/schedule` | Schedule task |
-| `GET` | `/api/schedule` | List scheduled tasks |
-| `PATCH` | `/api/schedule/:id` | Update task |
-| `DELETE` | `/api/schedule/:id` | Cancel task |
-| `POST` | `/api/sync` | Trigger Wiki sync |
-| `GET` | `/api/stats` | Cost & usage stats |
-| `GET` | `/api/metrics` | Prometheus metrics |
-| `POST` | `/api/tts` | Text-to-speech |
-| `GET` | `/api/skills` | List skills (local + peer) |
-| `GET` | `/api/skills/search?q=` | Full-text search skills |
-| `GET` | `/api/skills/:name` | Get skill details |
-| `POST` | `/api/skills` | Publish a skill |
-| `POST` | `/api/skills/:name/install` | Install skill to a bot |
-| `DELETE` | `/api/skills/:name` | Remove a skill |
-
-</details>
-
-<details>
-<summary><strong>CLI Tools</strong></summary>
-
-The installer places `metabot` in `~/.local/bin/` — available immediately. `metabot` is the **single CLI binary** with three command categories: (1) bridge process control (`update` / `start` / `stop` / `restart` / `logs` / `status`); (2) bridge daemon API (`bots` / `talk` / `schedule` / `peers` / `stats` / `voice` / `health`, which curl the local bridge at `localhost:9100`); (3) everything else (`t5t` / `agents` / `memory` / `skills`) forwards to the metabot-core feature CLI shipped in this monorepo at `packages/cli/bin/metabot`. The legacy `mb`/`mm`/`mh` CLIs and the standalone `metamemory` / `skill-hub` skill bundles have all been removed; install/update actively cleans up any leftover binaries in `~/.local/bin/`.
+For development:
 
 ```bash
-# 1. MetaBot process management (handled in-script by bin/metabot)
-metabot update                      # internal package refresh, rebuild, restart
-metabot update --git                # developer-only: git pull + rebuild + restart
-metabot start / stop / restart      # PM2 management
-metabot logs                        # view live logs
-metabot status                      # PM2 process status
-
-# 2. Bridge daemon API (curls the local bridge at localhost:9100)
-metabot bots                        # list all bots
-metabot talk <bot> <chatId> <prompt> # talk to a bot
-metabot stats                       # cost & usage stats
-metabot voice tts "Hello world" --play  # text-to-speech
-
-# 3. Feature subcommands (forwarded to packages/cli/bin/metabot)
-metabot t5t board                   # team standup board
-metabot agents list                 # peer-bot directory
-metabot memory search "deployment guide"   # shared-memory full-text search
-metabot memory visibility           # show whether this bot writes to /shared/<bot> or /users/<bot> by default
-metabot memory visibility private   # switch to private (default writes land in /users/<bot>, owner-only)
-metabot skills list                 # skill registry (central Skill Hub)
-# Override CLI path: export METABOT_CORE_CLI=/path/to/packages/cli/bin/metabot
-
-# Scheduling — prefer Claude Code's native CronCreate / /loop directly in chat.
-# The persistent server-side scheduler (`metabot schedule list / cron / cancel /
-# pause / resume`) is exposed by the opt-in /metaschedule skill. Enable with:
-#   cp src/skills/metaschedule/SKILL.md ~/.claude/skills/metaschedule/
-
-# Feishu Lark CLI (Feishu bots only)
-lark-cli docs +fetch --doc <feishu-url>
-lark-cli im +messages-send --chat-id oc_xxx --text "Hi"
-lark-cli calendar +agenda --as user
+git clone https://github.com/xvirobotics/metabot.git ~/metabot
+cd ~/metabot
+npm ci --include=dev
+npm test
 ```
 
-CLI supports connecting to a remote MetaBot server — configure `METABOT_URL` in `~/.metabot/.env`. MetaMemory / Skill Hub / Agents / T5T live in metabot-core inside this monorepo at `packages/server/`; configure `METABOT_CORE_URL` + `METABOT_CORE_TOKEN`. The personal edition has no enterprise login dependency; its local administrator creates and rotates tokens.
+Use Node.js >= 22.19. See [Contributing](CONTRIBUTING.md) before opening a PR.
 
-</details>
+## Security
 
-<details>
-<summary><strong>Manual install</strong></summary>
+MetaBot agents can read, write, and execute code in their configured workspace. Keep Core and Bridge tokens private, restrict IM bot visibility, and expose local ports only through your own authenticated reverse proxy or private network.
 
-```bash
-git clone https://github.com/xvirobotics/metabot.git
-cd metabot && npm install
-cp bots.example.json bots.json   # edit with your bot configs
-cp .env.example .env              # edit global settings
-npm run dev
-```
+## About and License
 
-Prerequisites: Node.js 20+, [Claude Code CLI](https://github.com/anthropics/claude-code) installed and authenticated.
-
-</details>
-
-## Development
-
-```bash
-npm run dev          # Hot-reload dev server (tsx)
-npm test             # Run tests (vitest)
-npm run lint         # ESLint check
-npm run build        # TypeScript compile
-```
-
-## Roadmap
-
-- [ ] Plugin marketplace (one-click MCP Server install)
-- [ ] More IM platforms (Slack, Discord, DingTalk)
-
-## About
-
-MetaBot is built by [XVI Robotics](https://xvirobotics.com) (humanoid robot brains). We use MetaBot internally to run our company as an **agent-native organization** — a small team of humans supervising self-improving AI agents.
-
-We open-sourced it because we believe this is how companies will work in the future.
-
-## License
-
-[MIT](LICENSE)
+MetaBot is built by [XVI Robotics](https://xvirobotics.com) and released under the [MIT License](LICENSE).

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,72 +1,106 @@
 # Architecture
 
-MetaBot is a TypeScript ESM project that connects IM platforms (Feishu, Telegram) to the Claude Code Agent SDK.
+MetaBot is a Node.js >= 22.19 TypeScript ESM monorepo. The Bridge connects
+Feishu/Lark, Telegram, WeChat, and Web clients to an engine-neutral message
+pipeline; each bot or chat can run Codex, Kimi Code, or Claude compatibility.
 
 ## System Overview
 
+```text
+Feishu/Lark · Telegram · WeChat · Web
+                    │
+          Event and API adapters
+                    │
+             MessageBridge
+       commands · tasks · sessions · media
+                    │
+              Engine Router
+          ┌─────────┼──────────┐
+          │         │          │
+   Codex CLI    Kimi Code    Claude Code
+   exec JSONL   local Server  compatibility
+   + resume     API 0.27+     CLI / SDK
+          └─────────┼──────────┘
+                    │
+     shared stream/card event model
+                    │
+        channel cards and Web updates
+
+Personal Core (:9200)        Bridge (:9100)
+Agents · Memory · Skills     IM · local API · WebSocket
+T5T · Teams · Chat      ↔     sessions · files · peers
 ```
-┌──────────────────────────────────────────────────────────┐
-│                       MetaBot                            │
-│                                                          │
-│  ┌──────────┐ ┌───────────┐ ┌──────────┐ ┌───────────┐  │
-│  │ MetaSkill│ │MetaMemory │ │IM Bridge │ │ Scheduler │  │
-│  │  Agent   │ │  Shared   │ │ Feishu + │ │   Cron    │  │
-│  │ Factory  │ │ Knowledge │ │ Telegram │ │   Tasks   │  │
-│  └────┬─────┘ └─────┬─────┘ └────┬─────┘ └─────┬─────┘  │
-│       └──────────────┴────────────┴─────────────┘        │
-│                       ↕                                  │
-│            Claude Code Agent SDK                         │
-│         (bypassPermissions, streaming)                   │
-│                       ↕                                  │
-│             HTTP API (:9100) — Agent Bus                 │
-│        task delegation · bot CRUD · scheduling           │
-└──────────────────────────────────────────────────────────┘
-```
+
+Codex is the default engine and currently uses `codex exec --json` plus
+`codex exec resume`; the public adapter does not yet use Codex app-server or
+native mid-turn steering. Kimi Code 0.27+ uses its official loopback Server API
+for durable Sessions, snapshots, questions, tools, subagents, goals, and
+completion state. Feishu mid-turn steering is not exposed in this release.
+Claude remains an explicit
+compatibility engine for existing bots and workspaces.
 
 ## Three Pillars
 
-| Pillar | Component | What it does |
-|--------|-----------|-------------|
-| **Supervised** | IM Bridge | Real-time streaming cards show every tool call. Humans see everything agents do. Access control via Feishu/Telegram platform settings. |
-| **Self-Improving** | MetaMemory | Shared knowledge store. Agents write what they learn, other agents retrieve it. The organization gets smarter every day without retraining. |
-| **Agent Organization** | MetaSkill + Scheduler + Agent Bus | One command generates a full agent team. Agents delegate tasks to each other. Scheduled tasks run autonomously. Agents can create new agents. |
+| Pillar | Components | What they do |
+|---|---|---|
+| **Supervised** | IM Bridge + Web UI | Stream tool activity and state so the user can monitor, stop, answer, and redirect supported engines. |
+| **Self-Improving** | MetaMemory + Skills + T5T | Preserve reusable knowledge, workflows, and project checkpoints outside a single model session. |
+| **Agent Organization** | Agent Teams + Agent Bus + Scheduler | Coordinate durable teammates, tasks, runs, cross-agent messages, and optional recurring work. |
 
 ## Message Flow
 
-**IM (Feishu/Telegram):**
+**IM channels:**
 
-```
-IM Client → EventHandler (parse, @mention filter)
-         → MessageBridge (command routing, task management)
-         → ClaudeExecutor (Agent SDK query)
-         → StreamProcessor (card state tracking)
-         → IM card updates (streaming)
+```text
+Channel event
+  → EventHandler (parse, media, exact @Bot routing)
+  → MessageBridge (commands, queue, task/session state)
+  → Engine.createExecutor() (Codex, Kimi, or Claude compatibility)
+  → engine output translated into shared SDKMessage/CardState events
+  → throttled streaming card or channel response
 ```
 
-**Web UI:**
+**Personal Web UI:**
 
+```text
+Browser
+  → token-authenticated Core API (:9200)
+  → Chat / Agents / Memory / Skills / T5T / Teams
+  → registered Bridge agent
+  → selected engine and workspace
 ```
-Web Browser → WebSocket (/ws?token=API_SECRET)
-           → ws-server.ts
-           → MessageBridge.executeApiTask(onUpdate, onQuestion)
-           → streaming CardState back to browser
-```
+
+The Core and Bridge are separate PM2 applications in the personal-edition
+package. Core authentication uses the local Bearer token; Bridge channel
+credentials stay with the Bridge.
+
+## Engine Boundary
+
+`src/engines/index.ts` resolves the configured engine, defaulting to Codex.
+All adapters implement the shared `Engine` / `Executor` contract and translate
+their native protocol into the event shape consumed by the Bridge and card
+renderer.
+
+| Engine | Native protocol | Session behavior |
+|---|---|---|
+| Codex | `codex exec --json` JSONL | `codex exec resume` continues a saved session |
+| Kimi Code | Official `/api/v1` local Server API | Durable Kimi Sessions and atomic frontend snapshots |
+| Claude compatibility | Claude CLI / Agent SDK | Existing Claude sessions and persistent-executor behavior |
 
 ## Key Modules
 
 | Module | Description |
-|--------|-------------|
-| `src/index.ts` | Entrypoint. Creates IM clients, wires up event dispatch, handles graceful shutdown. |
-| `src/config.ts` | Loads config from `bots.json` or env vars. |
-| `src/feishu/event-handler.ts` | Parses Feishu events, filters @mentions, handles text/image. |
-| `src/bridge/message-bridge.ts` | Core orchestrator. Routes commands, manages tasks per chat, executes Claude queries with streaming. |
-| `src/claude/executor.ts` | Wraps `query()` from the Agent SDK as an async generator. |
-| `src/claude/stream-processor.ts` | Transforms SDK messages into card state objects for display. |
-| `src/claude/session-manager.ts` | In-memory sessions keyed by `chatId`. 24-hour expiry. |
-| `src/feishu/card-builder.ts` | Builds Feishu interactive card JSON with color-coded headers. |
-| `src/feishu/message-sender.ts` | Feishu API wrapper for sending/updating cards, uploading images. |
-| `src/bridge/rate-limiter.ts` | Throttles card updates (1.5s default) to avoid API rate limits. |
-| `src/api/peer-manager.ts` | Cross-instance bot discovery and task forwarding. |
-| `src/api/voice-handler.ts` | Voice API: Doubao/Whisper STT, agent execution, Doubao/OpenAI/ElevenLabs TTS. |
-| `src/web/ws-server.ts` | WebSocket server for Web UI. Token auth, heartbeat, static file serving. |
-| `src/bridge/outputs-manager.ts` | Output file lifecycle (prepare, scan, cleanup, type routing). |
+|---|---|
+| `src/index.ts` | Entrypoint; creates channel clients, registries, stores, and shutdown handlers. |
+| `src/config.ts` | Loads engine, channel, Core, workspace, and per-bot configuration. |
+| `src/bridge/message-bridge.ts` | Core orchestrator for commands, queues, tasks, sessions, media, and engine execution. |
+| `src/engines/index.ts` | Engine selection and shared boundary. |
+| `src/engines/codex/executor.ts` | Spawns Codex exec/resume and translates JSONL events. |
+| `src/engines/kimi/daemon-client.ts` | Starts or connects to the Kimi Code local Server API. |
+| `src/engines/kimi/executor.ts` | Drives Kimi Sessions, snapshots, steering, questions, goals, and completion. |
+| `src/engines/claude/` | Claude compatibility executor, session, and stream-processing code. |
+| `src/feishu/event-handler.ts` | Feishu event parsing, media cache, group modes, and exact mention routing. |
+| `src/telegram/` / `src/wechat/` | Telegram and WeChat channel adapters. |
+| `src/agent-teams/` | Durable local team, task, member, and run orchestration. |
+| `packages/server/` | Personal Core HTTP backend and token authentication. |
+| `packages/web-ui/` | Personal Core browser application. |

--- a/docs/concepts/architecture.zh.md
+++ b/docs/concepts/architecture.zh.md
@@ -1,72 +1,102 @@
 # 架构
 
-MetaBot 是一个 TypeScript ESM 项目，连接 IM 平台（飞书、Telegram）与 Claude Code Agent SDK。
+MetaBot 是 Node.js >= 22.19 的 TypeScript ESM monorepo。Bridge 把飞书/Lark、
+Telegram、微信和 Web 客户端接入引擎无关的消息流水线；每个 Bot 或 Chat
+可以运行 Codex、Kimi Code 或 Claude 兼容引擎。
 
 ## 系统概览
 
+```text
+飞书/Lark · Telegram · 微信 · Web
+                    │
+             事件与 API 适配器
+                    │
+             MessageBridge
+         命令 · 任务 · 会话 · 媒体
+                    │
+                引擎路由
+          ┌─────────┼──────────┐
+          │         │          │
+   Codex CLI    Kimi Code    Claude Code
+   exec JSONL   本地 Server   兼容路径
+   + resume     API 0.27+     CLI / SDK
+          └─────────┼──────────┘
+                    │
+          共享流式/卡片事件模型
+                    │
+          渠道卡片与 Web 更新
+
+个人 Core (:9200)            Bridge (:9100)
+Agents · Memory · Skills     IM · 本地 API · WebSocket
+T5T · Teams · Chat      ↔     会话 · 文件 · Peers
 ```
-┌──────────────────────────────────────────────────────────┐
-│                       MetaBot                            │
-│                                                          │
-│  ┌──────────┐ ┌───────────┐ ┌──────────┐ ┌───────────┐  │
-│  │ MetaSkill│ │MetaMemory │ │IM Bridge │ │  定时任务  │  │
-│  │  Agent   │ │   共享    │ │  飞书 +  │ │   调度器   │  │
-│  │  工厂    │ │   知识库  │ │ Telegram │ │           │  │
-│  └────┬─────┘ └─────┬─────┘ └────┬─────┘ └─────┬─────┘  │
-│       └──────────────┴────────────┴─────────────┘        │
-│                       ↕                                  │
-│            Claude Code Agent SDK                         │
-│         （bypassPermissions，流式输出）                    │
-│                       ↕                                  │
-│             HTTP API (:9100) — Agent 总线                │
-│          任务委派 · Bot 管理 · 定时调度                    │
-└──────────────────────────────────────────────────────────┘
-```
+
+Codex 是默认引擎，当前使用 `codex exec --json` 和 `codex exec resume`；
+公开版尚未使用 Codex app-server 或原生执行中 steering。Kimi Code 0.27+
+使用官方 loopback Server API，提供持久 Session、原子快照、问题交互、
+工具、子 Agent、Goal 和完成状态。本版本暂不开放飞书执行中 steering。Claude 作为现有 Bot 和
+工作区的显式兼容引擎保留。
 
 ## 三大支柱
 
 | 支柱 | 组件 | 作用 |
-|------|------|------|
-| **受监督** | IM Bridge | 实时流式卡片展示每一步工具调用。人类看到 Agent 做的一切。通过飞书/Telegram 平台设置控制访问。 |
-| **自我进化** | MetaMemory | 共享知识库。Agent 写入学到的东西，其他 Agent 检索引用。组织每天都在变聪明，无需重新训练。 |
-| **Agent 组织** | MetaSkill + 调度器 + Agent 总线 | 一个命令生成完整 Agent 团队。Agent 互相委派任务。定时任务自主运行。Agent 可以创建新 Agent。 |
+|---|---|---|
+| **受监督** | IM Bridge + Web UI | 流式展示工具和状态，让用户监控、停止、回答，并在引擎支持时插话。 |
+| **自我进化** | MetaMemory + Skills + T5T | 把可复用知识、工作流和项目检查点保存在单个模型会话之外。 |
+| **Agent 组织** | Agent Teams + Agent Bus + 调度器 | 协调持久队友、任务、运行、跨 Agent 消息和可选周期工作。 |
 
 ## 消息流
 
-**IM（飞书/Telegram）：**
+**IM 渠道：**
 
-```
-IM 客户端 → EventHandler（解析，@mention 过滤）
-         → MessageBridge（命令路由，任务管理）
-         → ClaudeExecutor（Agent SDK 查询）
-         → StreamProcessor（卡片状态跟踪）
-         → IM 卡片更新（流式）
+```text
+渠道事件
+  → EventHandler（解析、媒体、精确 @Bot 路由）
+  → MessageBridge（命令、队列、任务/会话状态）
+  → Engine.createExecutor()（Codex、Kimi 或 Claude 兼容）
+  → 原生输出转换为共享 SDKMessage/CardState 事件
+  → 节流后的流式卡片或渠道回复
 ```
 
-**Web UI：**
+**个人 Web UI：**
 
+```text
+浏览器
+  → Token 鉴权的 Core API (:9200)
+  → Chat / Agents / Memory / Skills / T5T / Teams
+  → 已注册的 Bridge Agent
+  → 选定的引擎和工作区
 ```
-浏览器 → WebSocket (/ws?token=API_SECRET)
-       → ws-server.ts
-       → MessageBridge.executeApiTask(onUpdate, onQuestion)
-       → 流式 CardState 推送到浏览器
-```
+
+个人版 Package 将 Core 和 Bridge 作为独立 PM2 应用运行。Core 使用本地
+Bearer Token 鉴权，Bridge 渠道凭证留在 Bridge 侧。
+
+## 引擎边界
+
+`src/engines/index.ts` 解析配置的引擎，缺省为 Codex。所有适配器都实现共享
+`Engine` / `Executor` contract，并把各自原生协议转换成 Bridge 和卡片渲染器
+消费的事件格式。
+
+| 引擎 | 原生协议 | 会话行为 |
+|---|---|---|
+| Codex | `codex exec --json` JSONL | 使用 `codex exec resume` 续接已保存会话 |
+| Kimi Code | 官方 `/api/v1` 本地 Server API | 持久 Kimi Session 和原子前端快照 |
+| Claude 兼容 | Claude CLI / Agent SDK | 现有 Claude 会话和持久 Executor 行为 |
 
 ## 核心模块
 
 | 模块 | 说明 |
-|------|------|
-| `src/index.ts` | 入口。创建 IM 客户端，接线事件分发，优雅关闭。 |
-| `src/config.ts` | 从 `bots.json` 或环境变量加载配置。 |
-| `src/feishu/event-handler.ts` | 解析飞书事件，过滤 @mention，处理文本/图片。 |
-| `src/bridge/message-bridge.ts` | 核心调度器。路由命令，管理每个 chat 的任务，执行 Claude 查询并流式更新。 |
-| `src/claude/executor.ts` | 封装 Agent SDK 的 `query()` 为异步生成器。 |
-| `src/claude/stream-processor.ts` | 将 SDK 消息转为卡片状态对象。 |
-| `src/claude/session-manager.ts` | 内存中的会话存储，按 `chatId` 索引。24 小时过期。 |
-| `src/feishu/card-builder.ts` | 构建飞书交互卡片 JSON，带颜色编码的标题。 |
-| `src/feishu/message-sender.ts` | 飞书 API 封装：发送/更新卡片、上传图片。 |
-| `src/bridge/rate-limiter.ts` | 卡片更新节流（默认 1.5 秒）避免 API 频率限制。 |
-| `src/api/peer-manager.ts` | 跨实例 Bot 发现和任务转发。 |
-| `src/api/voice-handler.ts` | 语音 API：豆包/Whisper STT、Agent 执行、豆包/OpenAI/ElevenLabs TTS。 |
-| `src/web/ws-server.ts` | Web UI 的 WebSocket 服务器。Token 认证、心跳、静态文件服务。 |
-| `src/bridge/outputs-manager.ts` | 输出文件生命周期（准备、扫描、清理、类型路由）。 |
+|---|---|
+| `src/index.ts` | 入口；创建渠道客户端、注册表、存储和关闭处理器。 |
+| `src/config.ts` | 加载引擎、渠道、Core、工作区和每 Bot 配置。 |
+| `src/bridge/message-bridge.ts` | 命令、队列、任务、会话、媒体和引擎执行的核心调度器。 |
+| `src/engines/index.ts` | 引擎选择和共享边界。 |
+| `src/engines/codex/executor.ts` | 启动 Codex exec/resume 并转换 JSONL 事件。 |
+| `src/engines/kimi/daemon-client.ts` | 启动或连接 Kimi Code 本地 Server API。 |
+| `src/engines/kimi/executor.ts` | 驱动 Kimi Session、快照、插话、问题、Goal 和完成状态。 |
+| `src/engines/claude/` | Claude 兼容 Executor、会话和流处理代码。 |
+| `src/feishu/event-handler.ts` | 飞书事件解析、媒体缓存、群模式和精确 @ 路由。 |
+| `src/telegram/` / `src/wechat/` | Telegram 和微信渠道适配器。 |
+| `src/agent-teams/` | 持久本地 Team、任务、成员和运行编排。 |
+| `packages/server/` | 个人 Core HTTP 后端和 Token 鉴权。 |
+| `packages/web-ui/` | 个人 Core 浏览器应用。 |

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -7,6 +7,7 @@ All configuration is via `.env` file or system environment variables. Copy `.env
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BOTS_CONFIG` | — | Path to `bots.json` for multi-bot mode |
+| `METABOT_ENGINE` | `codex` | Default engine: `codex`, `kimi`, or compatibility `claude` |
 | `FEISHU_APP_ID` | — | Feishu app ID (single-bot mode) |
 | `FEISHU_APP_SECRET` | — | Feishu app secret (single-bot mode) |
 | `API_PORT` | `9100` | HTTP API port |
@@ -17,11 +18,11 @@ All configuration is via `.env` file or system environment variables. Copy `.env
 | `METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS` | `15000` | Timeout for a Feishu WebSocket connect/reconnect handshake. Safe range: 1000–120000 ms |
 | `METABOT_PUBLIC_DISTRIBUTION` | — | metabot-core server flag. The `/cli/*` and `/install/*` install endpoints are token-gated by default; set to `1` (or `true`) to serve them anonymously. Only enable when you intentionally self-distribute and your build embeds no secrets |
 
-## Claude Code
+## Workspace and Claude Compatibility
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DEFAULT_WORKING_DIRECTORY` | — | Working directory for Claude (single-bot mode) |
+| `CLAUDE_DEFAULT_WORKING_DIRECTORY` | — | Historical name for the single-bot workspace; used by every engine |
 | `CLAUDE_MAX_TURNS` | unlimited | Max turns per request |
 | `CLAUDE_MAX_BUDGET_USD` | unlimited | Max cost per request (USD) |
 | `CLAUDE_MODEL` | SDK default | Claude model to use |
@@ -36,8 +37,29 @@ All configuration is via `.env` file or system environment variables. Copy `.env
 | `CODEX_BASE_URL` | Codex default | OpenAI-compatible API base URL. Passed to Codex as `-c openai_base_url="..."` |
 | `CODEX_PROFILE` | — | Codex config profile |
 | `CODEX_APPROVAL_POLICY` | `never` | Approval policy (`untrusted`, `on-failure`, `on-request`, `never`) |
-| `CODEX_SANDBOX` | `danger-full-access` | Sandbox mode (`read-only`, `workspace-write`, `danger-full-access`) |
+| `CODEX_SANDBOX` | `workspace-write` | Sandbox mode (`read-only`, `workspace-write`, `danger-full-access`) |
+| `CODEX_REASONING_EFFORT` | — | Optional `low`, `medium`, `high`, `xhigh`, `max`, or `ultra` default |
+| `CODEX_BYPASS_APPROVALS_AND_SANDBOX` | — | Set `true` only when the host isolation boundary is intentional |
 | `CODEX_EXECUTABLE_PATH` | auto-detect | Path to `codex` binary |
+
+The public adapter currently uses `codex exec --json` and
+`codex exec resume`; these variables do not enable Codex app-server or native
+mid-turn steering.
+
+## Kimi Code 0.27+
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KIMI_CODE_SERVER_URL` | `http://127.0.0.1:58627` | Existing local Kimi Server origin; otherwise MetaBot starts it on demand |
+| `KIMI_CODE_HOME` | `~/.kimi-code` | Kimi Code configuration and local Server token directory |
+| `KIMI_API_KEY` | Kimi login state | Optional provider API key inherited by the local Server |
+
+Install the supported CLI with
+`npm install -g @moonshot-ai/kimi-code@latest`, then run `kimi login`.
+MetaBot uses Kimi's official local Server API rather than the retired Python
+`kimi-cli --wire` protocol. Per-bot `model`, `thinking`, `executable`,
+`serverUrl`, and `contextWindow` overrides belong in `bots.json`; see
+[Multi-Bot Mode](multi-bot.md#kimi-code-options).
 
 ## MetaMemory
 

--- a/docs/configuration/environment-variables.zh.md
+++ b/docs/configuration/environment-variables.zh.md
@@ -7,6 +7,7 @@
 | 变量 | 默认 | 说明 |
 |------|------|------|
 | `BOTS_CONFIG` | — | `bots.json` 路径（多 Bot 模式） |
+| `METABOT_ENGINE` | `codex` | 默认引擎：`codex`、`kimi` 或兼容引擎 `claude` |
 | `FEISHU_APP_ID` | — | 飞书 App ID（单 Bot 模式） |
 | `FEISHU_APP_SECRET` | — | 飞书 App Secret（单 Bot 模式） |
 | `API_PORT` | `9100` | HTTP API 端口 |
@@ -16,11 +17,11 @@
 | `METABOT_FEISHU_WS_PING_TIMEOUT_SEC` | `20` | 飞书 WebSocket 的 Pong 看门狗，安全范围 5–300 秒 |
 | `METABOT_FEISHU_WS_HANDSHAKE_TIMEOUT_MS` | `15000` | 飞书 WebSocket 建连/重连握手超时，安全范围 1000–120000 毫秒 |
 
-## Claude Code
+## 工作区与 Claude 兼容
 
 | 变量 | 默认 | 说明 |
 |------|------|------|
-| `DEFAULT_WORKING_DIRECTORY` | — | Claude 工作目录（单 Bot 模式） |
+| `CLAUDE_DEFAULT_WORKING_DIRECTORY` | — | 单 Bot 工作区的历史变量名；所有引擎都会使用 |
 | `CLAUDE_MAX_TURNS` | 不限 | 每次请求最大轮次 |
 | `CLAUDE_MAX_BUDGET_USD` | 不限 | 每次请求费用上限（美元） |
 | `CLAUDE_MODEL` | SDK 默认 | Claude 模型 |
@@ -35,8 +36,27 @@
 | `CODEX_BASE_URL` | Codex 默认 | OpenAI 兼容 API Base URL。会传给 Codex：`-c openai_base_url="..."` |
 | `CODEX_PROFILE` | — | Codex 配置 profile |
 | `CODEX_APPROVAL_POLICY` | `never` | 审批策略（`untrusted`、`on-failure`、`on-request`、`never`） |
-| `CODEX_SANDBOX` | `danger-full-access` | 沙箱模式（`read-only`、`workspace-write`、`danger-full-access`） |
+| `CODEX_SANDBOX` | `workspace-write` | 沙箱模式（`read-only`、`workspace-write`、`danger-full-access`） |
+| `CODEX_REASONING_EFFORT` | — | 可选默认值：`low`、`medium`、`high`、`xhigh`、`max` 或 `ultra` |
+| `CODEX_BYPASS_APPROVALS_AND_SANDBOX` | — | 仅在宿主隔离边界明确时设置为 `true` |
 | `CODEX_EXECUTABLE_PATH` | 自动检测 | `codex` 二进制路径 |
+
+公开版当前使用 `codex exec --json` 和 `codex exec resume`；这些变量不会启用
+Codex app-server 或原生执行中 steering。
+
+## Kimi Code 0.27+
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `KIMI_CODE_SERVER_URL` | `http://127.0.0.1:58627` | 已有本地 Kimi Server 地址；否则 MetaBot 按需启动 |
+| `KIMI_CODE_HOME` | `~/.kimi-code` | Kimi Code 配置和本地 Server Token 目录 |
+| `KIMI_API_KEY` | Kimi 登录状态 | 可选 Provider API Key，由本地 Server 继承 |
+
+使用 `npm install -g @moonshot-ai/kimi-code@latest` 安装支持的 CLI，然后执行
+`kimi login`。MetaBot 使用 Kimi 官方本地 Server API，不再使用旧 Python
+`kimi-cli --wire` 协议。每个 Bot 的 `model`、`thinking`、`executable`、
+`serverUrl` 和 `contextWindow` 覆盖应写入 `bots.json`；详见
+[多 Bot 模式](multi-bot.md#kimi-code-options)。
 
 ## MetaMemory
 

--- a/docs/configuration/multi-bot.md
+++ b/docs/configuration/multi-bot.md
@@ -1,111 +1,160 @@
 # Multi-Bot Mode
 
-Run multiple Feishu and Telegram bots in a single MetaBot process.
+Run multiple Feishu/Lark, Telegram, and WeChat bots in one MetaBot Bridge.
+Each bot has its own channel credentials, engine, workspace, sessions, and
+per-group reply settings.
 
 ## Setup
 
-Set `BOTS_CONFIG=./bots.json` in `.env` to enable multi-bot mode:
+Set `BOTS_CONFIG=./bots.json` in `.env`:
 
 ```json
 {
   "feishuBots": [
     {
-      "name": "metabot",
+      "name": "codex-dev",
+      "engine": "codex",
       "feishuAppId": "cli_xxx",
       "feishuAppSecret": "...",
-      "defaultWorkingDirectory": "/home/user/project-a"
+      "defaultWorkingDirectory": "/home/me/project-a",
+      "codex": {
+        "reasoningEffort": "high"
+      }
     },
     {
-      "name": "backend-bot",
+      "name": "kimi-reviewer",
+      "engine": "kimi",
       "feishuAppId": "cli_yyy",
       "feishuAppSecret": "...",
-      "defaultWorkingDirectory": "/home/user/project-b"
+      "defaultWorkingDirectory": "/home/me/project-b",
+      "kimi": {
+        "thinking": true
+      }
     }
   ],
   "telegramBots": [
     {
-      "name": "tg-bot",
+      "name": "personal-codex",
+      "engine": "codex",
       "telegramBotToken": "123456:ABC...",
-      "defaultWorkingDirectory": "/home/user/project-c"
+      "defaultWorkingDirectory": "/home/me/personal"
     }
   ]
 }
 ```
 
-## Bot Config Fields
+## Shared Bot Fields
 
 | Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `name` | Yes | — | Bot identifier |
-| `defaultWorkingDirectory` | Yes | — | Working directory for the agent |
-| `engine` | No | `"claude"` | Agent engine — `"claude"` or `"kimi"` |
-| `feishuAppId` / `feishuAppSecret` | Feishu | — | Feishu app credentials |
-| `telegramBotToken` | Telegram | — | Telegram bot token |
-| `maxTurns` | No | unlimited | Max turns per request |
-| `maxBudgetUsd` | No | unlimited | Max cost per request (Claude only — Kimi runs on subscription) |
-| `model` | No | SDK default | Default model ID (engine-specific) |
-| `allowedTools` | No | `Read,Edit,Write,Glob,Grep,Bash` | Tool whitelist (Claude only) |
-| `outputsBaseDir` | No | `/tmp/metabot-outputs` | Output files directory |
-| `kimi` | No | — | Kimi-specific options (only when `engine: "kimi"`) — see below |
+|---|---|---|---|
+| `name` | Yes | — | Stable bot identifier |
+| `defaultWorkingDirectory` | Yes | — | Workspace available to the agent |
+| `engine` | No | `"codex"` | `"codex"`, `"kimi"`, or compatibility `"claude"` |
+| `model` | No | Engine default | Session model override |
+| `visible` | No | `true` | Register the bot for Agent Bus discovery |
+| `memoryPublic` | No | sticky/default policy | Pin the bot's default memory visibility when explicitly set |
+| `maxTurns` / `maxBudgetUsd` | No | unlimited | Claude compatibility limits |
+| `outputsBaseDir` | No | temporary user directory | Files automatically returned to chat |
 
-### Kimi engine options
+Channel-specific credentials:
 
-When `engine: "kimi"`, the `kimi` object configures Kimi CLI behavior:
+| Channel | Fields |
+|---|---|
+| Feishu/Lark | `feishuAppId`, `feishuAppSecret`, optional `groupNoMention` |
+| Telegram | `telegramBotToken` |
+| WeChat | optional `wechatBotToken`; omit it for QR login |
+
+## Codex Options
 
 ```json
 {
-  "name": "coding-bot",
+  "engine": "codex",
+  "codex": {
+    "model": "gpt-5.6-sol",
+    "profile": "personal",
+    "reasoningEffort": "high",
+    "approvalPolicy": "never",
+    "sandbox": "workspace-write"
+  }
+}
+```
+
+Common fields are `model`, `profile`, `apiKey`, `baseUrl`, `reasoningEffort`,
+`approvalPolicy`, `sandbox`, `executable`, `extraArgs`, and `env`. Normal
+subscription use only needs `codex login`.
+
+The public adapter currently runs `codex exec --json` and resumes with
+`codex exec resume`. Codex app-server and native mid-turn steering are not part
+of the current public behavior.
+
+## Kimi Code Options {#kimi-code-options}
+
+```json
+{
   "engine": "kimi",
-  "feishuAppId": "cli_xxx",
-  "feishuAppSecret": "...",
-  "defaultWorkingDirectory": "/home/user/project",
   "kimi": {
-    "model": "kimi-for-coding",
-    "thinking": true
+    "model": "kimi-code/k3",
+    "thinking": true,
+    "permissionMode": "auto",
+    "serverUrl": "http://127.0.0.1:58627"
   }
 }
 ```
 
 | Field | Default | Description |
-|-------|---------|-------------|
-| `kimi.model` | `kimi-for-coding` | Kimi model ID |
-| `kimi.thinking` | `false` | Enable thinking mode (shows reasoning tokens) |
-| `kimi.executable` | (auto) | Override path to `kimi` CLI binary |
+|---|---|---|
+| `kimi.model` | Kimi Code config default | Model ID or configured short alias |
+| `kimi.thinking` | Kimi Code config default | Thinking override |
+| `kimi.permissionMode` | `auto` | Tool permission policy; `yolo` requires explicit trusted-workspace opt-in |
+| `kimi.executable` | `kimi` from `PATH` | Kimi Code executable |
+| `kimi.serverUrl` | `http://127.0.0.1:58627` | Existing loopback Server origin; otherwise started on demand |
+| `kimi.contextWindow` | current Kimi default | Display/context override |
 
-Kimi requires a one-time `kimi login` (run it in a separate terminal after installing `kimi-cli` via `uv tool install kimi-cli`). Authentication is shared with the Kimi CLI — no API key needed.
+Kimi requires Kimi Code 0.27+:
 
-## How It Works
-
-- Each bot gets its own Feishu/Telegram connection
-- Sessions are isolated per `chatId` — no collision between bots
-- Each bot uses its own working directory and configuration
-- Environment variables serve as defaults for any field not specified in JSON
-
-When `BOTS_CONFIG` is set, `FEISHU_APP_ID` / `FEISHU_APP_SECRET` env vars are ignored.
-
-## Peers Configuration
-
-You can also configure [Peers](../features/peers.md) in `bots.json`:
-
-```json
-{
-  "feishuBots": [{ "..." }],
-  "peers": [
-    {
-      "name": "alice",
-      "url": "http://localhost:9200",
-      "secret": "alice-api-secret"
-    }
-  ]
-}
+```bash
+npm install -g @moonshot-ai/kimi-code@latest
+kimi login
 ```
+
+MetaBot uses the official local Server API shared with Kimi's web frontend.
+It provides durable Sessions, live snapshots, questions, cancellation, usage,
+tools, subagents, and goals. Feishu mid-turn steering is not exposed in this
+release. The legacy Python `kimi-cli --wire --work-dir` protocol is not used.
+
+`permissionMode` defaults to `auto`. `yolo` is available only as an explicit
+opt-in for a workspace you trust; the personal edition never enables it by default.
+
+## Claude Code Compatibility
+
+Existing bots can set `"engine": "claude"` and continue using Claude login,
+Anthropic-compatible providers, `.claude/skills/`, and `CLAUDE.md`. New
+personal-edition bots default to Codex when `engine` is omitted.
+
+## Runtime Behavior
+
+- Each bot owns an independent channel connection and workspace.
+- Sessions are isolated per bot and `chatId`.
+- A chat can switch engine/model with `/model`; this does not rename the bot.
+- Feishu reply modes persist per bot and group.
+- Agent Teams and the Agent Bus can coordinate bots running different engines.
+- Environment variables provide defaults; explicit `bots.json` fields win.
+
+When `BOTS_CONFIG` is set, single-bot `FEISHU_APP_ID` and
+`FEISHU_APP_SECRET` are ignored.
 
 ## Single-Bot Mode
 
-Without `BOTS_CONFIG`, MetaBot runs in single-bot mode using environment variables:
+Without `BOTS_CONFIG`, configure one bot through environment variables:
 
 ```bash
+METABOT_ENGINE=codex
 FEISHU_APP_ID=cli_xxx
 FEISHU_APP_SECRET=...
-DEFAULT_WORKING_DIRECTORY=/home/user/project
+CLAUDE_DEFAULT_WORKING_DIRECTORY=/home/me/project
 ```
+
+`CLAUDE_DEFAULT_WORKING_DIRECTORY` keeps its historical name but supplies the
+workspace for every engine.
+
+See [Environment Variables](environment-variables.md) for the full list.

--- a/docs/configuration/multi-bot.zh.md
+++ b/docs/configuration/multi-bot.zh.md
@@ -1,111 +1,156 @@
 # 多 Bot 模式
 
-在单个 MetaBot 进程中运行多个飞书和 Telegram Bot。
+在一个 MetaBot Bridge 中运行多个飞书/Lark、Telegram 和微信 Bot。每个 Bot
+拥有独立的渠道凭证、引擎、工作区、会话和群回复设置。
 
 ## 配置
 
-在 `.env` 中设置 `BOTS_CONFIG=./bots.json` 启用多 Bot 模式：
+在 `.env` 中设置 `BOTS_CONFIG=./bots.json`：
 
 ```json
 {
   "feishuBots": [
     {
-      "name": "metabot",
+      "name": "codex-dev",
+      "engine": "codex",
       "feishuAppId": "cli_xxx",
       "feishuAppSecret": "...",
-      "defaultWorkingDirectory": "/home/user/project-a"
+      "defaultWorkingDirectory": "/home/me/project-a",
+      "codex": {
+        "reasoningEffort": "high"
+      }
     },
     {
-      "name": "backend-bot",
+      "name": "kimi-reviewer",
+      "engine": "kimi",
       "feishuAppId": "cli_yyy",
       "feishuAppSecret": "...",
-      "defaultWorkingDirectory": "/home/user/project-b"
+      "defaultWorkingDirectory": "/home/me/project-b",
+      "kimi": {
+        "thinking": true
+      }
     }
   ],
   "telegramBots": [
     {
-      "name": "tg-bot",
+      "name": "personal-codex",
+      "engine": "codex",
       "telegramBotToken": "123456:ABC...",
-      "defaultWorkingDirectory": "/home/user/project-c"
+      "defaultWorkingDirectory": "/home/me/personal"
     }
   ]
 }
 ```
 
-## Bot 配置字段
+## 通用 Bot 字段
 
 | 字段 | 必填 | 默认值 | 说明 |
-|------|------|--------|------|
-| `name` | 是 | — | Bot 标识名 |
-| `defaultWorkingDirectory` | 是 | — | Agent 工作目录 |
-| `engine` | 否 | `"claude"` | Agent 引擎 — `"claude"` 或 `"kimi"` |
-| `feishuAppId` / `feishuAppSecret` | 飞书 | — | 飞书应用凭证 |
-| `telegramBotToken` | Telegram | — | Telegram Bot Token |
-| `maxTurns` | 否 | 不限 | 每次请求最大轮次 |
-| `maxBudgetUsd` | 否 | 不限 | 每次请求费用上限（仅 Claude — Kimi 走订阅） |
-| `model` | 否 | SDK 默认 | 默认模型 ID（引擎相关） |
-| `allowedTools` | 否 | `Read,Edit,Write,Glob,Grep,Bash` | 工具白名单（仅 Claude） |
-| `outputsBaseDir` | 否 | `/tmp/metabot-outputs` | 输出文件目录 |
-| `kimi` | 否 | — | Kimi 专用配置（仅当 `engine: "kimi"` 时） — 见下方 |
+|---|---|---|---|
+| `name` | 是 | — | 稳定的 Bot 标识 |
+| `defaultWorkingDirectory` | 是 | — | Agent 可访问的工作区 |
+| `engine` | 否 | `"codex"` | `"codex"`、`"kimi"` 或兼容引擎 `"claude"` |
+| `model` | 否 | 引擎默认 | Session 模型覆盖 |
+| `visible` | 否 | `true` | 是否注册到 Agent Bus 供发现 |
+| `memoryPublic` | 否 | 粘性/默认策略 | 显式设置时固定 Bot 的默认 Memory 可见性 |
+| `maxTurns` / `maxBudgetUsd` | 否 | 不限制 | Claude 兼容限制 |
+| `outputsBaseDir` | 否 | 用户临时目录 | 自动回传到聊天的文件目录 |
 
-### Kimi 引擎选项
+渠道凭证字段：
 
-当 `engine: "kimi"` 时，`kimi` 对象用于配置 Kimi CLI 行为：
+| 渠道 | 字段 |
+|---|---|
+| 飞书/Lark | `feishuAppId`、`feishuAppSecret`，可选 `groupNoMention` |
+| Telegram | `telegramBotToken` |
+| 微信 | 可选 `wechatBotToken`；省略时扫码登录 |
+
+## Codex 配置
 
 ```json
 {
-  "name": "coding-bot",
+  "engine": "codex",
+  "codex": {
+    "model": "gpt-5.6-sol",
+    "profile": "personal",
+    "reasoningEffort": "high",
+    "approvalPolicy": "never",
+    "sandbox": "workspace-write"
+  }
+}
+```
+
+常用字段包括 `model`、`profile`、`apiKey`、`baseUrl`、
+`reasoningEffort`、`approvalPolicy`、`sandbox`、`executable`、`extraArgs`
+和 `env`。普通订阅场景只需执行 `codex login`。
+
+公开版当前运行 `codex exec --json`，通过 `codex exec resume` 续接。Codex
+app-server 和原生执行中 steering 不属于当前公开行为。
+
+## Kimi Code 配置 {#kimi-code-options}
+
+```json
+{
   "engine": "kimi",
-  "feishuAppId": "cli_xxx",
-  "feishuAppSecret": "...",
-  "defaultWorkingDirectory": "/home/user/project",
   "kimi": {
-    "model": "kimi-for-coding",
-    "thinking": true
+    "model": "kimi-code/k3",
+    "thinking": true,
+    "permissionMode": "auto",
+    "serverUrl": "http://127.0.0.1:58627"
   }
 }
 ```
 
 | 字段 | 默认值 | 说明 |
-|------|--------|------|
-| `kimi.model` | `kimi-for-coding` | Kimi 模型 ID |
-| `kimi.thinking` | `false` | 启用思考模式（展示推理过程） |
-| `kimi.executable` | (自动) | 覆盖 `kimi` CLI 二进制路径 |
+|---|---|---|
+| `kimi.model` | Kimi Code 配置默认 | 模型 ID 或已配置的短别名 |
+| `kimi.thinking` | Kimi Code 配置默认 | Thinking 覆盖 |
+| `kimi.permissionMode` | `auto` | 工具权限策略；`yolo` 仅限可信工作区显式启用 |
+| `kimi.executable` | `PATH` 中的 `kimi` | Kimi Code 可执行文件 |
+| `kimi.serverUrl` | `http://127.0.0.1:58627` | 已有 loopback Server 地址；否则按需启动 |
+| `kimi.contextWindow` | 当前 Kimi 默认 | 展示/上下文覆盖 |
 
-Kimi 需要先执行一次 `kimi login`（安装 `uv tool install kimi-cli` 后，在另外的终端运行）。授权与 Kimi CLI 共享 — 无需 API Key。
+Kimi 需要 Kimi Code 0.27+：
 
-## 工作原理
-
-- 每个 Bot 拥有独立的飞书/Telegram 连接
-- 会话按 `chatId` 隔离 — Bot 之间无冲突
-- 每个 Bot 使用各自的工作目录和配置
-- 环境变量作为 JSON 中未指定字段的默认值
-
-设置 `BOTS_CONFIG` 后，`FEISHU_APP_ID` / `FEISHU_APP_SECRET` 环境变量被忽略。
-
-## Peers 配置
-
-也可以在 `bots.json` 中配置 [Peers](../features/peers.md)：
-
-```json
-{
-  "feishuBots": [{ "..." }],
-  "peers": [
-    {
-      "name": "alice",
-      "url": "http://localhost:9200",
-      "secret": "alice-api-secret"
-    }
-  ]
-}
+```bash
+npm install -g @moonshot-ai/kimi-code@latest
+kimi login
 ```
+
+MetaBot 使用与 Kimi Web 前端同源的官方本地 Server API，支持持久 Session、
+原子快照、问题交互、停止、用量、工具、子 Agent 和 Goal。本版本暂不开放
+飞书执行中 steering，也不再使用旧 Python `kimi-cli --wire --work-dir` 协议。
+
+`permissionMode` 默认是 `auto`。只有在完全可信的工作区中才应显式选择
+`yolo`；个人版不会默认开启该模式。
+
+## Claude Code 兼容
+
+现有 Bot 可以设置 `"engine": "claude"`，继续使用 Claude 登录、Anthropic
+兼容 Provider、`.claude/skills/` 和 `CLAUDE.md`。个人版新 Bot 省略
+`engine` 时默认为 Codex。
+
+## 运行行为
+
+- 每个 Bot 拥有独立渠道连接和工作区。
+- 会话按 Bot 和 `chatId` 隔离。
+- Chat 可以使用 `/model` 切换引擎/模型，不会改变 Bot 身份。
+- 飞书群回复模式按 Bot 和群持久化。
+- Agent Teams 和 Agent Bus 可以协调不同引擎的 Bot。
+- 环境变量提供默认值；显式 `bots.json` 字段优先。
+
+设置 `BOTS_CONFIG` 后，单 Bot 的 `FEISHU_APP_ID` 和
+`FEISHU_APP_SECRET` 会被忽略。
 
 ## 单 Bot 模式
 
-不设 `BOTS_CONFIG` 时，MetaBot 使用环境变量运行单个 Bot：
+未设置 `BOTS_CONFIG` 时，通过环境变量配置一个 Bot：
 
 ```bash
+METABOT_ENGINE=codex
 FEISHU_APP_ID=cli_xxx
 FEISHU_APP_SECRET=...
-DEFAULT_WORKING_DIRECTORY=/home/user/project
+CLAUDE_DEFAULT_WORKING_DIRECTORY=/home/me/project
 ```
+
+`CLAUDE_DEFAULT_WORKING_DIRECTORY` 保留了历史名称，但会为所有引擎提供工作区。
+
+完整列表见[环境变量](environment-variables.md)。

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -10,7 +10,7 @@ git clone https://github.com/xvirobotics/metabot.git
 cd metabot
 
 # 2. Install dependencies
-npm install
+npm ci --include=dev
 
 # 3. Copy environment config
 cp .env.example .env
@@ -23,7 +23,10 @@ npm run build
 npm run dev
 ```
 
-**Prerequisites:** Node.js 20+, Claude Code CLI installed and authenticated.
+**Prerequisites:** Node.js >= 22.19 and Git. Install and authenticate only the
+engine needed for engine-specific work: Codex CLI, Kimi Code 0.27+, or the
+Claude Code compatibility CLI. Documentation and most unit tests do not
+require an authenticated engine.
 
 ## Development Commands
 

--- a/docs/development/contributing.zh.md
+++ b/docs/development/contributing.zh.md
@@ -10,7 +10,7 @@ git clone https://github.com/xvirobotics/metabot.git
 cd metabot
 
 # 2. 安装依赖
-npm install
+npm ci --include=dev
 
 # 3. 复制环境配置
 cp .env.example .env
@@ -23,7 +23,9 @@ npm run build
 npm run dev
 ```
 
-**前置条件：** Node.js 20+，Claude Code CLI 已安装并认证。
+**前置条件：** Node.js >= 22.19 和 Git。只有进行特定引擎开发时才需要安装、
+认证对应的 Codex CLI、Kimi Code 0.27+ 或 Claude Code 兼容 CLI。文档和大部分
+单元测试不需要已认证的引擎。
 
 ## 开发命令
 

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -1,73 +1,85 @@
 # Project Structure
 
-MetaBot is a TypeScript ESM project (`"type": "module"`, all imports use `.js` extensions).
+MetaBot is a Node.js >= 22.19 TypeScript ESM monorepo (`"type": "module"`;
+local imports use `.js` extensions).
 
 ## Directory Layout
 
-```
+```text
 metabot/
-├── src/
-│   ├── index.ts                    # Entrypoint
-│   ├── config.ts                   # Configuration loader
+├── src/                              # IM Bridge runtime
+│   ├── index.ts                      # Entrypoint and lifecycle
+│   ├── config.ts                     # Environment and bots.json loader
 │   ├── bridge/
-│   │   ├── message-bridge.ts       # Core orchestrator
-│   │   ├── rate-limiter.ts         # Card update throttling
-│   │   └── outputs-manager.ts      # Output file lifecycle
-│   ├── claude/
-│   │   ├── executor.ts             # Agent SDK wrapper
-│   │   ├── stream-processor.ts     # SDK message → card state
-│   │   └── session-manager.ts      # Session store
-│   ├── feishu/
-│   │   ├── event-handler.ts        # Feishu event parsing
-│   │   ├── card-builder.ts         # Interactive card builder
-│   │   ├── message-sender.ts       # Feishu API client
-│   │   └── doc-reader.ts           # Document → Markdown
-│   ├── telegram/
-│   │   └── ...                     # Telegram bot integration
-│   ├── web/
-│   │   └── ws-server.ts            # WebSocket server + static files
-│   ├── api/
-│   │   ├── http-server.ts          # REST API server
-│   │   ├── voice-handler.ts        # Voice API (STT + Agent + TTS)
-│   │   ├── bot-registry.ts         # Bot registry
-│   │   └── peer-manager.ts         # Cross-instance federation
-│   ├── memory/
-│   │   ├── memory-client.ts        # MetaMemory HTTP client
-│   │   └── memory-events.ts        # Change event emitter
-│   ├── sync/
-│   │   ├── doc-sync.ts             # Wiki sync service
-│   │   ├── sync-store.ts           # SQLite persistence
-│   │   └── markdown-to-blocks.ts   # MD → Feishu blocks
-│   ├── skills/
-│   │   └── metabot/
-│   │       └── SKILL.md            # Agent Bus skill
-│   └── utils/
-│       └── logger.ts               # Logging
-├── bin/
-│   ├── metabot                     # Single CLI binary (process control + bridge API + core delegation)
-│   └── doubao-tts                  # Doubao TTS CLI
-├── web/                            # Web UI source (React + Vite)
-│   ├── src/
-│   │   ├── components/             # React components
-│   │   ├── hooks/                  # Custom hooks (WebSocket)
-│   │   ├── store.ts                # Zustand state management
-│   │   └── theme.css               # Design system
-│   └── vite.config.ts
-├── tests/                          # Vitest test files
-├── docs/                           # Documentation (MkDocs)
-├── dist/                           # Compiled output (includes dist/web/)
-├── mkdocs.yml                      # MkDocs configuration
-├── bots.example.json               # Multi-bot config example
-├── .env.example                    # Environment config example
-└── package.json
+│   │   ├── message-bridge.ts         # Commands, queues, tasks, engine execution
+│   │   ├── command-handler.ts        # Chat command surface
+│   │   └── outputs-manager.ts        # Output file lifecycle
+│   ├── engines/
+│   │   ├── index.ts                  # Codex-default engine router
+│   │   ├── types.ts                  # Shared Engine / Executor contracts
+│   │   ├── codex/                    # codex exec JSONL + resume adapter
+│   │   ├── kimi/                     # Kimi Code 0.27+ local Server API adapter
+│   │   └── claude/                   # Claude Code compatibility adapter
+│   ├── feishu/                       # Lark events, cards, media, group routing
+│   ├── telegram/                     # Telegram long-polling adapter
+│   ├── wechat/                       # WeChat/ClawBot adapter
+│   ├── agent-teams/                  # Durable teams, tasks, members, and runs
+│   ├── session/                      # Shared session state
+│   ├── scheduler/                    # Persistent scheduling
+│   ├── api/                          # Bridge HTTP routes, peers, voice
+│   ├── memory/                       # Core Memory client and events
+│   ├── sync/                         # Feishu Wiki sync
+│   ├── skills/                       # Bundled Bridge-side skills
+│   ├── web/                          # Bridge WebSocket/static serving
+│   └── utils/                        # Logging and helpers
+├── packages/
+│   ├── server/                       # Personal Core HTTP backend
+│   ├── web-ui/                       # Personal Core React application
+│   ├── cli/                          # Feature CLI shipped as metabot
+│   ├── cli-core/                     # Shared CLI HTTP client
+│   ├── metamemory/                   # Memory client package
+│   ├── skill-hub/                    # Skill registry client package
+│   └── skills/                       # Core-distributed skill bundles
+├── web/                              # Bridge browser UI
+├── bin/                              # metabot and helper launchers
+├── scripts/                          # Release and packaging scripts
+├── tests/                            # Bridge Vitest suites
+├── docs/                             # MkDocs sources and landing page
+├── install.sh / install.ps1          # Personal-edition installers
+├── bots.example.json                 # Multi-bot example
+├── .env.example                      # Environment example
+└── package.json                      # npm workspaces root
 ```
 
-## Key Dependencies
+## Engine Adapters
 
-| Package | Purpose |
-|---------|---------|
-| `@anthropic-ai/claude-agent-sdk` | Claude Code Agent SDK |
-| `@anthropic-ai/claude-code` | Claude Code CLI (peer dependency) |
-| `@larksuiteoapi/node-sdk` | Feishu/Lark SDK |
-| `tsx` | TypeScript execution (dev) |
-| `vitest` | Test framework |
+| Path | Role |
+|---|---|
+| `src/engines/codex/executor.ts` | Runs `codex exec --json` / `exec resume`; translates JSONL into shared events. |
+| `src/engines/codex/session-lister.ts` | Discovers resumable Codex sessions without claiming app-server support. |
+| `src/engines/kimi/daemon-client.ts` | Starts or connects to Kimi Code's official loopback Server API. |
+| `src/engines/kimi/executor.ts` | Maps Sessions, snapshots, steering, questions, tools, subagents, and goals. |
+| `src/engines/kimi/session-lister.ts` | Lists Kimi Sessions through the Server API. |
+| `src/engines/claude/` | Keeps existing Claude CLI / Agent SDK behavior compatible. |
+
+All engines implement the shared boundary in `src/engines/types.ts`; the Bridge
+does not identify a bot by its current engine.
+
+## Key Dependencies and Runtimes
+
+| Package or runtime | Purpose |
+|---|---|
+| Node.js >= 22.19 | Supported runtime baseline |
+| Codex CLI | Default external engine executable; authenticated with `codex login` |
+| Kimi Code >= 0.27 | External `kimi` executable and official local Server API |
+| `@anthropic-ai/claude-agent-sdk` | Claude compatibility integration |
+| `@larksuiteoapi/node-sdk` | Feishu/Lark API and WebSocket SDK |
+| `grammy` | Telegram integration |
+| `better-sqlite3` | Local sessions, teams, schedules, and routing state |
+| `node-pty` | Claude compatibility PTY backend |
+| `ws` | Bridge and WebSocket transport |
+| Vitest + TypeScript + ESLint | Test, build, and lint toolchain |
+
+Codex and Kimi Code are intentionally external user-managed executables, not
+embedded SDK dependencies. This lets personal-edition users authenticate with
+their own subscriptions and update the engine CLIs independently.

--- a/docs/development/project-structure.zh.md
+++ b/docs/development/project-structure.zh.md
@@ -1,73 +1,84 @@
 # 项目结构
 
-MetaBot 是 TypeScript ESM 项目（`"type": "module"`，所有导入使用 `.js` 扩展名）。
+MetaBot 是 Node.js >= 22.19 的 TypeScript ESM monorepo（`"type": "module"`；
+本地导入使用 `.js` 扩展名）。
 
 ## 目录布局
 
-```
+```text
 metabot/
-├── src/
-│   ├── index.ts                    # 入口
-│   ├── config.ts                   # 配置加载器
+├── src/                              # IM Bridge 运行时
+│   ├── index.ts                      # 入口和生命周期
+│   ├── config.ts                     # 环境变量和 bots.json 加载器
 │   ├── bridge/
-│   │   ├── message-bridge.ts       # 核心调度器
-│   │   ├── rate-limiter.ts         # 卡片更新节流
-│   │   └── outputs-manager.ts      # 输出文件生命周期
-│   ├── claude/
-│   │   ├── executor.ts             # Agent SDK 封装
-│   │   ├── stream-processor.ts     # SDK 消息 → 卡片状态
-│   │   └── session-manager.ts      # 会话存储
-│   ├── feishu/
-│   │   ├── event-handler.ts        # 飞书事件解析
-│   │   ├── card-builder.ts         # 交互卡片构建器
-│   │   ├── message-sender.ts       # 飞书 API 客户端
-│   │   └── doc-reader.ts           # 文档 → Markdown
-│   ├── telegram/
-│   │   └── ...                     # Telegram Bot 集成
-│   ├── web/
-│   │   └── ws-server.ts            # WebSocket 服务 + 静态文件
-│   ├── api/
-│   │   ├── http-server.ts          # REST API 服务
-│   │   ├── voice-handler.ts        # 语音 API（STT + Agent + TTS）
-│   │   ├── bot-registry.ts         # Bot 注册表
-│   │   └── peer-manager.ts         # 跨实例联邦
-│   ├── memory/
-│   │   ├── memory-client.ts        # MetaMemory HTTP 客户端
-│   │   └── memory-events.ts        # 变更事件发射器
-│   ├── sync/
-│   │   ├── doc-sync.ts             # 知识库同步服务
-│   │   ├── sync-store.ts           # SQLite 持久化
-│   │   └── markdown-to-blocks.ts   # MD → 飞书块
-│   ├── skills/
-│   │   └── metabot/
-│   │       └── SKILL.md            # Agent 总线 skill
-│   └── utils/
-│       └── logger.ts               # 日志
-├── bin/
-│   ├── metabot                     # 唯一 CLI 入口（进程控制 + bridge API + core 转发）
-│   └── doubao-tts                  # 豆包 TTS CLI
-├── web/                            # Web UI 源码（React + Vite）
-│   ├── src/
-│   │   ├── components/             # React 组件
-│   │   ├── hooks/                  # 自定义 Hook（WebSocket）
-│   │   ├── store.ts                # Zustand 状态管理
-│   │   └── theme.css               # 设计系统
-│   └── vite.config.ts
-├── tests/                          # Vitest 测试文件
-├── docs/                           # 文档（MkDocs）
-├── dist/                           # 编译输出（含 dist/web/）
-├── mkdocs.yml                      # MkDocs 配置
-├── bots.example.json               # 多 Bot 配置示例
-├── .env.example                    # 环境配置示例
-└── package.json
+│   │   ├── message-bridge.ts         # 命令、队列、任务、引擎执行
+│   │   ├── command-handler.ts        # Chat 命令面
+│   │   └── outputs-manager.ts        # 输出文件生命周期
+│   ├── engines/
+│   │   ├── index.ts                  # Codex 默认的引擎路由
+│   │   ├── types.ts                  # 共享 Engine / Executor contract
+│   │   ├── codex/                    # codex exec JSONL + resume 适配器
+│   │   ├── kimi/                     # Kimi Code 0.27+ 本地 Server API 适配器
+│   │   └── claude/                   # Claude Code 兼容适配器
+│   ├── feishu/                       # Lark 事件、卡片、媒体、群路由
+│   ├── telegram/                     # Telegram 长轮询适配器
+│   ├── wechat/                       # 微信/ClawBot 适配器
+│   ├── agent-teams/                  # 持久 Team、任务、成员和运行
+│   ├── session/                      # 共享会话状态
+│   ├── scheduler/                    # 持久调度
+│   ├── api/                          # Bridge HTTP 路由、Peers、语音
+│   ├── memory/                       # Core Memory 客户端和事件
+│   ├── sync/                         # 飞书知识库同步
+│   ├── skills/                       # Bridge 侧内置 Skills
+│   ├── web/                          # Bridge WebSocket/静态服务
+│   └── utils/                        # 日志和工具
+├── packages/
+│   ├── server/                       # 个人 Core HTTP 后端
+│   ├── web-ui/                       # 个人 Core React 应用
+│   ├── cli/                          # 作为 metabot 发布的功能 CLI
+│   ├── cli-core/                     # 共享 CLI HTTP 客户端
+│   ├── metamemory/                   # Memory 客户端 Package
+│   ├── skill-hub/                    # Skill 注册表客户端 Package
+│   └── skills/                       # Core 分发的 Skill bundles
+├── web/                              # Bridge 浏览器 UI
+├── bin/                              # metabot 和辅助启动器
+├── scripts/                          # Release 和打包脚本
+├── tests/                            # Bridge Vitest 测试
+├── docs/                             # MkDocs 源文件和 Landing Page
+├── install.sh / install.ps1          # 个人版安装器
+├── bots.example.json                 # 多 Bot 示例
+├── .env.example                      # 环境变量示例
+└── package.json                      # npm workspaces 根
 ```
 
-## 核心依赖
+## 引擎适配器
 
-| 包 | 用途 |
-|---|------|
-| `@anthropic-ai/claude-agent-sdk` | Claude Code Agent SDK |
-| `@anthropic-ai/claude-code` | Claude Code CLI（peer 依赖） |
-| `@larksuiteoapi/node-sdk` | 飞书 SDK |
-| `tsx` | TypeScript 执行（开发） |
-| `vitest` | 测试框架 |
+| 路径 | 作用 |
+|---|---|
+| `src/engines/codex/executor.ts` | 运行 `codex exec --json` / `exec resume`，把 JSONL 转为共享事件。 |
+| `src/engines/codex/session-lister.ts` | 发现可续接 Codex 会话，不宣称支持 app-server。 |
+| `src/engines/kimi/daemon-client.ts` | 启动或连接 Kimi Code 官方 loopback Server API。 |
+| `src/engines/kimi/executor.ts` | 映射 Session、快照、插话、问题、工具、子 Agent 和 Goal。 |
+| `src/engines/kimi/session-lister.ts` | 通过 Server API 列出 Kimi Session。 |
+| `src/engines/claude/` | 保持现有 Claude CLI / Agent SDK 行为兼容。 |
+
+所有引擎都实现 `src/engines/types.ts` 中的共享边界；Bridge 不会用当前引擎
+标识 Bot 身份。
+
+## 核心依赖与运行时
+
+| Package 或运行时 | 用途 |
+|---|---|
+| Node.js >= 22.19 | 支持的运行时基线 |
+| Codex CLI | 默认外部引擎可执行文件；使用 `codex login` 认证 |
+| Kimi Code >= 0.27 | 外部 `kimi` 可执行文件和官方本地 Server API |
+| `@anthropic-ai/claude-agent-sdk` | Claude 兼容集成 |
+| `@larksuiteoapi/node-sdk` | 飞书/Lark API 和 WebSocket SDK |
+| `grammy` | Telegram 集成 |
+| `better-sqlite3` | 本地会话、Teams、调度和路由状态 |
+| `node-pty` | Claude 兼容 PTY 后端 |
+| `ws` | Bridge 和 WebSocket 传输 |
+| Vitest + TypeScript + ESLint | 测试、构建和 lint 工具链 |
+
+Codex 和 Kimi Code 有意保持为用户管理的外部可执行文件，而不是内嵌 SDK
+依赖。个人版用户可以使用自己的订阅认证，并独立更新引擎 CLI。

--- a/docs/features/wechat.md
+++ b/docs/features/wechat.md
@@ -89,12 +89,12 @@ Send a message to ClawBot in WeChat — MetaBot handles it and replies.
 |-------|----------|---------|-------------|
 | `name` | Yes | — | Bot identifier |
 | `description` | No | — | Bot description |
-| `defaultWorkingDirectory` | Yes | — | Working directory for Claude |
+| `defaultWorkingDirectory` | Yes | — | Working directory for the selected Agent engine |
 | `wechatBotToken` | No | — | Pre-authenticated iLink token (optional) |
 | `ilinkBaseUrl` | No | `https://ilinkai.weixin.qq.com` | iLink API URL |
 | `maxTurns` | No | unlimited | Max conversation turns |
 | `maxBudgetUsd` | No | unlimited | Max cost per request |
-| `model` | No | SDK default | Claude model |
+| `model` | No | Engine default | Model override for the selected engine |
 
 ## Environment Variable Mode
 

--- a/docs/features/wechat.zh.md
+++ b/docs/features/wechat.zh.md
@@ -109,12 +109,12 @@ Waiting for scan...
 |------|------|--------|------|
 | `name` | 是 | — | Bot 标识名 |
 | `description` | 否 | — | Bot 描述 |
-| `defaultWorkingDirectory` | 是 | — | Claude 的工作目录 |
+| `defaultWorkingDirectory` | 是 | — | 所选 Agent 引擎的工作目录 |
 | `wechatBotToken` | 否 | — | 预认证的 iLink token（可选，不填则 QR 登录） |
 | `ilinkBaseUrl` | 否 | `https://ilinkai.weixin.qq.com` | iLink API 地址 |
 | `maxTurns` | 否 | 不限 | 最大对话轮次 |
 | `maxBudgetUsd` | 否 | 不限 | 单次最大花费 |
-| `model` | 否 | SDK 默认 | Claude 模型 |
+| `model` | 否 | 引擎默认 | 所选引擎的模型覆盖 |
 
 ## 环境变量模式
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,15 @@
 # Installation
 
+## Requirements
+
+- **Node.js >= 22.19**
+- Git
+- Credentials for at least one engine and one chat channel
+- Linux/macOS for the complete signed-checksum personal-edition lifecycle
+
+Codex is the default engine. Kimi Code is a first-class alternative; Claude
+Code is an optional compatibility engine for existing workspaces.
+
 ## One-Line Install
 
 === "Linux / macOS"
@@ -14,49 +24,102 @@
     irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
     ```
 
-The Linux/macOS installer verifies the GitHub Release checksum, installs the complete personal edition (local Core + Web UI + Bridge + CLI), stores the bootstrap token at `~/.metabot-core/token` with mode `0600`, then walks you through engine authentication and IM credentials. The local console is `http://localhost:9200`.
+The Linux/macOS installer:
 
-To connect the Bridge to an existing external Core instead, run with `METABOT_INSTALL_CORE=0` and provide `METABOT_CORE_URL` / `METABOT_CORE_TOKEN`.
+1. downloads the current public GitHub Release and verifies `SHA256SUMS`;
+2. installs the local Core, token-only Web UI, Bridge, CLI, and bundled Skills;
+3. stores the generated Core token at `~/.metabot-core/token` with mode `0600`;
+4. prompts for a workspace, engine, authentication, and IM channel; and
+5. starts Core and Bridge as separate PM2 applications.
+
+The local personal console is `http://localhost:9200`. The installer does not
+print the raw token into logs. Core data is stored under `~/.metabot-core/` and
+Bridge state under `~/.metabot/` by default.
+
+To install elsewhere:
+
+```bash
+METABOT_HOME=/opt/metabot bash install.sh
+```
+
+The default directory is `~/metabot`.
+
+## Engine Authentication
+
+Run login commands from a standalone terminal.
+
+### Codex CLI (default)
+
+```bash
+npm install -g @openai/codex
+codex login
+```
+
+MetaBot's public adapter currently uses `codex exec --json` and
+`codex exec resume`. It does not require or claim Codex app-server support.
+
+### Kimi Code 0.27+
+
+```bash
+npm install -g @moonshot-ai/kimi-code@latest
+kimi login
+```
+
+MetaBot uses Kimi Code's official loopback Server API, the same frontend
+contract used by Kimi's web UI. Legacy Python `kimi-cli --wire` integrations
+are not supported by this path.
+
+### Claude Code compatibility
+
+Install and run `claude login` only when an existing bot or workspace selects
+`"engine": "claude"`.
 
 ## Update
 
-Already installed? One command downloads the latest public personal-edition package, rebuilds, updates skills, and restarts:
+Package installations update from stable GitHub Release assets:
 
 ```bash
 metabot update
 ```
 
-If `lark-cli` or Feishu/Lark skills were already installed, `metabot update` updates them too and syncs them into the bot workspace.
-
-Developer source checkouts can opt into Git-based updates with `metabot update --git`. Regular bot hosts should use the default package refresh so no Git credentials are required.
-
-## Manual Install
+Source checkouts use Git explicitly:
 
 ```bash
-git clone https://github.com/xvirobotics/metabot.git
-cd metabot && npm install
-cp bots.example.json bots.json   # edit with your bot configs
-cp .env.example .env              # edit global settings
+metabot update --git
+```
+
+The updater preserves `.env`, `bots.json`, user data, logs, workspace
+instructions, and locally modified Skills. Release and source update paths are
+kept separate.
+
+## Existing External Core
+
+To install only the Bridge and point it at an existing Core:
+
+```bash
+METABOT_INSTALL_CORE=0 bash install.sh
+```
+
+Configure `METABOT_CORE_URL` and `METABOT_CORE_TOKEN`. The installer will not
+replace a foreign Core PM2 process or its data.
+
+## Source Development Install
+
+```bash
+git clone https://github.com/xvirobotics/metabot.git ~/metabot
+cd ~/metabot
+npm ci --include=dev
+cp bots.example.json bots.json
+cp .env.example .env
 npm run dev
 ```
 
-## Prerequisites
-
-1. **Node.js 20+** is installed.
-2. **Claude Code CLI is installed and authenticated** — The Agent SDK spawns `claude` as a subprocess; it must be able to run independently.
-    - Install: `npm install -g @anthropic-ai/claude-code`
-    - Authenticate (one of):
-        - **OAuth login (recommended)**: Run `claude login` in a standalone terminal and complete the browser flow.
-        - **API Key**: Set `ANTHROPIC_API_KEY=sk-ant-...` in `.env` or your shell environment.
-    - Verify: Run `claude --version` and `claude "hello"` in a standalone terminal to confirm it works.
-
-    !!! warning
-        You cannot run `claude login` or `claude auth status` from inside a Claude Code session (nested sessions are blocked). Always use a separate terminal.
-
-3. **IM platform configured** — See [Quick Setup](quick-setup.md) or [Feishu App Setup](feishu-app-setup.md).
-
 ## Windows Notes
 
-The PowerShell installer auto-detects `winget`/`choco`/`scoop` for Node.js installation. The `metabot` CLI is installed with a `.cmd` wrapper and requires [Git for Windows](https://git-scm.com) (provides Git Bash).
+The PowerShell installer configures the Bridge and installs a `.cmd` wrapper
+for the `metabot` CLI. It requires Git for Windows. The complete local
+Core/Web UI lifecycle remains provided by the Linux/macOS Release installer
+until Windows reaches packaging parity.
 
-The complete local Core/Web UI lifecycle is currently provided by the signed-checksum Bash Release installer on Linux/macOS. Windows `install.ps1` remains a Bridge installer until its Core lifecycle reaches parity.
+Next: [Quick Setup](quick-setup.md) or the detailed
+[Feishu App Setup](feishu-app-setup.md).

--- a/docs/getting-started/installation.zh.md
+++ b/docs/getting-started/installation.zh.md
@@ -1,6 +1,16 @@
 # 安装
 
-## 一键安装
+## 前置条件
+
+- **Node.js >= 22.19**
+- Git
+- 至少一个引擎和一个聊天渠道的凭证
+- Linux/macOS 才能使用完整的签名校验个人版生命周期
+
+Codex 是默认引擎，Kimi Code 是一级可选引擎；Claude Code 作为现有工作区
+的可选兼容引擎保留。
+
+## 一行安装
 
 === "Linux / macOS"
 
@@ -14,49 +24,98 @@
     irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
     ```
 
-Linux/macOS 安装器会验证 GitHub Release 校验和，安装完整个人版（本地 Core + Web UI + Bridge + CLI），把首次 Token 以 `0600` 权限保存到 `~/.metabot-core/token`，再引导完成引擎认证和 IM 凭证。控制台地址为 `http://localhost:9200`。
+Linux/macOS 安装器会：
 
-如需连接已有外部 Core，请设置 `METABOT_INSTALL_CORE=0`，并提供 `METABOT_CORE_URL` / `METABOT_CORE_TOKEN`。
+1. 下载最新公开 GitHub Release 并验证 `SHA256SUMS`；
+2. 安装本地 Core、仅 Token 登录的 Web UI、Bridge、CLI 和内置 Skills；
+3. 把自动生成的 Core Token 以 `0600` 权限保存到 `~/.metabot-core/token`；
+4. 引导选择工作区、引擎、认证和 IM 渠道；
+5. 将 Core 和 Bridge 作为独立 PM2 应用启动。
+
+个人控制台地址为 `http://localhost:9200`。安装器不会把原始 Token 输出到
+日志。Core 数据默认存放在 `~/.metabot-core/`，Bridge 状态默认存放在
+`~/.metabot/`。
+
+安装到其他目录：
+
+```bash
+METABOT_HOME=/opt/metabot bash install.sh
+```
+
+默认目录为 `~/metabot`。
+
+## 引擎认证
+
+请在独立终端执行登录命令。
+
+### Codex CLI（默认）
+
+```bash
+npm install -g @openai/codex
+codex login
+```
+
+MetaBot 公开版当前使用 `codex exec --json` 和 `codex exec resume`，不要求、
+也不宣称支持 Codex app-server。
+
+### Kimi Code 0.27+
+
+```bash
+npm install -g @moonshot-ai/kimi-code@latest
+kimi login
+```
+
+MetaBot 使用 Kimi Code 官方 loopback Server API，与 Kimi Web UI 使用同一套
+前端协议。该路径不再支持旧 Python `kimi-cli --wire` 集成。
+
+### Claude Code 兼容
+
+只有现有 Bot 或工作区明确选择 `"engine": "claude"` 时，才需要安装并执行
+`claude login`。
 
 ## 更新
 
-已安装？一条命令下载最新公开个人版安装包、构建、更新 skills、重启：
+Package 安装从稳定 GitHub Release 资源更新：
 
 ```bash
 metabot update
 ```
 
-如果本机已经安装过 `lark-cli` 或飞书/Lark skills，`metabot update` 也会自动更新它们并同步到 bot 工作目录。
-
-开发者源码 checkout 可以显式使用 `metabot update --git` 走 Git 更新。普通 bot 主机建议使用默认 package refresh，不再依赖 Git 权限。
-
-## 手动安装
+源码 checkout 显式使用 Git：
 
 ```bash
-git clone https://github.com/xvirobotics/metabot.git
-cd metabot && npm install
-cp bots.example.json bots.json   # 编辑 Bot 配置
-cp .env.example .env              # 编辑全局设置
+metabot update --git
+```
+
+更新器会保留 `.env`、`bots.json`、用户数据、日志、工作区说明和用户修改过的
+Skills。Release 与源码更新路径相互独立。
+
+## 使用已有外部 Core
+
+只安装 Bridge 并连接已有 Core：
+
+```bash
+METABOT_INSTALL_CORE=0 bash install.sh
+```
+
+配置 `METABOT_CORE_URL` 和 `METABOT_CORE_TOKEN`。安装器不会替换其他目录的
+Core PM2 进程或其数据。
+
+## 源码开发安装
+
+```bash
+git clone https://github.com/xvirobotics/metabot.git ~/metabot
+cd ~/metabot
+npm ci --include=dev
+cp bots.example.json bots.json
+cp .env.example .env
 npm run dev
 ```
 
-## 前置条件
-
-1. **Node.js 20+** 已安装。
-2. **Claude Code CLI 已安装并认证** — Agent SDK 以子进程方式启动 `claude`，必须能独立运行。
-    - 安装：`npm install -g @anthropic-ai/claude-code`
-    - 认证（选一种）：
-        - **OAuth 登录（推荐）**：在独立终端运行 `claude login` 完成浏览器认证。
-        - **API Key**：在 `.env` 或环境变量中设置 `ANTHROPIC_API_KEY=sk-ant-...`。
-    - 验证：在独立终端运行 `claude --version` 和 `claude "hello"` 确认正常。
-
-    !!! warning "注意"
-        不能在 Claude Code 会话内运行 `claude login` 或 `claude auth status`（不支持嵌套）。务必使用独立终端。
-
-3. **IM 平台已配置** — 参见[快速配置](quick-setup.md)或[飞书应用配置](feishu-app-setup.md)。
-
 ## Windows 说明
 
-PowerShell 安装器自动检测 `winget`/`choco`/`scoop` 来安装 Node.js。`metabot` CLI 通过 `.cmd` 包装器安装，需要 [Git for Windows](https://git-scm.com)（提供 Git Bash）。
+PowerShell 安装器会配置 Bridge，并为 `metabot` CLI 安装 `.cmd` wrapper；需要
+Git for Windows。完整本地 Core/Web UI 生命周期目前仍由 Linux/macOS Release
+安装器提供，直到 Windows 打包能力达到同等水平。
 
-完整本地 Core/Web UI 生命周期目前由 Linux/macOS 的带校验和 Bash Release 安装器提供；Windows `install.ps1` 在补齐 Core 生命周期前仍只安装 Bridge。
+下一步：[快速配置](quick-setup.md)或详细的[飞书应用配置](feishu-app-setup.md)。

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,44 +1,44 @@
 # MetaBot
 
-**Infrastructure for building a supervised, self-improving agent organization.**
+**Run Codex and Kimi Code from Feishu/Lark, Telegram, WeChat, or the Web.**
 
 [![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/xvirobotics/metabot?style=flat-square)](https://github.com/xvirobotics/metabot)
 
----
+MetaBot is a self-hosted personal agent workspace. It combines a local Core,
+token-only Web UI, IM Bridge, CLI, Memory, Skills, T5T, and Agent Teams without
+requiring corporate SSO or OIDC.
 
-Claude Code and Kimi Code are the most capable AI coding agents — but they're both trapped in your laptop terminal.
+## Engines
 
-MetaBot sets them free. It gives every agent a **Claude Code or Kimi Code brain** (native subscriptions work directly — no API key required), persistent shared memory, the ability to create new agents, and a communication bus. All accessible from Feishu or Telegram on your phone.
+| Engine | Integration | Authentication | Position |
+|---|---|---|---|
+| **Codex CLI** | `codex exec --json` / `codex exec resume` | `codex login` or API profile | Default engine |
+| **Kimi Code 0.27+** | Official local Server API | `kimi login` | First-class alternative with durable Sessions and subagent state |
+| **Claude Code** | Compatibility CLI / SDK path | `claude login` or Anthropic-compatible API | Existing-bot compatibility |
 
-## Dual Engine: Claude Code ✕ Kimi Code
+The public Codex integration currently uses `codex exec`; it does not claim
+Codex app-server or native mid-turn steering. Kimi uses the official local
+Server API shared with Kimi's web frontend.
 
-| | Claude Code (Anthropic) | Kimi Code (Moonshot) |
-|---|---|---|
-| **Subscription login** | ✅ `claude login` OAuth | ✅ `kimi login` OAuth |
-| **API key fallback** | ✅ | ✅ |
-| **Context window** | 200k (1M optional) | 256k |
-| **Autonomous mode** | `bypassPermissions` | `yoloMode` (equivalent) |
+Each bot selects its engine and workspace independently. See
+[Multi-Bot Mode](configuration/multi-bot.md).
 
-Each bot picks its engine in `bots.json`. Frontend bot on Claude, backend bot on Kimi — totally fine. Cross-engine delegation through the Agent Bus is transparent to the caller. See [multi-bot config](configuration/multi-bot.md).
+## Core Capabilities
 
-## Core Components
-
-| Component | Description |
-|-----------|-------------|
-| **Dual Engine Kernel** | Each bot independently selects Claude Code or Kimi Code — full tool stack (Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP) in autonomous mode. |
-| **MetaSkill** | Agent factory. `/metaskill ios app` generates a complete `.claude/` agent team (orchestrator + specialists + code-reviewer). |
-| **MetaMemory** | Embedded SQLite knowledge store with full-text search and Web UI. Agents read/write Markdown documents across sessions. |
-| **IM Bridge** | Chat with any agent from Feishu/Lark or Telegram (including mobile). Streaming cards with color-coded status. |
-| **Web UI** | Browser-based chat at `/web/` with WebSocket streaming, phone call voice mode (VAD), MetaMemory browser, dark/light themes. [Learn more](features/web-ui.md) |
-| **Voice Assistant** | Hands-free voice control via iOS Shortcuts (Jarvis mode) or Web UI phone call mode. Server-side STT + TTS. [Learn more](features/voice-jarvis.md) |
-| **Agent Bus** | REST API on port 9100. Agents talk to each other via `metabot talk`. Create/remove bots at runtime. |
-| **Peers** | Federation system for cross-instance bot discovery and task routing. |
-| **Task Scheduler** | One-time delays and recurring cron jobs. Timezone-aware, persists across restarts. |
-| **CLI Tools** | `metabot` — the single CLI binary for service management, the bridge daemon API, and metabot-core delegation. |
+| Capability | Description |
+|---|---|
+| **IM Bridge** | Feishu/Lark, Telegram, and WeChat with streaming status, files, and exact @Bot routing |
+| **Local Core and Web UI** | Token-authenticated Agents, Chat, Memory, Skills, T5T, Teams, and diagnostics |
+| **Agent Teams and Bus** | Parallel teammates, durable tasks/runs, and cross-agent communication |
+| **MetaMemory** | Searchable knowledge across sessions with optional Feishu Wiki sync |
+| **Engine-native sessions** | Codex resume, durable Kimi Sessions, and Claude compatibility |
+| **Optional extensions** | Scheduling, Peers, voice, MetaSkill, and shared Skills |
 
 ## Quick Install
+
+Requires **Node.js >= 22.19**.
 
 === "Linux / macOS"
 
@@ -52,7 +52,10 @@ Each bot picks its engine in `bots.json`. Frontend bot on Claude, backend bot on
     irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
     ```
 
-The installer walks you through: working directory, **engine choice (Claude / Kimi)**, subscription login, IM credentials, and auto-start with PM2.
+The Linux/macOS installer verifies the Release checksum, installs the complete
+personal edition, stores the Core token at `~/.metabot-core/token` with mode
+`0600`, and configures the selected engine and chat channel. Open the local
+console at `http://localhost:9200`.
 
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
 [View on GitHub](https://github.com/xvirobotics/metabot){ .md-button }

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,44 +1,42 @@
 # MetaBot
 
-**构建受监督的、自我进化的 Agent 组织的基础设施。**
+**从飞书/Lark、Telegram、微信或 Web 使用 Codex 和 Kimi Code。**
 
 [![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/xvirobotics/metabot?style=flat-square)](https://github.com/xvirobotics/metabot)
 
----
+MetaBot 是可自托管的个人 Agent 工作台，把本地 Core、仅 Token 登录的 Web UI、
+IM Bridge、CLI、Memory、Skills、T5T 和 Agent Teams 组合在一起，不依赖企业
+SSO 或 OIDC。
 
-Claude Code 和 Kimi Code 是最强的 AI 编码 Agent —— 但它们都被锁在笔记本终端里。
+## 引擎
 
-MetaBot 把它们都解放出来。给每个 Agent 一个 **Claude Code 或 Kimi Code 大脑**（订阅直连，无需 API Key）、持久化的共享记忆、创建新 Agent 的能力、以及通信总线。全部可以从飞书或 Telegram 手机端控制。
+| 引擎 | 接入 | 认证 | 定位 |
+|---|---|---|---|
+| **Codex CLI** | `codex exec --json` / `codex exec resume` | `codex login` 或 API profile | 默认引擎 |
+| **Kimi Code 0.27+** | 官方本地 Server API | `kimi login` | 支持持久 Session 和子 Agent 状态的一级可选引擎 |
+| **Claude Code** | 兼容 CLI / SDK 路径 | `claude login` 或 Anthropic 兼容 API | 现有 Bot 兼容 |
 
-## 双引擎：Claude Code ✕ Kimi Code
+公开版 Codex 当前使用 `codex exec`，暂不宣称 Codex app-server 或原生执行中
+steering。Kimi 使用与 Kimi Web 前端同源的官方本地 Server API。
 
-| | Claude Code（Anthropic） | Kimi Code（Moonshot） |
-|---|---|---|
-| **订阅直连** | ✅ `claude login` OAuth | ✅ `kimi login` OAuth |
-| **API Key 兜底** | ✅ | ✅ |
-| **上下文窗口** | 200k（可选 1M） | 256k |
-| **自主运行模式** | `bypassPermissions` | `yoloMode`（等价） |
+每个 Bot 可以独立选择引擎和工作区。详见[多 Bot 模式](configuration/multi-bot.md)。
 
-每个 Bot 在 `bots.json` 独立选引擎，前后端用不同引擎完全可以。Agent 总线跨引擎通信对调用方透明。详见 [多 Bot 配置](configuration/multi-bot.zh.md)。
+## 核心能力
 
-## 核心组件
-
-| 组件 | 说明 |
-|------|------|
-| **双引擎内核** | 每个 Bot 独立选 Claude Code 或 Kimi Code — 完整工具链（Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP），自主模式运行。 |
-| **MetaSkill** | Agent 工厂。`/metaskill ios app` 调研最佳实践后生成完整的 `.claude/` Agent 团队。 |
-| **MetaMemory** | 内嵌 SQLite 知识库，全文搜索，Web UI。Agent 跨会话读写 Markdown 文档。 |
-| **IM Bridge** | 飞书或 Telegram（含手机端）与任意 Agent 对话。带颜色状态的流式卡片。 |
-| **Web UI** | 浏览器端聊天 `/web/`，WebSocket 流式输出、电话语音模式（VAD）、MetaMemory 浏览器、明暗主题。[了解更多](features/web-ui.md) |
-| **语音助手** | 通过 iOS 快捷指令（Jarvis 模式）或 Web UI 电话模式免手语音控制。服务端 STT + TTS。[了解更多](features/voice-jarvis.md) |
-| **Agent 总线** | 9100 端口 REST API。Agent 通过 `metabot talk` 互相对话。运行时创建/删除 Bot。 |
-| **Peers 联邦** | 跨实例 Bot 发现和任务路由。 |
-| **定时任务调度器** | 一次性延迟和周期性 cron 任务。支持时区，跨重启持久化。 |
-| **CLI 工具** | `metabot` —— 唯一的 CLI 入口，覆盖服务管理、bridge 守护进程 API 和 metabot-core 转发。 |
+| 能力 | 说明 |
+|---|---|
+| **IM Bridge** | 飞书/Lark、Telegram 和微信，支持流式状态、文件和精确 @Bot 路由 |
+| **本地 Core 与 Web UI** | Token 鉴权的 Agents、Chat、Memory、Skills、T5T、Teams 和诊断 |
+| **Agent Teams 与 Bus** | 并行队友、持久任务/运行和跨 Agent 通信 |
+| **MetaMemory** | 跨会话检索知识，并可同步到飞书知识库 |
+| **引擎原生会话** | Codex 续接、Kimi 持久 Session 和 Claude 兼容 |
+| **可选扩展** | 调度、Peers、语音、MetaSkill 和共享 Skills |
 
 ## 快速安装
+
+需要 **Node.js >= 22.19**。
 
 === "Linux / macOS"
 
@@ -52,7 +50,9 @@ MetaBot 把它们都解放出来。给每个 Agent 一个 **Claude Code 或 Kimi
     irm https://raw.githubusercontent.com/xvirobotics/metabot/main/install.ps1 | iex
     ```
 
-安装器引导：工作目录 → **引擎选择（Claude / Kimi）** → 订阅登录 → IM 凭证 → PM2 自动启动。
+Linux/macOS 安装器会验证 Release 校验和、安装完整个人版、把 Core Token 以
+`0600` 权限保存到 `~/.metabot-core/token`，并配置选定的引擎和聊天渠道。
+本地控制台地址为 `http://localhost:9200`。
 
 [开始使用](getting-started/installation.md){ .md-button .md-button--primary }
-[GitHub 仓库](https://github.com/xvirobotics/metabot){ .md-button }
+[查看 GitHub](https://github.com/xvirobotics/metabot){ .md-button }

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MetaBot — Infrastructure for the Agent-Native Organization</title>
-    <meta name="description" content="MetaBot: Infrastructure for building a supervised, self-improving agent organization. Run Claude Code or Kimi Code (both native subscriptions supported) from Feishu & Telegram with shared memory, agent factory, and communication bus.">
+    <meta name="description" content="MetaBot Personal Edition: run Codex or Kimi Code from Feishu/Lark, Telegram, WeChat, and the Web. Codex-first, token-only, self-hosted, with Claude Code compatibility.">
     <meta property="og:title" content="MetaBot — Infrastructure for the Agent-Native Organization">
-    <meta property="og:description" content="Give every AI agent a Claude Code or Kimi Code brain (native subscriptions, no API key required), shared memory, and a communication bus. Accessible from your phone.">
+    <meta property="og:description" content="A Codex-first, self-hosted personal agent workspace with Kimi Code 0.27+ Server API support, Claude compatibility, shared memory, and Agent Teams.">
     <meta property="og:image" content="https://raw.githubusercontent.com/xvirobotics/metabot/main/resources/metabot.png">
     <meta property="og:url" content="https://xvirobotics.github.io/metabot">
     <meta name="twitter:card" content="summary_large_image">
@@ -432,7 +432,7 @@
         </div>
         <h1>Infrastructure for the Agent-Native Organization</h1>
         <p class="hero-sub">
-            Give every AI agent a Claude Code or Kimi Code brain &mdash; both native subscriptions work directly, no API key. Plus persistent shared memory and a communication bus. Supervised by humans on Feishu or Telegram.
+            Run Codex or Kimi Code from Feishu/Lark, Telegram, WeChat, or the Web. Codex is the default engine; Kimi Code 0.27+ uses its official local Server API, and Claude Code remains available for compatibility.
         </p>
         <div class="cta-group">
             <a href="#install" class="cta-primary">Get Started</a>
@@ -479,8 +479,8 @@
             <div class="comp-card">
                 <div class="icon">SDK</div>
                 <div>
-                    <h4>Dual Engine Kernel</h4>
-                    <p>Each bot picks Claude Code or Kimi Code in <code>bots.json</code>. Full tool stack either way &mdash; Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP. Both native subscriptions (<code>claude login</code> / <code>kimi login</code>) work directly. Autonomous mode (<code>bypassPermissions</code> / <code>yoloMode</code>).</p>
+                    <h4>Codex-First Engine Router</h4>
+                    <p>Each bot picks Codex, Kimi Code, or Claude compatibility in <code>bots.json</code>. Codex currently runs through <code>codex exec --json</code>; Kimi Code 0.27+ uses the official local Server API for durable Sessions, questions, tools, and subagents. Your own subscription login stays local.</p>
                 </div>
             </div>
             <div class="comp-card">
@@ -542,7 +542,7 @@
             </div>
         </div>
         <p style="margin-top: 24px; font-size: 0.85rem; color: var(--text-dim);">
-            Prerequisites: Node.js 20+, plus one of: <a href="https://github.com/anthropics/claude-code">Claude Code CLI</a> (<code>claude login</code>) or <a href="https://platform.moonshot.ai">Kimi CLI</a> (<code>uv tool install kimi-cli && kimi login</code>). The installer asks which engine(s) to set up.
+            Prerequisites: Node.js &gt;= 22.19, plus Codex (<code>npm install -g @openai/codex &amp;&amp; codex login</code>) or Kimi Code 0.27+ (<code>npm install -g @moonshot-ai/kimi-code@latest &amp;&amp; kimi login</code>). Claude Code is an optional compatibility engine. The installer asks which engine and channel to set up.
         </p>
     </section>
 
@@ -554,7 +554,7 @@
             <div class="usecase-item">
                 <span class="emoji">&#x1f4f1;</span>
                 <h4>Solo AI Developer</h4>
-                <p>Full Claude Code or Kimi Code from your phone, bound to your project. Your existing subscription works directly. Code on the go via Feishu or Telegram.</p>
+                <p>Codex or Kimi Code from your phone, bound to your project and authenticated with your own subscription. Code on the go via Feishu/Lark, Telegram, WeChat, or the Web; keep Claude Code for existing workspaces.</p>
             </div>
             <div class="usecase-item">
                 <span class="emoji">&#x1f465;</span>

--- a/install.ps1
+++ b/install.ps1
@@ -128,6 +128,55 @@ function Test-Command {
     return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Test-VersionAtLeast {
+    param(
+        [string]$Version,
+        [string]$Minimum
+    )
+    try {
+        return ([version]($Version.TrimStart('v')) -ge [version]($Minimum.TrimStart('v')))
+    } catch {
+        return $false
+    }
+}
+
+function Get-KimiCodeVersion {
+    if (-not (Test-Command "kimi")) { return $null }
+    try {
+        $versionOutput = ((& kimi --version 2>$null) | Select-Object -First 1).ToString()
+        if ($versionOutput -match '([0-9]+\.[0-9]+\.[0-9]+)') { return $Matches[1] }
+    } catch {}
+    return $null
+}
+
+function Install-KimiCode {
+    $installedVersion = Get-KimiCodeVersion
+    if ($installedVersion -and (Test-VersionAtLeast $installedVersion "0.27.0")) {
+        Write-Success "Kimi Code found: $((Get-Command kimi).Source) (v$installedVersion)"
+        return $true
+    }
+    if (Test-Command "kimi") {
+        Write-Warn "The installed Kimi CLI is older than 0.27.0 or has an unreadable version; upgrading."
+    }
+
+    Write-Info "Installing Kimi Code 0.27+ from npm..."
+    try {
+        & npm install -g "@moonshot-ai/kimi-code@latest" | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "npm exited with code $LASTEXITCODE" }
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    } catch {
+        Write-Warn "Kimi Code install failed: $($_.Exception.Message)"
+    }
+
+    $installedVersion = Get-KimiCodeVersion
+    if ($installedVersion -and (Test-VersionAtLeast $installedVersion "0.27.0")) {
+        Write-Success "Kimi Code installed: $((Get-Command kimi).Source) (v$installedVersion)"
+        return $true
+    }
+    Write-Warn "Kimi Code 0.27+ verification failed. Install manually with 'npm install -g @moonshot-ai/kimi-code@latest'."
+    return $false
+}
+
 # ============================================================================
 # Phase 0: Banner + environment detection
 # ============================================================================
@@ -202,15 +251,15 @@ if (Test-Command "git") {
     $Missing = 1
 }
 
-# Node.js
+# Node.js (Kimi Code 0.27+ and MetaBot require 22.19.0 or newer.)
+$MinimumNodeVersion = "22.19.0"
 $NeedNode = $false
 if (Test-Command "node") {
     $NodeVer = (node --version) -replace '^v', ''
-    $NodeMajor = [int]($NodeVer.Split('.')[0])
-    if ($NodeMajor -ge 20) {
+    if (Test-VersionAtLeast $NodeVer $MinimumNodeVersion) {
         Write-Success "Node.js found: v$NodeVer"
     } else {
-        Write-Warn "Node.js v$NodeVer found, but v20+ is required."
+        Write-Warn "Node.js v$NodeVer found, but v$MinimumNodeVersion+ is required."
         $NeedNode = $true
     }
 } else {
@@ -229,7 +278,7 @@ if ($NeedNode) {
                 winget install --id OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements
                 # Refresh PATH
                 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-                if (Test-Command "node") { $NodeInstalled = $true; Write-Success "Node.js installed via winget" }
+                if ((Test-Command "node") -and (Test-VersionAtLeast ((node --version) -replace '^v', '') $MinimumNodeVersion)) { $NodeInstalled = $true; Write-Success "Node.js installed via winget" }
             } catch {
                 Write-Warn "winget install failed, trying alternatives..."
             }
@@ -241,7 +290,7 @@ if ($NeedNode) {
             try {
                 choco install nodejs-lts -y
                 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-                if (Test-Command "node") { $NodeInstalled = $true; Write-Success "Node.js installed via Chocolatey" }
+                if ((Test-Command "node") -and (Test-VersionAtLeast ((node --version) -replace '^v', '') $MinimumNodeVersion)) { $NodeInstalled = $true; Write-Success "Node.js installed via Chocolatey" }
             } catch {
                 Write-Warn "Chocolatey install failed, trying alternatives..."
             }
@@ -252,18 +301,18 @@ if ($NeedNode) {
             Write-Info "Installing Node.js via scoop..."
             try {
                 scoop install nodejs-lts
-                if (Test-Command "node") { $NodeInstalled = $true; Write-Success "Node.js installed via scoop" }
+                if ((Test-Command "node") -and (Test-VersionAtLeast ((node --version) -replace '^v', '') $MinimumNodeVersion)) { $NodeInstalled = $true; Write-Success "Node.js installed via scoop" }
             } catch {
                 Write-Warn "scoop install failed."
             }
         }
 
         if (-not $NodeInstalled) {
-            Write-Err "Automatic install failed. Please install Node.js 20+ manually from https://nodejs.org/"
+            Write-Err "Automatic install failed. Please install Node.js $MinimumNodeVersion+ manually from https://nodejs.org/"
             $Missing = 1
         }
     } else {
-        Write-Err "Node.js 20+ is required. Install manually and re-run."
+        Write-Err "Node.js $MinimumNodeVersion+ is required. Install manually and re-run."
         exit 1
     }
 }
@@ -374,20 +423,57 @@ if (-not $SkipConfig) {
     Write-Host ""
     Write-Host "Working Directory:" -ForegroundColor White
     $DefaultWorkDir = Join-Path $env:USERPROFILE "metabot-workspace"
-    $WorkDir = Read-Input "Project directory for Claude to work in" $DefaultWorkDir
+    $WorkDir = Read-Input "Project directory for the Agent to work in" $DefaultWorkDir
     if (-not (Test-Path $WorkDir)) { New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null }
     Write-Success "Working directory: $WorkDir"
 
-    # ------ 4b: Claude AI authentication ------
+    # ------ 4b: Engine selection + authentication ------
     Write-Host ""
-    Write-Host "Claude AI Authentication:" -ForegroundColor White
-    Write-Host "  1) Claude Code Subscription (OAuth - run 'claude login' after install)"
-    Write-Host "  2) Anthropic API Key (sk-ant-...)"
-    Write-Host "  3) Third-party provider (Kimi/Moonshot, DeepSeek, GLM, etc.)"
-    $AuthChoice = Read-Choice "1"
+    Write-Host "Agent Engine:" -ForegroundColor White
+    Write-Host "  1) Codex CLI (OpenAI)"
+    Write-Host "  2) Kimi Code (Moonshot AI - default model kimi-code/k3)"
+    Write-Host "  3) Claude Code compatibility (Anthropic)"
+    $EngineChoice = Read-Choice "1"
 
+    $BotEngine = "codex"
     $ClaudeAuthEnvLines = ""
-    $ClaudeAuthMethod = "subscription"
+    $ClaudeAuthMethod = "codex"
+
+    if ($EngineChoice -eq "2") {
+        $BotEngine = "kimi"
+        $ClaudeAuthMethod = "kimi"
+        $AuthChoice = "kimi"
+        if (-not (Install-KimiCode)) {
+            Write-Warn "Continuing with Kimi configuration; install Kimi Code 0.27+ before starting MetaBot."
+        }
+        Write-Info "Run 'kimi login' before starting MetaBot. MetaBot defaults Kimi sessions to kimi-code/k3."
+    } elseif ($EngineChoice -eq "1") {
+        $BotEngine = "codex"
+        $ClaudeAuthMethod = "codex"
+        $AuthChoice = "codex"
+        if (Test-Command "codex") {
+            Write-Success "Codex CLI found: $((Get-Command codex).Source)"
+        } else {
+            Write-Info "Installing Codex CLI..."
+            try {
+                & npm install -g "@openai/codex" | Out-Host
+                if ($LASTEXITCODE -ne 0) { throw "npm exited with code $LASTEXITCODE" }
+            } catch {
+                Write-Warn "Codex install failed: $($_.Exception.Message)"
+            }
+            if (-not (Test-Command "codex")) {
+                Write-Warn "Install Codex manually with 'npm install -g @openai/codex', then run 'codex login'."
+            }
+        }
+        Write-Info "Run 'codex login' before starting MetaBot."
+    } else {
+        Write-Host ""
+        Write-Host "Claude AI Authentication:" -ForegroundColor White
+        Write-Host "  1) Claude Code Subscription (OAuth - run 'claude login' after install)"
+        Write-Host "  2) Anthropic API Key (sk-ant-...)"
+        Write-Host "  3) Third-party provider (Kimi/Moonshot, DeepSeek, GLM, etc.)"
+        $AuthChoice = Read-Choice "1"
+    }
 
     switch ($AuthChoice) {
         "1" {
@@ -523,11 +609,15 @@ BOTS_CONFIG=./bots.json
 API_PORT=$ApiPort
 API_SECRET=$ApiSecret
 
-# Claude AI Authentication
+# Agent Engine Authentication
 "@
 
     if ($ClaudeAuthMethod -eq "subscription") {
         $envContent += "`n# Using Claude Code Subscription (OAuth). Run 'claude login' to authenticate."
+    } elseif ($ClaudeAuthMethod -eq "kimi") {
+        $envContent += "`n# Using Kimi Code 0.27+ (default model: kimi-code/k3). Run 'kimi login' to authenticate."
+    } elseif ($ClaudeAuthMethod -eq "codex") {
+        $envContent += "`n# Using Codex CLI. Run 'codex login' to authenticate."
     } elseif ($ClaudeAuthEnvLines) {
         $envContent += "`n$ClaudeAuthEnvLines"
     }
@@ -560,14 +650,14 @@ META_MEMORY_URL=$MemoryServerUrl
     $TelegramBotsJson = "[]"
 
     if ($SetupFeishu) {
-        $FeishuBotsJson = node -e "console.log(JSON.stringify([{name:process.argv[1],feishuAppId:process.argv[2],feishuAppSecret:process.argv[3],defaultWorkingDirectory:process.argv[4]}],null,2))" $BotName $FeishuAppId $FeishuAppSecret $WorkDir
+        $FeishuBotsJson = node -e "const e=process.argv[5];const b={name:process.argv[1],engine:e,feishuAppId:process.argv[2],feishuAppSecret:process.argv[3],defaultWorkingDirectory:process.argv[4]};if(e==='kimi')b.kimi={model:'kimi-code/k3',thinking:true,permissionMode:'auto'};if(e==='codex')b.codex={approvalPolicy:'never',sandbox:'workspace-write'};console.log(JSON.stringify([b],null,2))" $BotName $FeishuAppId $FeishuAppSecret $WorkDir $BotEngine
         $FeishuBotsJson = $FeishuBotsJson -join "`n"
     }
 
     if ($SetupTelegram) {
         $TgName = $BotName
         if ($SetupFeishu) { $TgName = "$BotName-telegram" }
-        $TelegramBotsJson = node -e "console.log(JSON.stringify([{name:process.argv[1],telegramBotToken:process.argv[2],defaultWorkingDirectory:process.argv[3]}],null,2))" $TgName $TelegramBotToken $WorkDir
+        $TelegramBotsJson = node -e "const e=process.argv[4];const b={name:process.argv[1],engine:e,telegramBotToken:process.argv[2],defaultWorkingDirectory:process.argv[3]};if(e==='kimi')b.kimi={model:'kimi-code/k3',thinking:true,permissionMode:'auto'};if(e==='codex')b.codex={approvalPolicy:'never',sandbox:'workspace-write'};console.log(JSON.stringify([b],null,2))" $TgName $TelegramBotToken $WorkDir $BotEngine
         $TelegramBotsJson = $TelegramBotsJson -join "`n"
     }
 
@@ -582,55 +672,38 @@ META_MEMORY_URL=$MemoryServerUrl
 Write-Step "Phase 6: Installing skills and setting up workspace"
 
 $SkillsDir = Join-Path $env:USERPROFILE ".claude\skills"
-New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
-
-# Sanity check: the bundled skill tree must exist in the checked-out repo.
-# If it's missing, the user's checkout is stale (predates the skill bundling
-# commits) — fail with a clear message instead of cryptic Copy-Item errors.
-$SkillSentinel = Join-Path $MetabotHome "src\skills\metabot\SKILL.md"
-if (-not (Test-Path $SkillSentinel)) {
-    Write-Err "Bundled skill source not found at: $SkillSentinel"
-    Write-Err "Your $MetabotHome checkout appears to be stale or incomplete."
-    Write-Err "Try: cd $MetabotHome; git fetch origin; git reset --hard origin/main"
-    Write-Err "(WARNING: 'git reset --hard' discards uncommitted local changes.)"
-    exit 1
+if ($env:CODEX_HOME) {
+    $CodexHome = $env:CODEX_HOME
+} else {
+    $CodexHome = Join-Path $env:USERPROFILE ".codex"
+}
+$CodexSkillsDir = Join-Path $CodexHome "skills"
+$AgentsSkillsDir = Join-Path $env:USERPROFILE ".agents\skills"
+$GlobalSkillRoots = @($SkillsDir, $CodexSkillsDir, $AgentsSkillsDir)
+$MetaBotSkillSources = [ordered]@{
+    "metabot" = (Join-Path $MetabotHome "packages\skills\metabot")
+    "metabot-team" = (Join-Path $MetabotHome "packages\skills\metabot-team")
+    "voice" = (Join-Path $MetabotHome "src\skills\voice")
 }
 
-# Clean up legacy metaskill skill if present — no longer installed by default.
-# Users who still want the agent-team generator can copy it back from
-# $MetabotHome\src\skills\metaskill\ (the source files remain bundled in the repo).
-$LegacyMetaskillDir = Join-Path $SkillsDir "metaskill"
-if (Test-Path $LegacyMetaskillDir) {
-    Remove-Item $LegacyMetaskillDir -Recurse -Force
-    Write-Info "Removed legacy metaskill skill from $SkillsDir (now opt-in -- see src\skills\metaskill\)"
+# Install complete MetaBot-owned bundles for Claude, Codex, and Kimi Code's
+# shared Agent Skills location. Existing unrelated user skills are untouched.
+foreach ($skillName in $MetaBotSkillSources.Keys) {
+    $skillSource = $MetaBotSkillSources[$skillName]
+    if (-not (Test-Path (Join-Path $skillSource "SKILL.md"))) {
+        Write-Err "Bundled $skillName skill source is missing or incomplete: $skillSource"
+        exit 1
+    }
 }
-
-# Install metamemory skill
-Write-Info "Installing metamemory skill..."
-New-Item -ItemType Directory -Path (Join-Path $SkillsDir "metamemory") -Force | Out-Null
-Copy-Item (Join-Path $MetabotHome "src\memory\skill\SKILL.md") (Join-Path $SkillsDir "metamemory\SKILL.md") -Force
-# Clean up old skill location if it exists
-$oldSkillDir = Join-Path $env:USERPROFILE ".claude\skills\memory"
-if (Test-Path $oldSkillDir) { Remove-Item $oldSkillDir -Recurse -Force }
-Write-Success "metamemory skill installed -> $(Join-Path $SkillsDir 'metamemory')"
-
-# Install metabot skill
-Write-Info "Installing metabot skill..."
-New-Item -ItemType Directory -Path (Join-Path $SkillsDir "metabot") -Force | Out-Null
-Copy-Item (Join-Path $MetabotHome "src\skills\metabot\SKILL.md") (Join-Path $SkillsDir "metabot\SKILL.md") -Force
-Write-Success "metabot skill installed -> $(Join-Path $SkillsDir 'metabot')"
-
-# Install voice skill
-Write-Info "Installing voice skill..."
-New-Item -ItemType Directory -Path (Join-Path $SkillsDir "voice") -Force | Out-Null
-Copy-Item (Join-Path $MetabotHome "src\skills\voice\SKILL.md") (Join-Path $SkillsDir "voice\SKILL.md") -Force
-Write-Success "voice skill installed -> $(Join-Path $SkillsDir 'voice')"
-
-# Install skill-hub skill
-Write-Info "Installing skill-hub skill..."
-New-Item -ItemType Directory -Path (Join-Path $SkillsDir "skill-hub") -Force | Out-Null
-Copy-Item (Join-Path $MetabotHome "src\skills\skill-hub\SKILL.md") (Join-Path $SkillsDir "skill-hub\SKILL.md") -Force
-Write-Success "skill-hub skill installed -> $(Join-Path $SkillsDir 'skill-hub')"
+foreach ($skillRoot in $GlobalSkillRoots) {
+    New-Item -ItemType Directory -Path $skillRoot -Force | Out-Null
+    foreach ($skillName in $MetaBotSkillSources.Keys) {
+        $skillDestination = Join-Path $skillRoot $skillName
+        New-Item -ItemType Directory -Path $skillDestination -Force | Out-Null
+        Get-ChildItem -LiteralPath ($MetaBotSkillSources[$skillName]) -Force | Copy-Item -Destination $skillDestination -Recurse -Force
+        Write-Success "$skillName installed -> $skillDestination"
+    }
+}
 
 # Install feishu-doc skill (only when Feishu is configured)
 $HasFeishu = $false
@@ -667,29 +740,46 @@ if (-not $SkipConfig) {
 # Deploy skills + CLAUDE.md to bot working directory
 if ($DeployWorkDir) {
     $SkillsDest = Join-Path $DeployWorkDir ".claude\skills"
+    $CodexSkillsDest = Join-Path $DeployWorkDir ".codex\skills"
+    $AgentsSkillsDest = Join-Path $DeployWorkDir ".agents\skills"
+    $WorkspaceSkillRoots = @($SkillsDest, $CodexSkillsDest, $AgentsSkillsDest)
 
     # metaskill (agent-team generator) and metaschedule (persistent server-side
     # scheduler) are no longer deployed by default -- copy them from
     # $MetabotHome\src\skills\ if needed. CC native CronCreate / /loop already
     # cover ad-hoc, session-scoped scheduling.
-    $deploySkills = @("metamemory", "metabot", "voice", "skill-hub")
+    $deploySkills = @("metabot", "metabot-team", "voice")
     if ($HasFeishu) { $deploySkills += "feishu-doc" }
 
     foreach ($skill in $deploySkills) {
         $skillSrc = Join-Path $SkillsDir $skill
         if (Test-Path $skillSrc) {
-            $skillDst = Join-Path $SkillsDest $skill
-            New-Item -ItemType Directory -Path $skillDst -Force | Out-Null
-            Copy-Item "$skillSrc\*" $skillDst -Recurse -Force
-            Write-Success "Deployed $skill -> $skillDst"
+            foreach ($workspaceSkillRoot in $WorkspaceSkillRoots) {
+                $skillDst = Join-Path $workspaceSkillRoot $skill
+                New-Item -ItemType Directory -Path $skillDst -Force | Out-Null
+                Get-ChildItem $skillSrc -Force | Copy-Item -Destination $skillDst -Recurse -Force
+                Write-Success "Deployed $skill -> $skillDst"
+            }
         }
     }
 
     # Deploy CLAUDE.md to working directory
     $workspaceClaude = Join-Path $MetabotHome "src\workspace\CLAUDE.md"
     if (Test-Path $workspaceClaude) {
-        Copy-Item $workspaceClaude (Join-Path $DeployWorkDir "CLAUDE.md") -Force
-        Write-Success "Deployed CLAUDE.md -> $(Join-Path $DeployWorkDir 'CLAUDE.md')"
+        $deployClaude = Join-Path $DeployWorkDir "CLAUDE.md"
+        if (Test-Path $deployClaude) {
+            Write-Info "Preserved existing CLAUDE.md at $deployClaude"
+        } else {
+            Copy-Item $workspaceClaude $deployClaude -Force
+            Write-Success "Deployed CLAUDE.md -> $deployClaude"
+        }
+        $workspaceAgents = Join-Path $DeployWorkDir "AGENTS.md"
+        if (-not (Test-Path $workspaceAgents)) {
+            Copy-Item $deployClaude $workspaceAgents -Force
+            Write-Success "Deployed AGENTS.md -> $workspaceAgents (Kimi Code/Codex)"
+        } else {
+            Write-Info "Preserved existing AGENTS.md at $workspaceAgents"
+        }
     }
 } else {
     Write-Warn "Could not determine working directory, skipping workspace deployment"
@@ -848,6 +938,7 @@ if (-not $SkipConfig) {
     Write-Host "  API:            " -ForegroundColor White -NoNewline; Write-Host "http://localhost:$ApiPort"
     $secretPreview = $ApiSecret.Substring(0, 8) + "..." + $ApiSecret.Substring($ApiSecret.Length - 4)
     Write-Host "  API Secret:     " -ForegroundColor White -NoNewline; Write-Host $secretPreview
+    Write-Host "  Engine:         " -ForegroundColor White -NoNewline; Write-Host $BotEngine
     Write-Host "  Auth Method:    " -ForegroundColor White -NoNewline; Write-Host $ClaudeAuthMethod
     if ($ClaudeAuthMethod -eq "third_party") {
         Write-Host "  Provider:       " -ForegroundColor White -NoNewline; Write-Host $ProviderName
@@ -871,6 +962,14 @@ if (-not $SkipConfig) {
     $StepNum = 1
     if ($ClaudeAuthMethod -eq "subscription") {
         Write-Host "    $StepNum. Run 'claude login' in a separate terminal"
+        $StepNum++
+    }
+    if ($ClaudeAuthMethod -eq "kimi") {
+        Write-Host "    $StepNum. Run 'kimi login' (Kimi Code 0.27+, default model kimi-code/k3)"
+        $StepNum++
+    }
+    if ($ClaudeAuthMethod -eq "codex") {
+        Write-Host "    $StepNum. Run 'codex login' in a separate terminal"
         $StepNum++
     }
     if ($SetupFeishu) {

--- a/install.sh
+++ b/install.sh
@@ -244,6 +244,26 @@ check_command() {
 MISSING=0
 check_command git "Git" "https://git-scm.com/downloads" || MISSING=1
 
+version_at_least() {
+  local current="${1#v}"
+  local required="${2#v}"
+  local current_major current_minor current_patch
+  local required_major required_minor required_patch
+
+  current="$(printf '%s' "$current" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')"
+  required="$(printf '%s' "$required" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')"
+  [[ "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+  [[ "$required" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+
+  IFS=. read -r current_major current_minor current_patch <<< "$current"
+  IFS=. read -r required_major required_minor required_patch <<< "$required"
+  (( current_major > required_major )) ||
+    (( current_major == required_major && current_minor > required_minor )) ||
+    (( current_major == required_major && current_minor == required_minor && current_patch >= required_patch ))
+}
+
+MIN_NODE_VERSION="22.19.0"
+
 install_node() {
   info "Installing Node.js 22.x via NodeSource..."
   if [[ "$OS" == "Linux" ]]; then
@@ -276,7 +296,7 @@ install_node() {
     fi
   fi
   # Verify
-  if command -v node &>/dev/null; then
+  if command -v node &>/dev/null && version_at_least "$(node --version)" "$MIN_NODE_VERSION"; then
     success "Node.js installed: $(node --version)"
     return 0
   fi
@@ -286,11 +306,10 @@ install_node() {
 NEED_NODE=false
 if command -v node &>/dev/null; then
   NODE_VER="$(node --version | sed 's/v//')"
-  NODE_MAJOR="$(echo "$NODE_VER" | cut -d. -f1)"
-  if [[ "$NODE_MAJOR" -ge 20 ]]; then
+  if version_at_least "$NODE_VER" "$MIN_NODE_VERSION"; then
     success "Node.js found: v${NODE_VER}"
   else
-    warn "Node.js v${NODE_VER} found, but v20+ is required."
+    warn "Node.js v${NODE_VER} found, but v${MIN_NODE_VERSION}+ is required."
     NEED_NODE=true
   fi
 else
@@ -303,12 +322,12 @@ if [[ "$NEED_NODE" == "true" ]]; then
     if install_node; then
       success "Node.js ready"
     else
-      error "Automatic install failed. Please install Node.js 20+ manually:"
+      error "Automatic install failed. Please install Node.js ${MIN_NODE_VERSION}+ manually:"
       echo "  https://nodejs.org/ or use nvm/fnm"
       MISSING=1
     fi
   else
-    error "Node.js 20+ is required. Install manually and re-run."
+    error "Node.js ${MIN_NODE_VERSION}+ is required. Install manually and re-run."
     exit 1
   fi
 fi
@@ -515,33 +534,40 @@ else
   fi
 fi
 
-# Install uv + kimi-cli helper. Used by the Kimi engine path below.
+# Install the current Kimi Code CLI. MetaBot's Kimi adapter requires the 0.27+
+# local Server API; the retired Python kimi-cli `--wire` surface is incompatible.
+kimi_code_version() {
+  local output
+  output="$(kimi --version 2>/dev/null | head -1 || true)"
+  printf '%s' "$output" | sed -nE 's/^[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p'
+}
+
 install_kimi_cli() {
   if command -v kimi &>/dev/null; then
-    success "Kimi CLI found: $(command -v kimi)"
-    return 0
-  fi
-  # Need uv first (kimi-cli is a Python tool distributed via uv)
-  if ! command -v uv &>/dev/null; then
-    info "Installing uv (required by kimi-cli)..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true
-    # uv installs to ~/.local/bin — make sure it's on PATH for this script
-    export PATH="$HOME/.local/bin:$PATH"
-    if ! command -v uv &>/dev/null; then
-      warn "uv install failed. Install manually from https://astral.sh/uv and re-run."
-      return 1
+    local installed_version
+    installed_version="$(kimi_code_version)"
+    if [[ -n "$installed_version" ]] && version_at_least "$installed_version" "0.27.0"; then
+      success "Kimi Code found: $(command -v kimi) (v${installed_version})"
+      return 0
     fi
-    success "uv installed: $(uv --version)"
+    warn "Kimi CLI at $(command -v kimi) is older than 0.27.0 or has an unreadable version; upgrading."
   fi
-  info "Installing kimi-cli via uv..."
-  if uv tool install kimi-cli 2>&1 | tail -3; then
+
+  info "Installing Kimi Code 0.27+ from npm..."
+  mkdir -p "$HOME/.local"
+  if npm install -g --prefix "$HOME/.local" @moonshot-ai/kimi-code@latest 2>&1 | tail -3; then
     export PATH="$HOME/.local/bin:$PATH"
+    hash -r
+    local installed_version=""
     if command -v kimi &>/dev/null; then
-      success "Kimi CLI installed: $(command -v kimi)"
+      installed_version="$(kimi_code_version)"
+    fi
+    if [[ -n "$installed_version" ]] && version_at_least "$installed_version" "0.27.0"; then
+      success "Kimi Code installed: $(command -v kimi) (v${installed_version})"
       return 0
     fi
   fi
-  warn "Kimi CLI install failed. Install manually: uv tool install kimi-cli"
+  warn "Kimi Code 0.27+ install verification failed. Install manually: npm install -g @moonshot-ai/kimi-code@latest"
   return 1
 }
 
@@ -684,32 +710,32 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
   # ------ 4a: Working directory ------
   echo ""
   echo -e "${BOLD}Working Directory:${NC}"
-  prompt_input WORK_DIR "Project directory for Claude to work in" "$HOME/metabot-workspace"
+  prompt_input WORK_DIR "Project directory for the Agent to work in" "$HOME/metabot-workspace"
   mkdir -p "$WORK_DIR"
   success "Working directory: ${WORK_DIR}"
 
   # ------ 4b: Engine selection ------
   echo ""
   echo -e "${BOLD}Agent Engine:${NC}"
-  echo "  1) Claude Code (Anthropic)"
-  echo "  2) Kimi (Moonshot AI — requires kimi-cli login, uses your subscription)"
-  echo "  3) Codex CLI (OpenAI — requires codex login, uses your ChatGPT subscription)"
+  echo "  1) Codex CLI (OpenAI — requires codex login, uses your ChatGPT subscription)"
+  echo "  2) Kimi Code (Moonshot AI — requires kimi login, uses your subscription; default model kimi-code/k3)"
+  echo "  3) Claude Code compatibility (Anthropic)"
   prompt_choice ENGINE_CHOICE "1"
 
-  BOT_ENGINE="claude"
+  BOT_ENGINE="codex"
   CLAUDE_AUTH_ENV_LINES=""
-  CLAUDE_AUTH_METHOD="subscription"
+  CLAUDE_AUTH_METHOD="codex"
 
   if [[ "$ENGINE_CHOICE" == "2" ]]; then
     BOT_ENGINE="kimi"
     CLAUDE_AUTH_METHOD="kimi"
     echo ""
-    info "Installing kimi-cli..."
-    install_kimi_cli || warn "Continuing despite kimi-cli install failure — you can install it later."
+    info "Installing Kimi Code..."
+    install_kimi_cli || warn "Continuing despite Kimi Code install failure — you can install it later."
     info "After install, run 'kimi login' in a separate terminal to authenticate."
     # Skip the Claude provider prompt entirely for Kimi — it has its own auth.
     AUTH_CHOICE="kimi"
-  elif [[ "$ENGINE_CHOICE" == "3" ]]; then
+  elif [[ "$ENGINE_CHOICE" == "1" ]]; then
     BOT_ENGINE="codex"
     CLAUDE_AUTH_METHOD="codex"
     echo ""
@@ -919,7 +945,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     if [[ "$CLAUDE_AUTH_METHOD" == "subscription" ]]; then
       echo "# Using Claude Code Subscription (OAuth). Run 'claude login' to authenticate."
     elif [[ "$CLAUDE_AUTH_METHOD" == "kimi" ]]; then
-      echo "# Using Kimi CLI. Run 'kimi login' to authenticate."
+      echo "# Using Kimi Code 0.27+ (default model: kimi-code/k3). Run 'kimi login' to authenticate."
     elif [[ "$CLAUDE_AUTH_METHOD" == "codex" ]]; then
       echo "# Using Codex CLI. Run 'codex login' to authenticate (or set OPENAI_API_KEY / configure ~/.codex/config.toml)."
       echo "# CODEX_EXECUTABLE_PATH="
@@ -987,7 +1013,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         feishuAppSecret: process.argv[3],
         defaultWorkingDirectory: process.argv[4],
       };
-      if (engine === 'kimi') { bot.kimi = { thinking: true }; }
+      if (engine === 'kimi') { bot.kimi = { model: 'kimi-code/k3', thinking: true, permissionMode: 'auto' }; }
       if (engine === 'codex') { bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$BOT_NAME" "$FEISHU_APP_ID" "$FEISHU_APP_SECRET" "$WORK_DIR" "${BOT_ENGINE:-claude}")
@@ -1004,7 +1030,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         telegramBotToken: process.argv[2],
         defaultWorkingDirectory: process.argv[3],
       };
-      if (engine === 'kimi') { bot.kimi = { thinking: true }; }
+      if (engine === 'kimi') { bot.kimi = { model: 'kimi-code/k3', thinking: true, permissionMode: 'auto' }; }
       if (engine === 'codex') { bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$TG_NAME" "$TELEGRAM_BOT_TOKEN" "$WORK_DIR" "${BOT_ENGINE:-claude}")
@@ -1021,7 +1047,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         engine,
         defaultWorkingDirectory: process.argv[2],
       };
-      if (engine === 'kimi') { bot.kimi = { thinking: true }; }
+      if (engine === 'kimi') { bot.kimi = { model: 'kimi-code/k3', thinking: true, permissionMode: 'auto' }; }
       if (engine === 'codex') { bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$WX_NAME" "$WORK_DIR" "${BOT_ENGINE:-claude}")
@@ -1053,7 +1079,10 @@ fi
 step "Phase 6: Installing skills and setting up workspace"
 
 SKILLS_DIR="$HOME/.claude/skills"
-mkdir -p "$SKILLS_DIR"
+CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
+AGENTS_SKILLS_DIR="$HOME/.agents/skills"
+GLOBAL_SKILL_ROOTS=("$SKILLS_DIR" "$CODEX_SKILLS_DIR" "$AGENTS_SKILLS_DIR")
+mkdir -p "${GLOBAL_SKILL_ROOTS[@]}"
 
 # Sanity check: bundled skill tree must exist in the checked-out repo.
 # If it's missing, the user's checkout is stale (predates the skill bundling
@@ -1064,6 +1093,11 @@ if [[ ! -f "$SKILL_SENTINEL" ]]; then
   error "Your $METABOT_HOME checkout appears to be stale or incomplete."
   error "Try: cd $METABOT_HOME && git fetch origin && git reset --hard origin/main"
   error "(WARNING: 'git reset --hard' discards uncommitted local changes.)"
+  exit 1
+fi
+TEAM_SKILL_SENTINEL="$METABOT_HOME/packages/skills/metabot-team/SKILL.md"
+if [[ ! -f "$TEAM_SKILL_SENTINEL" ]]; then
+  error "Bundled metabot-team skill source not found at: $TEAM_SKILL_SENTINEL"
   exit 1
 fi
 
@@ -1084,18 +1118,25 @@ for legacy in metamemory skill-hub memory; do
   fi
 done
 
-# Install metabot skill (bundled in packages/skills/metabot/) — single unified
-# skill covering memory / skills / agents / t5t via the metabot-core CLI.
-info "Installing metabot skill..."
-mkdir -p "$SKILLS_DIR/metabot"
-cp "$METABOT_HOME/packages/skills/metabot/SKILL.md" "$SKILLS_DIR/metabot/SKILL.md"
-success "metabot skill installed → $SKILLS_DIR/metabot"
-
-# Install voice skill (bundled in src/skills/voice/)
-info "Installing voice skill..."
-mkdir -p "$SKILLS_DIR/voice"
-cp "$METABOT_HOME/src/skills/voice/SKILL.md" "$SKILLS_DIR/voice/SKILL.md"
-success "voice skill installed → $SKILLS_DIR/voice"
+# Install the complete MetaBot-owned skill bundles for Claude, Codex, and the
+# shared Agent Skills location used by Kimi Code 0.27+. Copying the full bundle
+# (rather than only SKILL.md) preserves required references and scripts.
+declare -a METABOT_SKILL_NAMES=("metabot" "metabot-team" "voice")
+declare -a METABOT_SKILL_SOURCES=(
+  "$METABOT_HOME/packages/skills/metabot"
+  "$METABOT_HOME/packages/skills/metabot-team"
+  "$METABOT_HOME/src/skills/voice"
+)
+for skill_index in "${!METABOT_SKILL_NAMES[@]}"; do
+  skill_name="${METABOT_SKILL_NAMES[$skill_index]}"
+  skill_source="${METABOT_SKILL_SOURCES[$skill_index]}"
+  info "Installing $skill_name skill..."
+  for skill_root in "${GLOBAL_SKILL_ROOTS[@]}"; do
+    mkdir -p "$skill_root/$skill_name"
+    cp -R "$skill_source/." "$skill_root/$skill_name/"
+    success "$skill_name skill installed → $skill_root/$skill_name"
+  done
+done
 
 # Detect Feishu bots
 HAS_FEISHU=false
@@ -1185,6 +1226,10 @@ fi
 # Deploy skills + CLAUDE.md to bot working directory
 if [[ -n "${DEPLOY_WORK_DIR:-}" ]]; then
   SKILLS_DEST="$DEPLOY_WORK_DIR/.claude/skills"
+  CODEX_SKILLS_DEST="$DEPLOY_WORK_DIR/.codex/skills"
+  AGENTS_SKILLS_DEST="$DEPLOY_WORK_DIR/.agents/skills"
+  WORKSPACE_SKILL_ROOTS=("$SKILLS_DEST" "$CODEX_SKILLS_DEST" "$AGENTS_SKILLS_DEST")
+  mkdir -p "${WORKSPACE_SKILL_ROOTS[@]}"
 
   # Clean up legacy skill bundles from a previously-deployed workspace so the
   # bot doesn't load stale skills after the Phase 4 consolidation.
@@ -1200,7 +1245,7 @@ if [[ -n "${DEPLOY_WORK_DIR:-}" ]]; then
   # scheduler) are no longer installed by default — copy them from
   # $METABOT_HOME/src/skills/ if you want them. CC native CronCreate / /loop
   # already cover ad-hoc, session-scoped scheduling.
-  DEPLOY_SKILLS="metabot voice"
+  DEPLOY_SKILLS="metabot metabot-team voice"
   if [[ "$SETUP_LARK_CLI" == "true" ]]; then
     for lark_skill in lark-base lark-calendar lark-contact lark-doc lark-drive lark-event lark-im lark-mail lark-minutes lark-openapi-explorer lark-shared lark-sheets lark-skill-maker lark-task lark-vc lark-whiteboard lark-wiki lark-workflow-meeting-summary lark-workflow-standup-report; do
       [[ -d "$SKILLS_DIR/$lark_skill" ]] && DEPLOY_SKILLS="$DEPLOY_SKILLS $lark_skill"
@@ -1208,21 +1253,30 @@ if [[ -n "${DEPLOY_WORK_DIR:-}" ]]; then
   fi
   for SKILL in $DEPLOY_SKILLS; do
     if [[ -d "$SKILLS_DIR/$SKILL" ]]; then
-      mkdir -p "$SKILLS_DEST/$SKILL"
-      cp -r "$SKILLS_DIR/$SKILL/." "$SKILLS_DEST/$SKILL/"
-      success "Deployed $SKILL → $SKILLS_DEST/$SKILL"
+      for skill_dest in "${WORKSPACE_SKILL_ROOTS[@]}"; do
+        mkdir -p "$skill_dest/$SKILL"
+        cp -R "$SKILLS_DIR/$SKILL/." "$skill_dest/$SKILL/"
+        success "Deployed $SKILL → $skill_dest/$SKILL"
+      done
     fi
   done
 
   # Deploy CLAUDE.md to working directory (+ AGENTS.md symlink for Kimi engine)
   if [[ -f "$METABOT_HOME/src/workspace/CLAUDE.md" ]]; then
-    cp "$METABOT_HOME/src/workspace/CLAUDE.md" "$DEPLOY_WORK_DIR/CLAUDE.md"
-    success "Deployed CLAUDE.md → $DEPLOY_WORK_DIR/CLAUDE.md"
-    # Kimi engine reads AGENTS.md not CLAUDE.md — symlink so both engines see the same doc
-    if [[ ! -e "$DEPLOY_WORK_DIR/AGENTS.md" ]]; then
+    if [[ -e "$DEPLOY_WORK_DIR/CLAUDE.md" || -L "$DEPLOY_WORK_DIR/CLAUDE.md" ]]; then
+      info "Preserved existing CLAUDE.md at $DEPLOY_WORK_DIR/CLAUDE.md"
+    else
+      cp "$METABOT_HOME/src/workspace/CLAUDE.md" "$DEPLOY_WORK_DIR/CLAUDE.md"
+      success "Deployed CLAUDE.md → $DEPLOY_WORK_DIR/CLAUDE.md"
+    fi
+    # Kimi Code and Codex read AGENTS.md. Derive the compatibility link from
+    # the current (possibly user-customized) CLAUDE.md instead of overwriting it.
+    if [[ ! -e "$DEPLOY_WORK_DIR/AGENTS.md" && ! -L "$DEPLOY_WORK_DIR/AGENTS.md" ]]; then
       (cd "$DEPLOY_WORK_DIR" && ln -s CLAUDE.md AGENTS.md 2>/dev/null) \
-        && success "Linked AGENTS.md → CLAUDE.md (for Kimi engine compatibility)" \
+        && success "Linked AGENTS.md → CLAUDE.md (for Kimi Code/Codex compatibility)" \
         || warn "Could not create AGENTS.md symlink"
+    else
+      info "Preserved existing AGENTS.md at $DEPLOY_WORK_DIR/AGENTS.md"
     fi
   fi
 else

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metabot",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metabot",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "workspaces": [
         "packages/cli",
         "packages/cli-core",
@@ -19,7 +19,6 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.154",
         "@anthropic-ai/sdk": "^0.100.0",
         "@larksuiteoapi/node-sdk": "^1.64.0",
-        "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
         "@types/ws": "^8.18.0",
         "@volcengine/openapi": "^1.36.0",
         "@xterm/headless": "^6.0.0",
@@ -35,9 +34,9 @@
         "openai": "^6.29.0",
         "pino": "^9.0.0",
         "pino-pretty": "^11.0.0",
-        "undici": "^7.24.5",
-        "ws": "^8.19.0",
-        "xlsx": "^0.18.5"
+        "undici": "^7.28.0",
+        "ws": "^8.21.1",
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -49,6 +48,9 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -1252,23 +1254,6 @@
         }
       }
     },
-    "node_modules/@moonshot-ai/kimi-agent-sdk": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@moonshot-ai/kimi-agent-sdk/-/kimi-agent-sdk-0.1.8.tgz",
-      "integrity": "sha512-MneDv0RRoauvQ5XL5rqDpFTHokiH0WWB/hlHpgz54VL7OWnanCejrPW4cPK4YL7WurTMjt6p2shO9eZMhd++5g==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "toml": "^3.0.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.24.0 || ^4.0.0"
-      }
-    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -1294,9 +1279,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
@@ -1312,12 +1297,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1337,15 +1316,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2267,39 +2237,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@volcengine/openapi/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@volcengine/openapi/node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -2389,15 +2326,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/agent-base": {
@@ -2503,51 +2431,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/axios/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/axios/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/balanced-match": {
@@ -2813,19 +2730,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2871,15 +2775,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -3008,18 +2903,6 @@
         "buffer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cron-parser": {
@@ -3167,15 +3050,6 @@
       "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
       "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -3866,15 +3740,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35"
       },
       "engines": {
@@ -3910,15 +3784,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -4091,9 +3956,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4109,9 +3974,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5260,19 +5125,18 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -5298,10 +5162,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -5427,38 +5294,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/readable-stream": {
@@ -5859,18 +5694,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6094,12 +5917,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
-      "license": "MIT"
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6247,9 +6064,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -6319,13 +6136,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -6972,24 +6792,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7024,9 +6826,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -7045,19 +6847,10 @@
       }
     },
     "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "version": "0.20.3",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
       "bin": {
         "xlsx": "bin/xlsx.njs"
       },
@@ -7144,6 +6937,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
@@ -7235,11 +7029,11 @@
       "name": "@xvirobotics/metabot-core-web-ui",
       "version": "0.1.0",
       "dependencies": {
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.4.12",
         "marked": "^14.1.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^6.30.4"
       },
       "devDependencies": {
         "@types/dompurify": "^3.0.5",
@@ -7248,6 +7042,24 @@
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5.9.3",
         "vite": "^5.4.11"
+      }
+    },
+    "packages/web-ui/node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/web-ui/node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "packages/web-ui/node_modules/marked": {
@@ -7260,6 +7072,38 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "packages/web-ui/node_modules/react-router-dom": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "packages/web-ui/node_modules/react-router-dom/node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "metabot",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "metabotEdition": "personal",
-  "description": "MetaBot — Bridge service connecting IM bots (Feishu/Lark, Telegram) to Claude Code Agent SDK",
+  "description": "MetaBot Personal Edition — use Codex and Kimi Code from IM channels and the local Web UI",
   "main": "dist/index.js",
   "type": "module",
   "workspaces": [
@@ -34,7 +34,6 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.154",
     "@anthropic-ai/sdk": "^0.100.0",
     "@larksuiteoapi/node-sdk": "^1.64.0",
-    "@moonshot-ai/kimi-agent-sdk": "^0.1.8",
     "@types/ws": "^8.18.0",
     "@volcengine/openapi": "^1.36.0",
     "@xterm/headless": "^6.0.0",
@@ -50,9 +49,9 @@
     "openai": "^6.29.0",
     "pino": "^9.0.0",
     "pino-pretty": "^11.0.0",
-    "undici": "^7.24.5",
-    "ws": "^8.19.0",
-    "xlsx": "^0.18.5"
+    "undici": "^7.28.0",
+    "ws": "^8.21.1",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -66,6 +65,14 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
-    "buffer": "^6.0.3"
+    "axios": "^1.15.2",
+    "buffer": "^6.0.3",
+    "form-data": "^4.0.6",
+    "hono": "^4.12.25",
+    "protobufjs": "^7.6.3",
+    "uuid": "^11.1.1"
+  },
+  "engines": {
+    "node": ">=22.19.0"
   }
 }

--- a/packages/cli/scripts/pack.sh
+++ b/packages/cli/scripts/pack.sh
@@ -45,12 +45,12 @@ if [[ ! -x "$ESBUILD_BIN" ]]; then
   exit 1
 fi
 
-echo "==> Bundling CLI with esbuild (target=node20, format=esm)"
+echo "==> Bundling CLI with esbuild (target=node22, format=esm)"
 "$ESBUILD_BIN" \
   "$CLI_PKG_DIR/scripts/standalone-entry.ts" \
   --bundle \
   --platform=node \
-  --target=node20 \
+  --target=node22 \
   --format=esm \
   --banner:js='#!/usr/bin/env node' \
   --outfile="$STAGE_DIR/bundle.mjs" \

--- a/packages/server/deploy/install.sh
+++ b/packages/server/deploy/install.sh
@@ -15,7 +15,7 @@
 #   - Set up TLS termination or an SSO/auth reverse proxy. Both are OPTIONAL and
 #     left to the operator (see the note printed at the end). The personal
 #     edition authenticates with a local API token out of the box.
-#   - Install Node or any system package — assumes Node 20+ is already on PATH.
+#   - Install Node or any system package — assumes Node >=22.19 is already on PATH.
 #
 # Configurable via environment:
 #   USER_NAME              run user             (default: ${SUDO_USER:-$USER})
@@ -48,7 +48,12 @@ if ! id -u "$USER_NAME" >/dev/null 2>&1; then
 fi
 
 if ! command -v node >/dev/null 2>&1; then
-  echo "error: node not on PATH; install Node 20+ before running this script" >&2
+  echo "error: node not on PATH; install Node >=22.19 before running this script" >&2
+  exit 2
+fi
+
+if ! node -e 'const [a,b,c]=process.versions.node.split(".").map(Number); process.exit(a>22 || (a===22 && (b>19 || (b===19 && c>=0))) ? 0 : 1)'; then
+  echo "error: Node >=22.19 is required; found $(node --version)" >&2
   exit 2
 fi
 

--- a/packages/skills/metabot-team/README.md
+++ b/packages/skills/metabot-team/README.md
@@ -8,9 +8,12 @@ handoffs, run inspection, and lead reporting.
 
 ```bash
 metabot skills install metabot-team --to ~/.codex/skills/metabot-team
+metabot skills install metabot-team --to ~/.agents/skills/metabot-team
+metabot skills install metabot-team --to ~/.claude/skills/metabot-team
 ```
 
-For Claude Code, install to `~/.claude/skills/metabot-team` instead.
+The one-line MetaBot installer mirrors this bundle to all three locations for
+Codex, Kimi Code, and Claude Code compatibility.
 
 ## Source of truth
 

--- a/packages/skills/metabot/README.md
+++ b/packages/skills/metabot/README.md
@@ -1,28 +1,28 @@
-# `metabot` — Claude Code skill bundle
+# `metabot` Agent Skill bundle
 
-This directory ships the canonical Claude Code skill for the unified `metabot` CLI. It's the address-book + memory + skills front-end for the entire metabot-core stack.
+Engine-neutral instructions for the unified `metabot` CLI in MetaBot Personal
+Edition. The same bundle works with Codex, Kimi Code, and Claude Code.
 
-## Install
+The one-line installer mirrors the complete bundle to:
+
+- `~/.codex/skills/metabot`
+- `~/.agents/skills/metabot`
+- `~/.claude/skills/metabot`
+- the matching per-workspace skill roots
+
+To install it manually, choose the destination for your engine:
 
 ```bash
-# Per-project (default): writes to <cwd>/.claude/skills/metabot/SKILL.md
-metabot skills install metabot
-
-# Global (recommended for personal Claude Code installs):
+metabot skills install metabot --to ~/.codex/skills/metabot
+metabot skills install metabot --to ~/.agents/skills/metabot
 metabot skills install metabot --to ~/.claude/skills/metabot
 ```
 
-**Mind the install path landmine.** `metabot skills install <name>` (and its alias `mh install <name>`) defaults to `<cwd>/.claude/skills/<name>` — a per-project install. If you want every Claude Code session on your machine to see this skill, pass `--to ~/.claude/skills/metabot`. Without that flag, other sessions outside the install cwd will not see the skill and will wonder why `metabot agents …` shows up as an "unknown command" hint instead of a usable tool.
+This bundle documents Memory, Skill Hub, the personal-edition agent registry
+and inbox relay, Agent Teams routing, T5T, and runtime operations. Legacy
+`mm`, `mh`, and `mb` binaries are intentionally absent.
 
-The legacy `metamemory` and `skill-hub` Claude Code skills keep working unchanged; this one is purely additive.
-
-## What's inside
-
-- `SKILL.md` — the user-facing skill manifest with frontmatter (`name`, `description`) and the full `metabot` CLI reference: `memory`, `skills`, `agents` (incl. `talk <peer>/<bot> [<chatId>] "<msg>"` with project-derived chatId default), `inbox` (central spool for CC/Codex agents that have no resident bridge), and `t5t`.
-
-## Source of truth
-
-This skill is published from this directory inside `metabot-core`. To re-publish after editing:
+Publish changes from this directory:
 
 ```bash
 metabot skills publish metabot --from packages/skills/metabot

--- a/packages/skills/metabot/SKILL.md
+++ b/packages/skills/metabot/SKILL.md
@@ -1,369 +1,129 @@
 ---
 name: metabot
-description: "Unified MetaBot CLI — central memory, skills hub, agent bus (talk to peer bots), and t5t (daily team status portal). Use when reading/writing shared memory, browsing/installing skills, listing or messaging peer bots, posting daily T5T entries, or coordinating cross-bot work."
+description: "Unified MetaBot CLI for personal memory, Skill Hub, agent registry and inbox relay, Agent Teams, T5T, and bridge runtime operations."
 ---
 
-## Quickstart
+# MetaBot Personal CLI
 
-The `metabot` CLI is the single entry point to the metabot-core ecosystem. It wraps four surfaces:
+Use `metabot` as the single CLI. Legacy `mm`, `mh`, and `mb` binaries are
+retired. This bundle is engine-neutral and can be installed for Codex, Kimi
+Code, or Claude Code.
+
+## Fast Path
 
 ```bash
-metabot memory <cmd>   # shared knowledge / notes
-metabot skills <cmd>   # skill registry                (alias: skill)
-metabot agents <cmd>   # peer-bot address book
-metabot inbox  <cmd>   # central inbox for CLI agents (CC / Codex with no bridge)
-metabot teams  <cmd>   # local Agent Teams orchestration
-metabot t5t    <cmd>   # daily team status portal
-metabot help           # top-level help (also --help, -h, bare invocation)
+metabot memory search "query"
+metabot memory get <id|path>
+metabot skills list
+metabot agents list
+metabot agents talk <agent> "message"
+metabot inbox poll --loop
+metabot teams status <team> --summary
+metabot t5t projects list
+metabot health
 ```
 
-`metabot` is the **single** CLI binary. Beyond the metabot-core surfaces above, it also handles bridge process control (`update`/`start`/`stop`/`restart`/`logs`/`status`) and a bridge daemon API (`bots`/`bot`/`talk`/`schedule`/`voice`/`stats`/`peers`/`metrics`/`health` — see the bridge-local section below). The legacy `mm`, `mh`, and per-bot `bot-skills` surfaces have been removed; `mb` is now a thin deprecation wrapper that forwards to `metabot`. Switch any script still calling them to the `metabot <subcommand>` form (see the migration table below).
+Run `metabot help` or `metabot <surface> --help` before assuming an optional
+bridge-local command is available.
 
-Auth is automatic: `METABOT_CORE_TOKEN` (env) or `~/.metabot-core/token` (first line). Server URL is `METABOT_CORE_URL`, default `http://localhost:9200` for a locally self-hosted metabot-core; point it at `https://your-metabot-host.example.com` if you run metabot-core on a remote box behind your own reverse proxy.
+## Authentication
 
-**Fastest path for a fresh agent**: run metabot-core locally (or reach your own remote host), then put the API token in `~/.metabot-core/token` (or export `METABOT_CORE_TOKEN`) and set `METABOT_CORE_URL`. No SSO or corporate VPN is required for the personal edition — a single local API token is the only credential. Then `metabot agents whoami` should echo your identity.
+- Personal Core defaults to `http://127.0.0.1:9200`.
+- Override it with `METABOT_CORE_URL` when using your own remote Core.
+- Use `METABOT_CORE_TOKEN`, or the first line of `~/.metabot-core/token`.
+- Never print tokens, bot secrets, or complete credential files.
+- Verify identity with `metabot agents whoami`.
 
-## `metabot memory` — shared knowledge
-
-Most-used:
+## Memory
 
 ```bash
-metabot memory list [folder_id]                      # browse the tree
-metabot memory search "<query>"                      # full-text search
-metabot memory get <id|path>                         # read a doc (JSON metadata + content)
-metabot memory create "<title>" ["<content>"] --share --tags a,b
-metabot memory create "<title>" ["<html>"] --share --html --tags docs
-metabot memory mkdir "<name>"                        # create a folder
-metabot memory update <id> [content] [--title …] [--tags a,b,c] [--share|--no-share]
-metabot memory share <id> [on|off]                   # toggle one doc's cross-bot visibility
-metabot memory visibility [public|private]           # default shared flag for new docs
+metabot memory list [folder]
+metabot memory search "query"
+metabot memory get <id|path>
+metabot memory create "title" "content" --share --tags a,b
+metabot memory update <id> "content" [--share|--no-share]
+metabot memory mkdir "name"
 metabot memory health
 ```
 
-(Replaces the former standalone `mm` CLI — same wire calls, same behavior, single binary.)
+Search before creating. Bare writes belong in the caller's own namespace;
+use an explicit `--path` only when the target is known to be writable. A
+document is cross-agent readable only when `shared=true`.
 
-**Write target — `create` / `mkdir`.** Both accept an explicit `--path </absolute/path>`:
-
-```bash
-metabot memory create "Smoke note" "..." --path /users/<botName>/smoke-note
-metabot memory mkdir "smoke-folder"   --path /users/<botName>/smoke-folder
-```
-
-When `--path` is given the server ACL-checks it and auto-creates any missing
-ancestor folders. With **neither** `--path` nor `--folder` (nor a `parent_id`
-for `mkdir`), the write **defaults into your own namespace** —
-`/users/<botName>/<slug-of-title>` for `create`,
-`/users/<botName>/<name>` for `mkdir` — resolved via `GET /api/whoami`. This
-is the fix for the old member `403 forbidden`: members cannot write the root
-namespace, so a bare `create`/`mkdir` previously failed. Admin tokens keep the
-legacy root default. `--folder <id>` still targets an explicit existing folder
-as before.
-
-**Read visibility is document-level.** A document's cross-bot visibility is
-controlled by its `shared` flag, not by the path. Use `--share` when creating
-team-visible memory; use `--no-share` for private notes. Tags are for search
-and discovery, not ACL, but they should still describe audience and topic:
-
-```bash
-metabot memory create "Runbook" "$CONTENT" --share --tags team,runbook
-metabot memory create "Landing page" "$HTML" --share --html --tags metabot,tutorial
-metabot memory update <doc_id> --share --tags metabot,public
-metabot memory share <doc_id> on
-```
-
-**Per-bot default visibility — `memoryPublic`.** Bots can flip the default
-`shared` value for new documents without admin intervention. `public` means
-new docs default to `shared:true`; `private` means new docs default to
-`shared:false`. Explicit `--share` / `--no-share` on create/update always wins.
-Default for newly-registered bots is **public** (`memoryPublic: true`):
-
-```bash
-metabot memory visibility            # prints {state: "public" | "private"}
-metabot memory visibility public     # new docs default shared:true
-metabot memory visibility private    # new docs default shared:false
-```
-
-Same shape and auth model as `bots.json` `visible` for agent-bus discovery
-("bot self-toggles, owner credential or admin only" — PATCH
-`/api/agents/<botName>/memory-visibility`). It only changes the default
-`shared` value for *new* documents; existing docs are unchanged until you run
-`metabot memory share <doc_id> on|off` or `metabot memory update <doc_id>
---share|--no-share`. To pin the choice across bridge restarts, set
-`memoryPublic: true|false` on the bot's entry in `bots.json` — the bridge
-re-asserts the column on every bulk-register and overrides whatever was last
-toggled via CLI. Omitting the field in bots.json leaves CLI toggles sticky.
-
-## `metabot skills` — skill registry
+## Skill Hub
 
 ```bash
 metabot skills list
 metabot skills get <name>
-metabot skills publish <name> --from <dir>        # reads <dir>/SKILL.md
-metabot skills install <name> [--to <dir>]        # default --to .claude/skills/<name>
+metabot skills install <name> [--to <dir>]
+metabot skills publish <name> --from <bundle-dir>
 metabot skills remove <name>
-metabot skills health
 ```
 
-**Install location landmine:** `metabot skills install <name>` defaults to `<cwd>/.claude/skills/<name>`. For a Claude-Code-wide install, pass `--to ~/.claude/skills/<name>`:
+Install complete bundles, not only `SKILL.md`. Standard destinations are
+`.codex/skills`, `.agents/skills`, and `.claude/skills`; MetaBot's installer
+mirrors its owned bundles to all three while preserving unrelated skills.
+
+## Agent Registry And Inbox Relay
 
 ```bash
-metabot skills install metabot --to ~/.claude/skills/metabot
-```
-
-(Replaces the former standalone `mh` CLI — same wire calls, same behavior, single binary.)
-
-## `metabot agents` — peer-bot address book
-
-The agent bus is the registry of all reachable MetaBot bots in the org. Bots self-register with their callable URL; peers discover them with zero config; the actual talk RPC stays bot-to-bot (P2P). **Visibility is the permission** — if a bot is in the visible registry, anyone with a metabot-core token can talk to it. Owner credentials decide which of their bots to expose via `bots.json` (`visible: true|false`); the registry no longer stores a per-bot `talkSecret`.
-
-```bash
-metabot agents list [--include-hidden]
-metabot agents register --url <url> [--bot-name <name>] [--hidden]
-metabot agents heartbeat [--bot-name <name>]
-metabot agents whoami
-metabot agents visible <botName>
-metabot agents hide    <botName>
-metabot agents talk <peer>[/<bot>] [<chatId>] "<message>"
-```
-
-**`list`** — returns the visible registry. `--include-hidden` requires an admin token; member tokens get 403.
-
-**`register`** — typically called by the IM-bridge on boot for each `visible:true` bot in `bots.json`, not by a human. `--bot-name` lets one credential register many distinct bots; without it, the credential's own `botName` is used (legacy 1:1 mode). Anti-squat is enforced server-side — re-registering an existing name from a different credential returns `403 name_squat`. `--hidden` sets `visible=false` at registration.
-
-**`heartbeat`** — IM-bridges call this every ~60s, batched across all owned bots via `{botNames:[...]}`. Without `--bot-name`, falls back to the legacy single-bot form (uses the credential's own `botName`). After ~180s (3× heartbeat) a row is treated as stale and filtered out of `list`. Stale rows are kept in storage for audit; the store sweeps anything older than 24h.
-
-**`whoami`** — calls `GET /api/whoami` to echo `{botName, role, authSource, credentialId}` for the current token. Bridges use the same endpoint internally to verify an inbound cross-bridge talk caller.
-
-**`visible` / `hide`** — ownership-gated. Only the credential that registered the bot (or an admin token) can toggle visibility.
-
-**`talk`** is a thin convenience: it does `GET /api/agents` to resolve `<peer>` → `{url}`, then either (a) `POST <peerUrl>/api/talk` for resident bridges, or (b) `POST <core>/api/inbox/<botName>` for CLI-only peers whose registered URL is the literal string `inbox:` (see [CLI-only agents](#cli-only-agents-inbox--project-as-chatid) below). The peer bridge verifies the token by calling central `GET /api/whoami`; if it returns 200, the call is authorized. Use `<peer>/<bot>` to target a specific bot inside that peer; `<peer>` alone targets a bot of the same name on that peer.
-
-**Default chatId — project-derived.** If you omit `<chatId>`, the CLI derives one from the current working directory: `proj:<basename>:<sha1(abs-path)[:8]>` (stable per absolute path, intentionally **not** cross-machine stable — see the inbox section). The derived id is echoed on stderr so you can tell when the default fired:
-
-```bash
-$ metabot agents talk alice/research-bot "ping"
-→ using project-derived chatId: proj:metabot:1a2b3c4d
-→ alice/research-bot @ proj:metabot:1a2b3c4d
-```
-
-Pass an explicit chatId when you want to share a thread across machines or with a non-CLI sender (Feishu, browser, etc.).
-
-**Semantics:**
-- **Asynchronous.** The target bot receives the message in its own chat/session and processes the turn there. Its reply lands in the target bot's chat (not as the return value of this command).
-- **The talk RPC is P2P for resident bridges.** The registry is an address book only — for bridge peers, `metabot agents talk` shells out to the peer's `/api/talk` directly and metabot-core never proxies the message body. For CLI-only peers (`url: 'inbox:'`), the message is spooled centrally in metabot-core's `agent_inbox` table and drained by the target via `metabot inbox poll`.
-
-```bash
-# Resolve the registry, then deliver
 metabot agents list
-metabot agents talk alice/research-bot chat_BBB "What did last week's retention dashboard show?"
-```
-
-### CLI-only agents (`inbox:` + project-as-chatId)
-
-Claude Code and Codex have no resident bridge, so they can't accept inbound `POST /api/talk`. To make them addressable on the agent bus anyway, they register with a literal `url: 'inbox:'` marker (no scheme, no host — just the string). Senders observe the marker and reroute through metabot-core's central inbox; the CLI agent drains the queue with `metabot inbox poll`.
-
-**Project = chatId.** Without Feishu, there's no natural conversation id, so each project directory's absolute path is hashed into `proj:<basename>:<sha1>[:8]`. This is the default chatId for both `metabot agents talk` (when chatId is omitted) and `metabot inbox peek/poll/clear` (when `--chat` and `--all-chats` are both omitted). Two checkouts of the same repo at different paths or on different machines are deliberately treated as **different** chats — pass an explicit `--chat` if you want to merge them.
-
-```bash
-metabot inbox project-id   # echo the cwd-derived chatId without doing anything else
-```
-
-End-to-end registration:
-
-```bash
-# On machine A (the CC/Codex user) — register once per machine
-metabot inbox register                     # bot name defaults to cli:<ownerName>@<hostname>
-metabot inbox poll --loop                  # block forever, draining as messages arrive
-
-# On machine B (any sender with a metabot-core token)
-metabot agents talk cli:flood@laptop "follow-up on the deploy"
-# stderr: → using project-derived chatId: proj:<project>:<hash>
-# A's `inbox poll` prints one JSON line per delivered message
-```
-
-## `metabot inbox` — central inbox for CLI-only agents
-
-A small spool kept inside metabot-core (table `agent_inbox`) so CC/Codex peers — who can't accept inbound HTTP — can still receive `metabot agents talk` messages. Bots register with `url: 'inbox:'` (see the [CLI-only agents](#cli-only-agents-inbox--project-as-chatid) section above); senders observe the marker and reroute through `POST /api/inbox/<botName>`; the target drains the queue with `poll`. Each project directory is its own chatId by default.
-
-```bash
+metabot agents whoami
+metabot agents talk <peer>[/<bot>] [<chatId>] "message"
 metabot inbox register [--bot-name <name>]
-metabot inbox project-id
-metabot inbox peek    [--chat <id>] [--all-chats] [--limit 20]
-metabot inbox poll    [--chat <id>] [--wait 30] [--once|--loop]
-metabot inbox clear   [--chat <id>] [--all-chats]
+metabot inbox poll [--chat <id>] [--once|--loop]
+metabot inbox peek [--chat <id>]
 ```
 
-**`register`** — registers an inbox-only agent on the bus. Default `--bot-name` is `cli:<ownerName>@<hostname>` (ownerName from `GET /api/whoami`, hostname from `os.hostname().split('.')[0]`). The registration uses `url: 'inbox:'` and `visible: true`. Re-running it from the same credential is idempotent; a different credential trying to claim the same name gets `403 name_squat` like any other agent registration.
+When `chatId` is omitted, the CLI derives a project-scoped conversation id from
+the current working directory. Pass an explicit id for a thread that must be
+shared across machines. Preserve returned message ids for diagnostics. Inbox
+polling is intended for CLI-only Codex/Kimi/Claude agents without a resident
+bridge; use Agent Teams when you need owned tasks and run state.
 
-**`project-id`** — print the cwd-derived chatId and exit. Useful for sanity checks and for copy-pasting into an explicit `--chat` on a remote sender.
+## Agent Teams
 
-**`peek`** — show queued messages without popping them. Without `--chat` or `--all-chats`, filters to the cwd-derived chatId and prints a stderr notice (`→ using project-derived chatId: …`). `--limit` defaults to 20 and is hard-capped at 200.
-
-**`poll`** — atomically pop the oldest queued message, long-polling up to `--wait` seconds. `--wait` defaults to 30 and is hard-capped at 60 (proxy idle limits). `--once` (default) returns after the first message or timeout; `--loop` keeps the call open forever and prints one JSON line per delivered message — the canonical mode for "open a terminal on machine A and leave it running". On `--once` timeout, prints a marker line `{"message":null,"waitedMs":<n>}` so pipelines can distinguish empty-poll from error. SIGINT/SIGTERM exits cleanly in `--loop` mode.
-
-```json
-{"id":"…","targetBot":"cli:flood@laptop","chatId":"proj:metabot:1a2b3c4d",
- "fromBot":"alice","fromOwner":"alice@example.com","content":"ping","enqueuedAt":"…"}
-```
-
-**`clear`** — delete queued messages. Defaults to the cwd chatId; `--all-chats` wipes every chat for the bot. Use this when a stale CLI session left messages behind that no longer make sense.
-
-**Auth.** All inbox routes are Bearer-only (web identity is excluded by the same structural fork that protects `/api/t5t/cli/*`). `peek` / `poll` / `clear` require **owner** of the target bot (`cred.ownerName === bot.ownerName`, or admin); `enqueue` (i.e. `POST /api/inbox/<botName>` triggered by `metabot agents talk`) only requires a valid Bearer — sending is open, draining is gated.
-
-**Anti-spoof.** The server stamps `fromBot`, `fromOwner`, `fromCredentialId` from the authenticated credential on every enqueue; any matching fields in the request body are ignored. The receiver can trust those three fields without further verification.
-
-**Storage.** SQLite table `agent_inbox(id, target_bot, chat_id, from_bot, from_owner, from_credential_id, content, enqueued_at)` with index `(target_bot, chat_id, enqueued_at)`. No TTL — use `clear` or `metabot inbox count` (if added) to manage size. The table lives in the same `central.db` as `agents`, `memory_*`, and `t5t_*`.
-
-## `metabot teams` — local Agent Teams
-
-Agent Teams live in the local bridge (`/api/agent-teams/*`) and are optimized
-for Codex-first delegation. New CLI-spawned teammates default to `codex`; pass
-`--engine claude|kimi` only for explicit exceptions.
-
-Lead path:
+Use the separate `metabot-team` skill for the full workflow. Common commands:
 
 ```bash
 metabot teams create <team> --description "..."
-metabot teams agents spawn <team> <agent> --role "runtime" --prompt "Own runtime work."
-metabot teams dispatch <team> <agent> "Fix update package" --description "Self-contained scope." --plain
+metabot teams dispatch <team> <agent> "subject" --description "..." --plain
+metabot teams next <team> <agent> --read
 metabot teams status <team> --summary
 metabot teams runs list <team>
 ```
 
-`dispatch` is the smooth path: it creates a task, assigns it to the agent, and
-sends the wake-up message in one command.
+Teams are local orchestration. Agent Bus delivery does not prove a remote
+worker can mutate the sender's local team store.
 
-To parallelize independent verification, dispatch multiple pending tasks to the
-same reviewer/verifier. The supervisor starts one run per ready task, up to
-`METABOT_AGENT_TEAM_MAX_PARALLEL_PER_AGENT` concurrent runs per agent
-(default: `4`), using isolated run-scoped chats for parallel same-agent work.
-
-Teammate path:
+## T5T
 
 ```bash
-metabot teams next <team> <agent> --read
-metabot teams status <team> --summary
-metabot teams tasks claim <team> <taskId> <agent>
-metabot teams tasks done <team> <taskId> "result"
-metabot teams tasks block <team> <taskId> "blocked reason" --blocked-by <id,id>
-metabot teams send <team> lead "Completed task <taskId>: ..."
+metabot t5t projects list
+metabot t5t projects show <project>
+metabot t5t board [project]
+metabot t5t push <project> <YYYY-MM-DD> "entry"
+metabot t5t feedback <entryId> "comment"
 ```
 
-For repeated local teammate use, set `METABOT_TEAM_AGENT=<agent>` and omit the
-owner argument in `tasks claim`.
+Record meaningful `START`, `MILESTONE`, `BLOCKER`, `REVIEW`, `SMOKE`,
+`RELEASE`, and `FINAL` events. Include changed targets, verification evidence,
+the exact blocker, and the next safe action.
 
-Add `--summary` or `--plain` to `status`, `next`, `inbox`, `tasks list`,
-`runs list`, `dispatch`, and `watch` for concise text output. Omit it when you
-need the default JSON for scripts.
+## Bridge Runtime
 
-## `metabot t5t` — daily team status portal
-
-T5T (天天天天天 — daily team status) is the team's append-only project tracker: each member pushes a daily entry, evaluators score evaluator-columns, leaders set goals and surface bottlenecks. All state is append-only docs in central memory; there are no updates or deletes — latest-doc-wins per `(project, type)` at read time.
+Installed personal runtimes may expose:
 
 ```bash
-metabot t5t board                              # full board (projects + recent + anomalies)
-metabot t5t status                             # lightweight: projects + anomalies, no entries
-metabot t5t whoami                             # echo caller's identity
-metabot t5t projects [list|show <slug>]        # list or detail-view a project
-metabot t5t push <project> <YYYY-MM-DD> "<item1>" ["<item2>" ...]
-                                               # append a daily entry
-metabot t5t feedback <entryDocId> "<comment>" [--mentions @a,@b]
-                                               # reply on an entry
-metabot t5t goal <project> "<text>"            # owner-only
-metabot t5t evaluator <project> add|remove <email>
-                                               # owner-only
-metabot t5t bottleneck <project> "<text>"      # owner-only ; pass --clear to remove
-metabot t5t wip <project> <evaluatorId> "<title>"
-                                               # owner-only
-metabot t5t kill <project>                     # owner-only ; soft-kill (append-only status=killed)
-metabot t5t reopen <project>                   # owner-only ; reopen by appending status=unknown
-metabot t5t delete <smoke-project>             # owner-only ; hard-delete smoke* test projects
-metabot t5t top5 <project> add "<text>"        # owner-only ; add a Top-5 todo item
-metabot t5t top5 <project> done|reopen|remove <itemId>
-                                               # owner-only ; flip status of an existing item
-metabot t5t top5 <project> list                # show the current Top-5 items
+metabot update
+metabot restart
+metabot status
+metabot logs
+metabot bots
+metabot peers
+metabot health
 ```
 
-**Routes.** Every subcommand calls `/api/t5t/cli/*` (Bearer-only; web identity is excluded by the server). See `packages/server/src/t5t/t5t-routes.ts` for the exact shapes.
-
-**Auth.** Uses the same `METABOT_CORE_TOKEN` env / `~/.metabot-core/token` file as `metabot memory` and `metabot agents`. No separate `~/.t5t/credentials` (the Python `t5t` CLI's auth file) is read or honored.
-
-**Owner-auth.** `goal` / `evaluator` / `bottleneck` / `wip` / `kill` / `top5` are gated by project ownership: only the project's `leaderEmail` or an email listed in `allowedUsers` (admin tokens always pass). The server's deny-by-default contract means a project with *empty* `leaderEmail` AND *empty* `allowedUsers` rejects all writes — even from the project's original author. If you hit `owner_required` on a project you created, the leader was never seeded — fix via an admin token or by `push`ing the first entry under that slug (push auto-creates the project with the caller as leader).
-
-**Auto-creation on push.** `metabot t5t push <new-slug> ...` creates the project with `leaderEmail = <your botName/email>`. The other write paths (`goal/evaluator/bottleneck/wip`) require the project to already exist; they 404 otherwise.
-
-**Anomalies.** `board` and `status` include an `anomalies[]` array — each entry has a `reason` (`no_owner` / `stale` / `kill_red` / `no_goal` / `stale_bottleneck`). These are derived by the server from the latest docs at read time; no separate maintenance call needed.
-
-**Migration from an older standalone `t5t` CLI**, if you ever used one:
-
-| Old | New |
-|---|---|
-| `t5t push <slug> <date> "<item>"` | `metabot t5t push <slug> <date> "<item>"` |
-| `t5t board` / `t5t projects` | `metabot t5t board` / `metabot t5t projects list` |
-| `t5t goal <slug> "<text>"` | `metabot t5t goal <slug> "<text>"` |
-| `t5t feedback <entry> "<comment>"` | `metabot t5t feedback <entryDocId> "<comment>"` |
-| `~/.t5t/credentials` | discarded — use `~/.metabot-core/token` or `METABOT_CORE_TOKEN` |
-| a hardcoded t5t host | `METABOT_CORE_URL` (default `http://localhost:9200`) |
-
-The t5t portal is now just the t5t tab of your metabot-core instance — only `metabot t5t` is needed.
-
-## `metabot` bridge-local — local bridge daemon API
-
-Separate from the metabot-core surfaces above, `metabot` also curls the **local
-bridge daemon** at `localhost:9100` (auth from `API_PORT` / `API_SECRET` in the
-bridge `.env`). These commands act on the bot process running on this host:
-
-```bash
-metabot bots                              # list all bots (local + peer)
-metabot bot <name>                        # get bot details
-metabot talk [peer/]<bot> <chatId> <msg>  # talk to a bot via the bridge /api/talk
-metabot teams ...                          # local Agent Teams
-metabot schedule list|add|cron|pause|resume|cancel …   # task scheduler
-metabot peers                             # list peers and status
-metabot stats                             # cost & usage statistics
-metabot metrics                           # Prometheus metrics
-metabot voice call|transcript|list|config|tts …       # RTC voice call + TTS
-metabot health                            # health check
-```
-
-**`talk` — two distinct paths.** `metabot talk` (here) hits the **bridge**
-`/api/talk` on `localhost:9100` for local + peer-federated routing. `metabot
-agents talk` (above) is the **central-registry** P2P path that resolves a peer
-via the metabot-core agent bus. They are not aliases — pick by which registry
-you want.
-
-The per-bot bridge-local Skill Hub (`metabot bot-skills`) has been retired —
-all skill publishing/installing now goes through the central `metabot skills`
-surface above.
-
-## Env vars
-
-| Var | Purpose |
-|---|---|
-| `METABOT_CORE_URL` | Memory + skills + agents base URL. Default `http://localhost:9200` (locally self-hosted metabot-core); set to your own remote host if running it elsewhere. |
-| `METABOT_CORE_TOKEN` | Bearer token for member or admin access. If unset, the CLI reads the first line of `~/.metabot-core/token`. |
-| `METABOT_CORE_AGENT_BUS_URL` | Optional override for the agent-registry base URL when it diverges from `METABOT_CORE_URL` (e.g. a staging core). Falls back to `METABOT_CORE_URL`. |
-
-## Migration from `mm` / `mh` / `mb`
-
-The legacy `mm`, `mh`, and `mb` bins have all been removed. Install and
-`metabot update` actively delete any leftover binaries from `~/.local/bin/`,
-so old scripts will now hit `command not found`. Update every call site to
-the unified form:
-
-| Old | New (canonical) |
-|---|---|
-| `mm <cmd>` | `metabot memory <cmd>` |
-| `mh <cmd>` | `metabot skills <cmd>` |
-| `mb skills <cmd>` (was → `bot-skills`) | `metabot skills <cmd>` (central Skill Hub) |
-| `mb talk <bot> <chatId> "<msg>"` | `metabot talk <bot> <chatId> "<msg>"` (bridge `/api/talk`) |
-| `mb bots / schedule / voice / stats / peers / metrics / health` | `metabot <same subcommand>` |
-| (n/a) | `metabot agents talk <peer>[/<bot>] <chatId> "<msg>"` (central-registry P2P variant) |
-| (n/a) | `metabot agents list / register / heartbeat / visible / hide` (new in the agent-bus batch) |
-| (n/a) | `metabot t5t <cmd>` (new in T5T MR5) |
-
-The wire calls are identical — only the executable name changed. If
-`command -v mm`, `mh`, or `mb` still resolves on your machine, run a fresh
-`metabot update` (or `install.sh`) to scrub the stragglers.
-
-The standalone `metamemory` and `skill-hub` skill bundles were never published in this fresh metabot-core arch; the unified `metabot` skill is the single skill bundle for the whole CLI surface.
+Before runtime changes, verify the target process, cwd, ports, and package
+version. Preserve `.env`, `bots.json`, local Core data, tokens, logs, workspace
+instructions, and unrelated user changes.

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -14,9 +14,9 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0",
+    "react-router-dom": "^6.30.4",
     "marked": "^14.1.3",
-    "dompurify": "^3.2.4"
+    "dompurify": "^3.4.12"
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",

--- a/packages/web-ui/src/routes/cli-access.tsx
+++ b/packages/web-ui/src/routes/cli-access.tsx
@@ -64,7 +64,7 @@ export function CliAccess() {
             <pre className="env-block">{installCmd}</pre>
             <div className="cli-access-meta" style={{ marginBottom: 12 }}>
               <span style={{ color: 'var(--bone-300)', fontSize: 11 }}>
-                The token appears in shell history. Use a protected env file when possible; Node 20+ is required.
+                The token appears in shell history. Use a protected env file when possible; Node &gt;= 22.19 is required.
               </span>
             </div>
 

--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -37,12 +37,12 @@ export class CommandHandler {
      */
     private releaseExecutor: (chatId: string, reason: string) => Promise<void>,
     /**
-     * List the recent Claude sessions for this chat's working directory
+     * List the recent sessions for this chat's active engine and working directory
      * (newest first). Backs the direct `/resume <id>` form. Read-only.
      */
-    private listSessions: (chatId: string) => SessionSummary[],
+    private listSessions: (chatId: string) => SessionSummary[] | Promise<SessionSummary[]>,
     /**
-     * Swap the chat into a previous Claude session: re-point the sessionId,
+     * Swap the chat into a previous engine session: re-point the sessionId,
      * reset usage counters, release the persistent executor so the next turn
      * resumes via `claude --resume`. Backs both `/resume` forms.
      */
@@ -74,8 +74,8 @@ export class CommandHandler {
           '`/model` - Show current engine/model; `/model list` - Available options',
           '`/model claude`, `/model kimi`, or `/model codex` - Switch engine (resets session)',
           '`/model <name>` - Set model for current engine',
-          '`/effort low|medium|high|xhigh` - Set Codex reasoning effort for this chat',
-          '`/resume` - List & switch to a previous Claude session (Claude only)',
+          '`/effort low|medium|high|xhigh|max|ultra` - Set Codex reasoning effort for this chat',
+          '`/resume` - List & switch to a previous Claude/Codex/Kimi session',
           '`/resume <id>` - Resume a session directly by id prefix',
           '`/memory` - Memory document commands',
           '`@Bot /group-reply mention|all|status` - Feishu group reply mode (scoped to this Agent and group)',
@@ -402,12 +402,16 @@ export class CommandHandler {
         { id: 'claude-haiku-4-5', label: 'Haiku 4.5', note: 'Fastest · 200k context' },
       ];
       const kimiModels = [
-        { id: 'kimi-for-coding', label: 'Kimi for Coding', note: 'Subscription default · 256k context · thinking' },
-        { id: 'kimi-k2', label: 'Kimi K2', note: 'Legacy coding model' },
+        { id: 'kimi-code/k3', label: 'Kimi K3', note: 'Current Kimi Code subscription model' },
+        { id: 'kimi-code/kimi-for-coding-highspeed', label: 'Kimi for Coding Highspeed', note: 'Low-latency coding model when enabled for your account' },
       ];
       const codexModels = [
-        { id: 'gpt-5.5', label: 'GPT 5.5', note: 'Recommended Codex model for ChatGPT subscription users' },
-        { id: 'gpt-5.5-codex', label: 'GPT 5.5 Codex', note: 'Codex coding model, when available in your Codex account' },
+        { id: 'gpt-5.6', label: 'GPT 5.6', note: 'General GPT-5.6 Codex model' },
+        { id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', note: 'Flagship GPT-5.6 capability model' },
+        { id: 'gpt-5.6-terra', label: 'GPT 5.6 Terra', note: 'Stronger speed/cost balance for Codex workers' },
+        { id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna', note: 'Efficient high-volume Codex workloads' },
+        { id: 'gpt-5.5', label: 'GPT 5.5', note: 'Legacy Codex model' },
+        { id: 'gpt-5.5-codex', label: 'GPT 5.5 Codex', note: 'Legacy Codex coding model, when available in your account' },
         { id: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', note: 'Legacy Codex coding model' },
       ];
       const models = activeEngine === 'kimi' ? kimiModels : activeEngine === 'codex' ? codexModels : claudeModels;
@@ -434,7 +438,7 @@ export class CommandHandler {
       } else if (activeEngine === 'codex') {
         lines.push('_Tip: leave unset to use the Codex CLI default from `~/.codex/config.toml`._');
       } else {
-        lines.push('_Tip: leave unset to use the kimi-cli default (recommended for subscription users — the server picks the best available)._');
+        lines.push('_Tip: leave unset to use the Kimi Code Server default (recommended for subscription users)._');
       }
       lines.push('Use `/model <name>` to set the model for the current engine.');
       await this.sender.sendTextNotice(chatId, '🤖 Available Models', lines.join('\n'));
@@ -485,7 +489,9 @@ export class CommandHandler {
           '- `/effort low` — fastest',
           '- `/effort medium` — balanced',
           '- `/effort high` — deeper reasoning',
-          '- `/effort xhigh` — maximum Codex-supported effort',
+          '- `/effort xhigh` — extra-high reasoning',
+          '- `/effort max` — maximum reasoning depth',
+          '- `/effort ultra` — maximum reasoning with automatic task delegation',
           '- `/effort reset` — clear session override',
         ].join('\n'),
       );
@@ -496,7 +502,7 @@ export class CommandHandler {
       await this.sender.sendTextNotice(
         chatId,
         'ℹ️ Codex effort only',
-        `This chat is on \`${activeEngine}\`. Switch with \`/model codex\`, then use \`/effort high\` or \`/effort xhigh\`.`,
+        `This chat is on \`${activeEngine}\`. Switch with \`/model codex\`, then use \`/effort high\`, \`/effort max\`, or \`/effort ultra\`.`,
         'blue',
       );
       return;
@@ -517,7 +523,7 @@ export class CommandHandler {
       await this.sender.sendTextNotice(
         chatId,
         '❌ Invalid Effort',
-        'Use one of: `low`, `medium`, `high`, `xhigh`. `max` is accepted as an alias for `xhigh`.',
+        'Use one of: `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.',
         'red',
       );
       return;
@@ -533,23 +539,23 @@ export class CommandHandler {
   }
 
   /**
-   * `/resume <id-or-prefix>` — switch the chat directly into a previous Claude
+   * `/resume <id-or-prefix>` — switch the chat directly into a previous engine
    * session by (a prefix of) its session id. Bare `/resume` is intercepted by
    * the bridge picker before reaching here; we keep a usage notice as a
    * defensive fallback.
    *
-   * Gated to the Claude engine (transcripts are claude-specific) and refused
+   * Supported for Claude, Codex, and Kimi, and refused
    * while a turn is running (the swap would race the in-flight executor).
    */
   private async handleResumeCommand(msg: IncomingMessage, arg: string): Promise<void> {
     const { chatId } = msg;
     const session = this.sessionManager.getSession(chatId);
     const activeEngine = session.engine ?? resolveEngineName(this.config);
-    if (activeEngine !== 'claude') {
+    if (activeEngine !== 'claude' && activeEngine !== 'codex' && activeEngine !== 'kimi') {
       await this.sender.sendTextNotice(
         chatId,
-        '❌ /resume is Claude-only',
-        `This chat is on the \`${activeEngine}\` engine. Session resume is only available for the Claude engine.`,
+        '❌ /resume Unsupported',
+        `This chat is on the \`${activeEngine}\` engine. Session resume is available for Claude, Codex, and Kimi.`,
         'red',
       );
       return;
@@ -575,12 +581,12 @@ export class CommandHandler {
       return;
     }
 
-    const sessions = this.listSessions(chatId);
+    const sessions = await this.listSessions(chatId);
     if (sessions.length === 0) {
       await this.sender.sendTextNotice(
         chatId,
         'ℹ️ No Previous Sessions',
-        'No earlier Claude sessions were found for this chat\'s working directory.',
+        `No earlier ${activeEngine} sessions were found for this chat's working directory.`,
         'blue',
       );
       return;
@@ -635,9 +641,9 @@ export class CommandHandler {
       case 'claude':
         return '`claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`';
       case 'kimi':
-        return '`kimi-for-coding`, `kimi-k2`';
+        return '`kimi-code/k3`, `kimi-code/kimi-for-coding-highspeed`';
       case 'codex':
-        return '`gpt-5.5`, `gpt-5.5-codex`, `gpt-5.2-codex`';
+        return '`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`';
     }
   }
 
@@ -660,7 +666,13 @@ function isEngineName(value: string): value is EngineName {
 function normalizeCodexEffort(value: string): CodexReasoningEffort | 'reset' | undefined {
   const normalized = value.trim().toLowerCase();
   if (normalized === 'reset' || normalized === 'clear' || normalized === 'default') return 'reset';
-  if (normalized === 'max') return 'xhigh';
-  if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh') return normalized;
+  if (
+    normalized === 'low' ||
+    normalized === 'medium' ||
+    normalized === 'high' ||
+    normalized === 'xhigh' ||
+    normalized === 'max' ||
+    normalized === 'ultra'
+  ) return normalized;
   return undefined;
 }

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -21,6 +21,8 @@ import {
   SessionManager,
 } from '../engines/index.js';
 import { listClaudeSessions, type SessionSummary } from '../engines/claude/session-lister.js';
+import { listCodexSessions } from '../engines/codex/session-lister.js';
+import { listKimiSessions } from '../engines/kimi/session-lister.js';
 import { ExecutorRegistry } from '../engines/claude/executor-registry.js';
 import { RateLimiter } from './rate-limiter.js';
 import { OutputsManager } from './outputs-manager.js';
@@ -1260,12 +1262,28 @@ export class MessageBridge {
   }
 
   /**
-   * List the recent Claude sessions for a chat's working directory, newest
-   * first. Read-only — does not touch session state. Used by the `/resume`
-   * picker and the direct `/resume <id>` form.
+   * List recent sessions for the chat's active engine and working directory.
+   * Read-only — does not touch session state.
    */
-  listSessionsForChat(chatId: string): SessionSummary[] {
+  async listSessionsForChat(chatId: string): Promise<SessionSummary[]> {
     const session = this.sessionManager.getSession(chatId);
+    const engineName = session.engine ?? resolveEngineName(this.config);
+    if (engineName === 'codex') {
+      return listCodexSessions({
+        workingDirectory: session.workingDirectory,
+        currentSessionId: session.sessionId,
+      });
+    }
+    if (engineName === 'kimi') {
+      return listKimiSessions({
+        workingDirectory: session.workingDirectory,
+        currentSessionId: session.sessionId,
+        executable: this.config.kimi?.executable,
+        serverUrl: this.config.kimi?.serverUrl,
+        apiKey: this.config.kimi?.apiKey,
+      });
+    }
+    if (engineName !== 'claude') return [];
     return listClaudeSessions({
       workingDirectory: session.workingDirectory,
       currentSessionId: session.sessionId,
@@ -1273,7 +1291,7 @@ export class MessageBridge {
   }
 
   /**
-   * Switch a chat into a previous Claude session. Single source of truth for
+   * Switch a chat into a previous engine session. Single source of truth for
    * the `/resume` swap (both the picker and the direct form route here):
    *   1. point the chat's sessionId at the chosen transcript,
    *   2. zero the cumulative usage counters (they belonged to the old session),
@@ -1282,14 +1300,19 @@ export class MessageBridge {
    * The actual `--resume` happens lazily on the user's next message.
    */
   async applyResume(chatId: string, sessionId: string): Promise<void> {
-    this.sessionManager.setSessionId(chatId, sessionId, 'claude');
+    const session = this.sessionManager.getSession(chatId);
+    const engineName = session.engine ?? resolveEngineName(this.config);
+    this.sessionManager.setSessionId(chatId, sessionId, engineName);
     this.sessionManager.resetUsage(chatId);
     try {
       await this.releaseChatExecutor(chatId, 'resume-command');
     } catch (err) {
       this.logger.warn({ err, chatId }, 'applyResume: failed to release persistent executor');
     }
-    this.logger.info({ chatId, sessionId: sessionId.slice(0, 8) }, 'MessageBridge: resumed session');
+    this.logger.info(
+      { chatId, engine: engineName, sessionId: sessionId.slice(0, 8) },
+      'MessageBridge: resumed session',
+    );
   }
 
   /**

--- a/src/bridge/slash-picker-controller.ts
+++ b/src/bridge/slash-picker-controller.ts
@@ -13,10 +13,12 @@ const SLASH_PICKERS: Record<string, { question: string; header: string; options:
     question: 'Set the reasoning effort level',
     header: 'Effort',
     options: [
-      { label: 'xhigh', description: 'Maximum Codex-supported effort for deep agentic/coding work' },
-      { label: 'high', description: 'Complex reasoning — quality over speed/cost' },
-      { label: 'medium', description: 'Balanced speed, cost & performance (default)' },
-      { label: 'low', description: 'Fastest — high-volume / latency-sensitive work' },
+      { label: 'low', description: 'Fast responses with lighter reasoning' },
+      { label: 'medium', description: 'Balanced speed and reasoning depth for everyday tasks' },
+      { label: 'high', description: 'Greater reasoning depth for complex problems' },
+      { label: 'xhigh', description: 'Extra-high reasoning depth for complex problems' },
+      { label: 'max', description: 'Maximum reasoning depth for the hardest problems' },
+      { label: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
     ],
   },
 };
@@ -37,7 +39,7 @@ export class SlashPickerController {
       sender: IMessageSender;
       sessionManager: SessionManager;
       outputsManager: OutputsManager;
-      listSessionsForChat: (chatId: string) => SessionSummary[];
+      listSessionsForChat: (chatId: string) => SessionSummary[] | Promise<SessionSummary[]>;
       applyResume: (chatId: string, sessionId: string) => Promise<void>;
       finalizeQuestionCard: (messageId: string, state: CardState) => Promise<void>;
       handleMessage: (msg: IncomingMessage) => Promise<void>;
@@ -189,22 +191,22 @@ export class SlashPickerController {
     const { chatId } = msg;
     const session = this.deps.sessionManager.getSession(chatId);
     const activeEngine = session.engine ?? resolveEngineName(this.deps.config);
-    if (activeEngine !== 'claude') {
+    if (activeEngine !== 'claude' && activeEngine !== 'codex' && activeEngine !== 'kimi') {
       await this.deps.sender.sendTextNotice(
         chatId,
-        'ℹ️ /resume is Claude-only',
-        `This chat is on the \`${activeEngine}\` engine. Session resume is only available for the Claude engine.`,
+        'ℹ️ /resume Unsupported',
+        `This chat is on the \`${activeEngine}\` engine. Session resume is available for Claude, Codex, and Kimi.`,
         'blue',
       );
       return true;
     }
 
-    const sessions = this.deps.listSessionsForChat(chatId);
+    const sessions = await this.deps.listSessionsForChat(chatId);
     if (sessions.length === 0) {
       await this.deps.sender.sendTextNotice(
         chatId,
         'ℹ️ No Previous Sessions',
-        'No earlier Claude sessions were found for this chat\'s working directory.',
+        `No earlier ${activeEngine} sessions were found for this chat's working directory.`,
         'blue',
       );
       return true;
@@ -303,8 +305,14 @@ export class SlashPickerController {
 function normalizeCodexEffort(value: string): CodexReasoningEffort | 'reset' | undefined {
   const normalized = value.trim().toLowerCase();
   if (normalized === 'reset' || normalized === 'clear' || normalized === 'default') return 'reset';
-  if (normalized === 'max') return 'xhigh';
-  if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh') return normalized;
+  if (
+    normalized === 'low' ||
+    normalized === 'medium' ||
+    normalized === 'high' ||
+    normalized === 'xhigh' ||
+    normalized === 'max' ||
+    normalized === 'ultra'
+  ) return normalized;
   return undefined;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,23 @@ loadEnvFiles();
 
 /** Agent engine backing a bot. */
 export type EngineName = 'claude' | 'kimi' | 'codex';
-export type CodexReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type CodexReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+
+export function normalizeCodexReasoningEffort(value: unknown): CodexReasoningEffort | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === 'low' ||
+    normalized === 'medium' ||
+    normalized === 'high' ||
+    normalized === 'xhigh' ||
+    normalized === 'max' ||
+    normalized === 'ultra'
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
 
 /** Shared config fields used by MessageBridge and Executors (platform-agnostic). */
 export interface BotConfigBase {
@@ -105,7 +121,11 @@ export interface BotConfigBase {
     model?: string;
     thinking?: boolean;
     apiKey?: string;
-    /** Context window size in tokens (defaults to 262144 — Kimi for Coding default). */
+    /** Kimi tool permission policy. Defaults to safe `auto`; `yolo` must be explicit. */
+    permissionMode?: 'auto' | 'yolo';
+    /** Kimi Code local Server origin. Personal edition accepts loopback only. */
+    serverUrl?: string;
+    /** Context window size in tokens (defaults to 1M for current Kimi Code). */
     contextWindow?: number;
   };
   /** Codex-specific overrides. Populated only when engine === 'codex'. */
@@ -248,7 +268,11 @@ export interface KimiJsonConfig {
   model?: string;
   thinking?: boolean;
   apiKey?: string;
-  /** Context window size in tokens (defaults to 262144 — Kimi for Coding default). */
+  /** Kimi tool permission policy. Defaults to safe `auto`; `yolo` must be explicit. */
+  permissionMode?: 'auto' | 'yolo';
+  /** Kimi Code local Server origin. Personal edition accepts loopback only. */
+  serverUrl?: string;
+  /** Context window size in tokens (defaults to 1M for current Kimi Code). */
   contextWindow?: number;
 }
 
@@ -487,6 +511,7 @@ function buildClaudeConfig(entry: {
 }
 
 function buildCodexConfig(entry?: CodexJsonConfig): BotConfigBase['codex'] | undefined {
+  const envReasoningEffort = normalizeCodexReasoningEffort(process.env.CODEX_REASONING_EFFORT);
   const cfg: BotConfigBase['codex'] = {
     ...(process.env.CODEX_EXECUTABLE_PATH ? { executable: process.env.CODEX_EXECUTABLE_PATH } : {}),
     ...(process.env.CODEX_MODEL ? { model: process.env.CODEX_MODEL } : {}),
@@ -498,14 +523,10 @@ function buildCodexConfig(entry?: CodexJsonConfig): BotConfigBase['codex'] | und
     ...(process.env.CODEX_SANDBOX ? { sandbox: process.env.CODEX_SANDBOX as CodexJsonConfig['sandbox'] } : {}),
     ...(process.env.CODEX_BYPASS_APPROVALS_AND_SANDBOX === 'true' ? { dangerouslyBypassApprovalsAndSandbox: true } : {}),
     ...(process.env.CODEX_CONTEXT_WINDOW ? { contextWindow: parseInt(process.env.CODEX_CONTEXT_WINDOW, 10) } : {}),
-    ...(isCodexReasoningEffort(process.env.CODEX_REASONING_EFFORT) ? { reasoningEffort: process.env.CODEX_REASONING_EFFORT } : {}),
+    ...(envReasoningEffort ? { reasoningEffort: envReasoningEffort } : {}),
     ...(entry ?? {}),
   };
   return Object.keys(cfg).length > 0 ? cfg : undefined;
-}
-
-function isCodexReasoningEffort(value: unknown): value is CodexReasoningEffort {
-  return value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh';
 }
 
 // --- Single-bot env var mode ---

--- a/src/engines/claude/stream-processor.ts
+++ b/src/engines/claude/stream-processor.ts
@@ -43,6 +43,9 @@ export class StreamProcessor {
   private _lastOutputTokens: number | undefined;
   // Live background tasks (Monitor, etc.) — task_id → latest rollup.
   private _backgroundEvents: Map<string, BackgroundEvent> = new Map();
+  // Kimi/Codex snapshot adapters may repeat the same native tool id while it
+  // is running. Update that row instead of appending duplicate card entries.
+  private _nativeToolIndexes: Map<string, number> = new Map();
 
   constructor(private userPrompt: string) {}
 
@@ -181,7 +184,13 @@ export class StreamProcessor {
           this.responseText = block.text;
         }
       } else if (block.type === 'tool_use' && block.name) {
-        this.addToolCall(block.name, block.input);
+        const existingIndex = block.id ? this._nativeToolIndexes.get(block.id) : undefined;
+        if (existingIndex !== undefined) {
+          this.updateToolCall(existingIndex, block.name, block.input);
+        } else {
+          const index = this.addToolCall(block.name, block.input);
+          if (block.id) this._nativeToolIndexes.set(block.id, index);
+        }
         // Detect interactive tools at top level
         if (message.parent_tool_use_id === null || message.parent_tool_use_id === undefined) {
           if (block.name === 'AskUserQuestion' && block.id && block.input) {
@@ -305,13 +314,14 @@ export class StreamProcessor {
     };
   }
 
-  private addToolCall(name: string, input: unknown): void {
+  private addToolCall(name: string, input: unknown): number {
     // Complete previous tool
     this.completeCurrentTool();
 
     this.currentToolName = name;
     const detail = formatToolDetail(name, input);
     this.toolCalls.push({ name, detail, status: 'running' });
+    const index = this.toolCalls.length - 1;
 
     // Track image file paths and plan file paths from Write tool
     if (name === 'Write' && input && typeof input === 'object') {
@@ -323,6 +333,15 @@ export class StreamProcessor {
         this._planFilePath = filePath;
       }
     }
+    return index;
+  }
+
+  private updateToolCall(index: number, name: string, input: unknown): void {
+    const tool = this.toolCalls[index];
+    if (!tool) return;
+    tool.name = name;
+    const detail = formatToolDetail(name, input);
+    if (detail) tool.detail = detail;
   }
 
   private completeCurrentTool(): void {
@@ -442,13 +461,13 @@ function formatToolDetail(name: string, input: unknown): string {
 
   switch (name) {
     case 'Read':
-      return inp.file_path ? `\`${shortenPath(inp.file_path as string)}\`` : '';
+      return inp.file_path || inp.path ? `\`${shortenPath(String(inp.file_path ?? inp.path))}\`` : '';
     case 'Write':
-      return inp.file_path ? `\`${shortenPath(inp.file_path as string)}\`` : '';
+      return inp.file_path || inp.path ? `\`${shortenPath(String(inp.file_path ?? inp.path))}\`` : '';
     case 'Edit':
-      return inp.file_path ? `\`${shortenPath(inp.file_path as string)}\`` : '';
+      return inp.file_path || inp.path ? `\`${shortenPath(String(inp.file_path ?? inp.path))}\`` : '';
     case 'Bash':
-      return inp.command ? `\`${truncate(inp.command as string, 60)}\`` : '';
+      return inp.command || inp.cmd ? `\`${truncate(String(inp.command ?? inp.cmd), 60)}\`` : '';
     case 'Glob':
       return inp.pattern ? `\`${inp.pattern}\`` : '';
     case 'Grep':

--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -20,6 +20,7 @@ import {
 const isWindows = process.platform === 'win32';
 const FALLBACK_CODEX_CONTEXT_WINDOW = 272000;
 const CODEX_AUTH_ENV_VARS = ['OPENAI_API_KEY', 'CODEX_API_KEY', 'CODEX_ACCESS_TOKEN'];
+const CODEX_EXIT_GRACE_MS = 1000;
 
 export function resolveCodexPath(explicitPath?: string): string {
   const override = explicitPath || process.env.CODEX_EXECUTABLE_PATH;
@@ -275,7 +276,7 @@ export function buildCodexArgs(
     args.push('--dangerously-bypass-approvals-and-sandbox');
   } else {
     args.push('-a', codexConfig.approvalPolicy ?? 'never');
-    args.push('--sandbox', codexConfig.sandbox ?? 'danger-full-access');
+    args.push('--sandbox', codexConfig.sandbox ?? 'workspace-write');
   }
 
   args.push('-C', cwd);
@@ -319,13 +320,16 @@ export class CodexExecutor {
     let pendingResult: SDKMessage | undefined;
     let stderr = '';
     let stdoutBuffer = '';
+    let terminalResultDelivered = false;
+    let exitTimer: ReturnType<typeof setTimeout> | undefined;
 
     const executable = resolveCodexPath(codexConfig.executable);
     this.logger.info({ cwd, hasSession: !!sessionId, outputsDir, executable, engine: 'codex' }, 'Starting Codex execution');
 
     const finishWithError = (message: string): void => {
-      if (sawResult) return;
+      if (terminalResultDelivered) return;
       sawResult = true;
+      terminalResultDelivered = true;
       queue.enqueue({
         type: 'result',
         subtype: abortController.signal.aborted ? 'error_cancelled' : 'error_during_execution',
@@ -335,6 +339,28 @@ export class CodexExecutor {
         is_error: true,
         errors: [message],
       });
+      queue.finish();
+    };
+
+    const deliverPendingResult = (): void => {
+      if (!pendingResult || terminalResultDelivered) return;
+      terminalResultDelivered = true;
+      const snapshot = state.lastUsage
+        ? { usage: state.lastUsage, contextWindow: state.contextWindow }
+        : readLastTokenCountFromSession(state.sessionId ?? sessionId);
+      queue.enqueue(applyTokenCountSnapshot(pendingResult, snapshot));
+      queue.finish();
+
+      exitTimer = setTimeout(() => {
+        if (!child || child.exitCode !== null || child.signalCode !== null) return;
+        this.logger.warn({ pid: child.pid }, 'Codex emitted a terminal result but did not exit; terminating process');
+        child.kill('SIGTERM');
+        const killTimer = setTimeout(() => {
+          if (child && child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+        }, CODEX_EXIT_GRACE_MS);
+        killTimer.unref?.();
+      }, CODEX_EXIT_GRACE_MS);
+      exitTimer.unref?.();
     };
 
     const emitEvent = (event: CodexJsonEvent): void => {
@@ -343,6 +369,7 @@ export class CodexExecutor {
         if (message.type === 'result') {
           sawResult = true;
           pendingResult = message;
+          deliverPendingResult();
         } else {
           queue.enqueue(message);
         }
@@ -387,9 +414,9 @@ export class CodexExecutor {
       });
       child.on('error', (err) => {
         finishWithError(err.message);
-        queue.finish();
       });
       child.on('close', (code, signal) => {
+        if (exitTimer) clearTimeout(exitTimer);
         if (stdoutBuffer.trim()) {
           try {
             emitEvent(JSON.parse(stdoutBuffer) as CodexJsonEvent);
@@ -400,11 +427,8 @@ export class CodexExecutor {
         if (code !== 0 && !sawResult) {
           const suffix = stderr.trim() ? `: ${stderr.trim()}` : '';
           finishWithError(`Codex exited with ${signal ? `signal ${signal}` : `code ${code}`}${suffix}`);
-        } else if (pendingResult) {
-          const snapshot = state.lastUsage
-            ? { usage: state.lastUsage, contextWindow: state.contextWindow }
-            : readLastTokenCountFromSession(state.sessionId ?? sessionId);
-          queue.enqueue(applyTokenCountSnapshot(pendingResult, snapshot));
+        } else {
+          deliverPendingResult();
         }
         if (stderr.trim()) {
           this.logger.debug({ stderr: stderr.trim() }, 'Codex stderr');
@@ -422,6 +446,7 @@ export class CodexExecutor {
         this.logger.warn({ engine: 'codex' }, 'resolveQuestion called on Codex executor — not implemented');
       },
       finish: () => {
+        if (exitTimer) clearTimeout(exitTimer);
         if (child && !child.killed) child.kill('SIGTERM');
         queue.finish();
       },

--- a/src/engines/codex/session-lister.ts
+++ b/src/engines/codex/session-lister.ts
@@ -1,0 +1,256 @@
+/**
+ * Codex session lister -- read-only helper for the Feishu `/resume` command.
+ *
+ * Codex records resumable threads in `$CODEX_HOME/state_5.sqlite` and mirrors
+ * full transcripts under `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+ * Prefer the SQLite index because it already carries cwd/title/preview and is
+ * what `codex exec resume` uses for cwd-filtered resume discovery.
+ */
+
+import { existsSync, openSync, readSync, statSync, closeSync, readdirSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import Database from 'better-sqlite3';
+import type { SessionSummary } from '../claude/session-lister.js';
+
+interface CodexThreadRow {
+  id: string;
+  rollout_path?: string;
+  updated_at?: number;
+  updated_at_ms?: number;
+  title?: string;
+  first_user_message?: string;
+  preview?: string;
+}
+
+export function codexHomeDir(homeDir: string = os.homedir()): string {
+  return process.env.CODEX_HOME || path.join(homeDir, '.codex');
+}
+
+export function listCodexSessions(opts: {
+  workingDirectory: string;
+  currentSessionId?: string;
+  limit?: number;
+  homeDir?: string;
+  previewMaxLen?: number;
+}): SessionSummary[] {
+  const { workingDirectory, currentSessionId, limit = 10, homeDir = os.homedir(), previewMaxLen = 80 } = opts;
+
+  const codexHome = codexHomeDir(homeDir);
+  const indexed = listCodexSessionsFromStateDb({
+    codexHome,
+    workingDirectory,
+    currentSessionId,
+    limit,
+    previewMaxLen,
+  });
+  if (indexed.length > 0) return indexed;
+
+  return listCodexSessionsFromJsonl({
+    codexHome,
+    workingDirectory,
+    currentSessionId,
+    limit,
+    previewMaxLen,
+  });
+}
+
+function listCodexSessionsFromStateDb(opts: {
+  codexHome: string;
+  workingDirectory: string;
+  currentSessionId?: string;
+  limit: number;
+  previewMaxLen: number;
+}): SessionSummary[] {
+  const dbPath = path.join(opts.codexHome, 'state_5.sqlite');
+  if (!existsSync(dbPath)) return [];
+
+  let db: Database.Database | undefined;
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const rows = db
+      .prepare(
+        `
+      SELECT id, rollout_path, updated_at, updated_at_ms, title, first_user_message, preview
+      FROM threads
+      WHERE archived = 0 AND cwd = ?
+      ORDER BY COALESCE(updated_at_ms, updated_at * 1000) DESC, id DESC
+      LIMIT ?
+    `,
+      )
+      .all(path.resolve(opts.workingDirectory), opts.limit) as CodexThreadRow[];
+
+    return rows.map((row) => {
+      const filePath = row.rollout_path ? resolveRolloutPath(opts.codexHome, row.rollout_path) : undefined;
+      const stat = filePath ? safeStat(filePath) : undefined;
+      const preview = row.preview || row.first_user_message || row.title || '';
+      return {
+        sessionId: row.id,
+        preview: truncatePreview(preview, opts.previewMaxLen) || '(no preview)',
+        lastActive: (row.updated_at_ms ?? (row.updated_at ?? 0) * 1000) || stat?.mtimeMs || 0,
+        sizeBytes: stat?.size ?? 0,
+        isCurrent: row.id === opts.currentSessionId,
+      };
+    });
+  } catch {
+    return [];
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function listCodexSessionsFromJsonl(opts: {
+  codexHome: string;
+  workingDirectory: string;
+  currentSessionId?: string;
+  limit: number;
+  previewMaxLen: number;
+}): SessionSummary[] {
+  const sessionsDir = path.join(opts.codexHome, 'sessions');
+  const files = findJsonlFiles(sessionsDir);
+  const cwd = path.resolve(opts.workingDirectory);
+  const summaries: SessionSummary[] = [];
+
+  for (const filePath of files) {
+    const meta = readCodexJsonlMeta(filePath, opts.previewMaxLen);
+    if (!meta?.sessionId || path.resolve(meta.cwd || '') !== cwd) continue;
+    const stat = safeStat(filePath);
+    if (!stat) continue;
+    summaries.push({
+      sessionId: meta.sessionId,
+      preview: meta.preview || '(no preview)',
+      lastActive: stat.mtimeMs,
+      sizeBytes: stat.size,
+      isCurrent: meta.sessionId === opts.currentSessionId,
+    });
+  }
+
+  summaries.sort((a, b) => b.lastActive - a.lastActive);
+  return summaries.slice(0, opts.limit);
+}
+
+function resolveRolloutPath(codexHome: string, rolloutPath: string): string {
+  return path.isAbsolute(rolloutPath) ? rolloutPath : path.join(codexHome, rolloutPath);
+}
+
+function safeStat(filePath: string): { size: number; mtimeMs: number } | undefined {
+  try {
+    const stat = statSync(filePath);
+    return stat.isFile() ? { size: stat.size, mtimeMs: stat.mtimeMs } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findJsonlFiles(root: string): string[] {
+  const out: string[] = [];
+  try {
+    if (!existsSync(root)) return out;
+    const stack = [root];
+    while (stack.length > 0) {
+      const dir = stack.pop()!;
+      for (const entry of readdirSync(dir)) {
+        const fullPath = path.join(dir, entry);
+        const stat = safeDirOrFileStat(fullPath);
+        if (!stat) continue;
+        if (stat.isDirectory) stack.push(fullPath);
+        else if (entry.endsWith('.jsonl')) out.push(fullPath);
+      }
+    }
+  } catch {
+    return out;
+  }
+  return out;
+}
+
+function safeDirOrFileStat(filePath: string): { isDirectory: boolean } | undefined {
+  try {
+    const stat = statSync(filePath);
+    return { isDirectory: stat.isDirectory() };
+  } catch {
+    return undefined;
+  }
+}
+
+function readCodexJsonlMeta(
+  filePath: string,
+  previewMaxLen: number,
+): { sessionId?: string; cwd?: string; preview?: string } | undefined {
+  const CHUNK = 64 * 1024;
+  let fd: number | undefined;
+  let buffered = '';
+  let offset = 0;
+  let sessionId: string | undefined;
+  let cwd: string | undefined;
+  let preview: string | undefined;
+
+  try {
+    fd = openSync(filePath, 'r');
+    const buf = Buffer.alloc(CHUNK);
+    let scanned = 0;
+    while (scanned < 8 * CHUNK) {
+      const bytes = readSync(fd, buf, 0, CHUNK, offset);
+      if (bytes <= 0) break;
+      offset += bytes;
+      scanned += bytes;
+      buffered += buf.toString('utf8', 0, bytes);
+      const lines = buffered.split('\n');
+      buffered = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const rec = parseJson(line);
+        if (!rec) continue;
+        if (rec.type === 'session_meta') {
+          sessionId = typeof rec.payload?.id === 'string' ? rec.payload.id : sessionId;
+          cwd = typeof rec.payload?.cwd === 'string' ? rec.payload.cwd : cwd;
+        }
+        preview = preview || extractCodexUserPreview(rec, previewMaxLen);
+        if (sessionId && cwd && preview) return { sessionId, cwd, preview };
+      }
+      if (bytes < CHUNK) break;
+    }
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return sessionId || cwd || preview ? { sessionId, cwd, preview } : undefined;
+}
+
+function parseJson(line: string): any | undefined {
+  try {
+    const trimmed = line.trim();
+    return trimmed ? JSON.parse(trimmed) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractCodexUserPreview(rec: any, previewMaxLen: number): string | undefined {
+  if (rec.type === 'event_msg' && rec.payload?.type === 'user_message' && typeof rec.payload.message === 'string') {
+    return truncatePreview(rec.payload.message, previewMaxLen);
+  }
+  if (rec.type === 'response_item' && rec.payload?.role === 'user') {
+    const content = rec.payload.content;
+    if (Array.isArray(content)) {
+      const text = content.find((item: any) => item?.type === 'input_text' && typeof item.text === 'string')?.text;
+      if (text) return truncatePreview(text, previewMaxLen);
+    }
+  }
+  return undefined;
+}
+
+function truncatePreview(text: string, previewMaxLen: number): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  return collapsed.length > previewMaxLen ? collapsed.slice(0, previewMaxLen) + '...' : collapsed;
+}

--- a/src/engines/kimi/daemon-client.ts
+++ b/src/engines/kimi/daemon-client.ts
@@ -1,0 +1,475 @@
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_ORIGIN = 'http://127.0.0.1:58627';
+const START_TIMEOUT_MS = 15_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+interface KimiEnvelope<T> {
+  code: number;
+  msg: string;
+  data: T | null;
+  request_id?: string;
+  details?: unknown;
+}
+
+export interface KimiWireUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_cost_usd: number;
+  context_tokens: number;
+  context_limit: number;
+  turn_count: number;
+}
+
+export type KimiWireMessageContent =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string; signature?: string }
+  | { type: 'tool_use'; tool_call_id: string; tool_name: string; input: unknown }
+  | { type: 'tool_result'; tool_call_id: string; output: unknown; is_error?: boolean }
+  | { type: string; [key: string]: unknown };
+
+export interface KimiWireMessage {
+  id: string;
+  session_id: string;
+  role: 'user' | 'assistant' | 'tool' | 'system';
+  content: KimiWireMessageContent[];
+  created_at: string;
+  prompt_id?: string;
+}
+
+export interface KimiWireSession {
+  id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+  busy: boolean;
+  main_turn_active?: boolean;
+  pending_interaction?: 'none' | 'approval' | 'question';
+  last_turn_reason?: 'completed' | 'cancelled' | 'failed';
+  current_prompt_id?: string;
+  last_prompt?: string;
+  metadata: { cwd?: string; [key: string]: unknown };
+  agent_config: { model?: string; [key: string]: unknown };
+  usage: KimiWireUsage;
+}
+
+export interface KimiInFlightTool {
+  tool_call_id: string;
+  name: string;
+  args?: unknown;
+  description?: string;
+  last_progress?: { kind: string; text?: string; percent?: number };
+}
+
+export interface KimiPendingQuestion {
+  question_id: string;
+  session_id: string;
+  turn_id?: number;
+  tool_call_id?: string;
+  questions: Array<{
+    id: string;
+    question: string;
+    header?: string;
+    body?: string;
+    options: Array<{ id: string; label: string; description?: string }>;
+    multi_select?: boolean;
+    allow_other?: boolean;
+  }>;
+}
+
+export interface KimiPendingApproval {
+  approval_id: string;
+  session_id: string;
+  tool_call_id: string;
+  tool_name: string;
+}
+
+export interface KimiSubagentTask {
+  id: string;
+  session_id: string;
+  description: string;
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
+  output_preview?: string;
+  subagent_phase?: 'queued' | 'working' | 'suspended' | 'completed' | 'failed';
+  subagent_type?: string;
+}
+
+export interface KimiSessionSnapshot {
+  as_of_seq: number;
+  epoch: string;
+  session: KimiWireSession;
+  messages: { items: KimiWireMessage[]; has_more: boolean };
+  in_flight_turn: {
+    turn_id: number;
+    assistant_text: string;
+    thinking_text: string;
+    running_tools: KimiInFlightTool[];
+    current_prompt_id?: string;
+  } | null;
+  subagents?: KimiSubagentTask[];
+  pending_approvals: KimiPendingApproval[];
+  pending_questions: KimiPendingQuestion[];
+}
+
+export interface KimiSessionStatus {
+  busy: boolean;
+  model?: string;
+  thinking_level: string;
+  permission: string;
+  context_tokens: number;
+  max_context_tokens: number;
+  context_usage: number;
+}
+
+export interface KimiPromptResult {
+  prompt_id: string;
+  user_message_id: string;
+  status: 'running' | 'queued' | 'blocked';
+}
+
+export type KimiPermissionMode = 'auto' | 'yolo';
+
+export interface KimiDaemonClientOptions {
+  executable?: string;
+  serverUrl?: string;
+  apiKey?: string;
+}
+
+export class KimiDaemonError extends Error {
+  constructor(
+    message: string,
+    readonly code?: number,
+    readonly requestId?: string,
+  ) {
+    super(message);
+    this.name = 'KimiDaemonError';
+  }
+}
+
+/**
+ * Minimal first-party Kimi Code Server client for the Feishu bridge.
+ *
+ * Kimi Code 0.27 replaced the legacy `--wire --work-dir` protocol with its
+ * local REST/WS frontend server. Feishu cards update far less frequently than
+ * model token deltas, so an atomic `/snapshot` poll gives us reliable text,
+ * tool, question, subagent, and completion state while the REST prompt queue
+ * provides native mid-turn steering.
+ */
+export class KimiDaemonClient {
+  private static readonly starts = new Map<string, Promise<void>>();
+
+  readonly origin: string;
+  private readonly executable: string;
+  private readonly apiKey?: string;
+  private ready = false;
+
+  constructor(options: KimiDaemonClientOptions = {}) {
+    this.origin = normalizeOrigin(options.serverUrl ?? process.env.KIMI_CODE_SERVER_URL ?? DEFAULT_ORIGIN);
+    const hostname = new URL(this.origin).hostname;
+    if (!isLoopbackHostname(hostname)) {
+      throw new KimiDaemonError(`Personal edition only connects to a loopback Kimi Code server; got ${this.origin}`);
+    }
+    this.executable = options.executable ?? 'kimi';
+    this.apiKey = options.apiKey;
+  }
+
+  async ensureRunning(): Promise<void> {
+    if (this.ready) return;
+    if (await this.probe()) {
+      this.ready = true;
+      return;
+    }
+    const existing = KimiDaemonClient.starts.get(this.origin);
+    if (existing) {
+      await existing;
+      this.ready = true;
+      return;
+    }
+    const start = this.startLocalServer().finally(() => KimiDaemonClient.starts.delete(this.origin));
+    KimiDaemonClient.starts.set(this.origin, start);
+    await start;
+    this.ready = true;
+  }
+
+  async getSession(sessionId: string): Promise<KimiWireSession> {
+    return this.request(`/sessions/${encodeURIComponent(sessionId)}`);
+  }
+
+  async createSession(cwd: string, model?: string): Promise<KimiWireSession> {
+    return this.request('/sessions', {
+      title: path.basename(cwd) || 'MetaBot Kimi session',
+      metadata: { cwd },
+      ...(model ? { agent_config: { model } } : {}),
+    });
+  }
+
+  async openSession(cwd: string, sessionId?: string, model?: string): Promise<KimiWireSession> {
+    await this.ensureRunning();
+    if (sessionId) return this.getSession(sessionId);
+    return this.createSession(cwd, model);
+  }
+
+  async listSessions(cwd?: string): Promise<KimiWireSession[]> {
+    await this.ensureRunning();
+    const page = await this.request<{ items: KimiWireSession[]; has_more: boolean }>('/sessions', undefined, {
+      page_size: 100,
+      include_archive: false,
+      exclude_empty: false,
+    });
+    return cwd ? page.items.filter((session) => session.metadata?.cwd === cwd) : page.items;
+  }
+
+  async getSnapshot(sessionId: string): Promise<KimiSessionSnapshot> {
+    return this.request(`/sessions/${encodeURIComponent(sessionId)}/snapshot`);
+  }
+
+  async getStatus(sessionId: string): Promise<KimiSessionStatus> {
+    return this.request(`/sessions/${encodeURIComponent(sessionId)}/status`);
+  }
+
+  async getGoal(sessionId: string): Promise<Record<string, unknown> | null> {
+    return this.request(`/sessions/${encodeURIComponent(sessionId)}/goal`);
+  }
+
+  async submitPrompt(
+    sessionId: string,
+    text: string,
+    options: {
+      model?: string;
+      thinking?: string;
+      goalObjective?: string;
+      permissionMode?: KimiPermissionMode;
+    } = {},
+  ): Promise<KimiPromptResult> {
+    return this.request(`/sessions/${encodeURIComponent(sessionId)}/prompts`, {
+      content: [{ type: 'text', text }],
+      permission_mode: options.permissionMode ?? 'auto',
+      ...(options.model ? { model: options.model } : {}),
+      ...(options.thinking ? { thinking: options.thinking } : {}),
+      ...(options.goalObjective ? { goal_objective: options.goalObjective } : {}),
+    });
+  }
+
+  async steer(sessionId: string, text: string, options: { model?: string; thinking?: string } = {}): Promise<void> {
+    const queued = await this.submitPrompt(sessionId, text, options);
+    // If the active turn ended in the submission race, Kimi starts this as a
+    // normal follow-up in the same Session. Otherwise merge the queued prompt
+    // into the active turn, matching the Kimi TUI's Ctrl+S behavior.
+    if (queued.status !== 'queued') return;
+    await this.request(`/sessions/${encodeURIComponent(sessionId)}/prompts:steer`, {
+      prompt_ids: [queued.prompt_id],
+    });
+  }
+
+  async abortSession(sessionId: string): Promise<void> {
+    await this.request(`/sessions/${encodeURIComponent(sessionId)}:abort`, {});
+  }
+
+  async setGoal(sessionId: string, objective: string): Promise<void> {
+    await this.request(`/sessions/${encodeURIComponent(sessionId)}/profile`, {
+      agent_config: { goal_objective: objective },
+    });
+  }
+
+  async controlGoal(sessionId: string, action: 'pause' | 'resume' | 'cancel'): Promise<void> {
+    await this.request(`/sessions/${encodeURIComponent(sessionId)}/profile`, {
+      agent_config: { goal_control: action },
+    });
+  }
+
+  async approve(sessionId: string, approvalId: string): Promise<void> {
+    await this.request(`/sessions/${encodeURIComponent(sessionId)}/approvals/${encodeURIComponent(approvalId)}`, {
+      decision: 'approved',
+      scope: 'session',
+    });
+  }
+
+  async respondQuestion(
+    sessionId: string,
+    question: KimiPendingQuestion,
+    answers: Record<string, string>,
+  ): Promise<void> {
+    const wireAnswers: Record<string, unknown> = {};
+    for (const item of question.questions) {
+      const raw = answers[item.question] ?? answers[item.id] ?? answers._answer ?? answers._auto ?? '';
+      const labels = raw
+        .split(/[,，\n]/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+      const selected = labels.flatMap((label) => item.options.filter((option) => option.label === label));
+      if (item.multi_select && selected.length > 0) {
+        wireAnswers[item.id] = { kind: 'multi', option_ids: selected.map((option) => option.id) };
+      } else if (selected[0]) {
+        wireAnswers[item.id] = { kind: 'single', option_id: selected[0].id };
+      } else if (raw) {
+        wireAnswers[item.id] = { kind: 'other', text: raw };
+      } else {
+        wireAnswers[item.id] = { kind: 'skipped' };
+      }
+    }
+    await this.request(
+      `/sessions/${encodeURIComponent(sessionId)}/questions/${encodeURIComponent(question.question_id)}`,
+      { answers: wireAnswers, method: 'click' },
+    );
+  }
+
+  /** Resolve a configured short model name against Kimi Code's current config. */
+  async resolveModel(configured?: string): Promise<{ id: string; displayName: string }> {
+    const config = await this.readConfig();
+    const aliases = [...config.matchAll(/^\[models\."([^"]+)"\]/gm)].map((match) => match[1]);
+    const defaultModel = config.match(/^default_model\s*=\s*"([^"]+)"/m)?.[1];
+    const requested = configured?.trim();
+    const id =
+      (requested && aliases.find((alias) => alias === requested || alias.endsWith(`/${requested}`))) ||
+      requested ||
+      defaultModel ||
+      aliases[0] ||
+      'kimi-code/k3';
+    return { id, displayName: modelDisplayName(config, id) ?? id.split('/').at(-1) ?? id };
+  }
+
+  private async request<T>(
+    resource: string,
+    body?: unknown,
+    query?: Record<string, string | number | boolean>,
+  ): Promise<T> {
+    await this.ensureRunning();
+    try {
+      return await this.rawRequest(resource, body, query);
+    } catch (error) {
+      // Recover once from a daemon restart or half-open local connection. API
+      // validation/provider errors carry a numeric code and must not restart.
+      if (!(error instanceof KimiDaemonError) || error.code !== undefined) throw error;
+      this.ready = false;
+      await this.ensureRunning();
+      return this.rawRequest(resource, body, query);
+    }
+  }
+
+  private async rawRequest<T>(
+    resource: string,
+    body?: unknown,
+    query?: Record<string, string | number | boolean>,
+  ): Promise<T> {
+    const url = new URL(`${this.origin}/api/v1${resource.startsWith('/') ? resource : `/${resource}`}`);
+    for (const [key, value] of Object.entries(query ?? {})) url.searchParams.set(key, String(value));
+    const token = await this.readToken();
+    const headers: Record<string, string> = {
+      'X-Kimi-Client-Id': 'metabot-feishu',
+      'X-Kimi-Client-Name': 'MetaBot',
+      'X-Kimi-Client-Version': '2',
+      'X-Kimi-Client-Ui-Mode': 'bridge',
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (body !== undefined) headers['Content-Type'] = 'application/json; charset=utf-8';
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: body === undefined ? 'GET' : 'POST',
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (error) {
+      throw new KimiDaemonError(
+        `Kimi Code server request failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    let envelope: KimiEnvelope<T>;
+    try {
+      envelope = (await response.json()) as KimiEnvelope<T>;
+    } catch {
+      throw new KimiDaemonError(`Kimi Code server returned invalid JSON (HTTP ${response.status})`);
+    }
+    if (!response.ok || envelope.code !== 0) {
+      throw new KimiDaemonError(
+        envelope.msg || `Kimi Code server HTTP ${response.status}`,
+        envelope.code,
+        envelope.request_id,
+      );
+    }
+    return envelope.data as T;
+  }
+
+  private async probe(): Promise<boolean> {
+    try {
+      await this.rawRequest('/healthz');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async startLocalServer(): Promise<void> {
+    const url = new URL(this.origin);
+    if (!isLoopbackHostname(url.hostname)) {
+      throw new KimiDaemonError(`Kimi Code server is unavailable at ${this.origin}`);
+    }
+    const args = ['server', 'run', '--port', url.port || '58627', '--keep-alive'];
+    const child = spawn(this.executable, args, {
+      env: { ...process.env, ...(this.apiKey ? { KIMI_API_KEY: this.apiKey } : {}) },
+      stdio: 'ignore',
+      detached: true,
+    });
+    let spawnFailure: Error | undefined;
+    child.once('error', (error) => {
+      spawnFailure = error;
+    });
+    child.unref();
+    const deadline = Date.now() + START_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (spawnFailure) throw new KimiDaemonError(`Failed to start Kimi Code: ${spawnFailure.message}`);
+      if (await this.probe()) return;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    throw new KimiDaemonError(`Timed out starting Kimi Code server at ${this.origin}`);
+  }
+
+  private async readToken(): Promise<string | undefined> {
+    try {
+      const value = await readFile(path.join(kimiHome(), 'server.token'), 'utf8');
+      return value.trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async readConfig(): Promise<string> {
+    try {
+      return await readFile(path.join(kimiHome(), 'config.toml'), 'utf8');
+    } catch {
+      return '';
+    }
+  }
+}
+
+function kimiHome(): string {
+  return process.env.KIMI_CODE_HOME || path.join(os.homedir(), '.kimi-code');
+}
+
+function normalizeOrigin(value: string): string {
+  const url = new URL(value);
+  url.pathname = url.pathname.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/$/, '');
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1' || hostname === '[::1]';
+}
+
+function modelDisplayName(config: string, modelId: string): string | undefined {
+  const header = `[models."${modelId}"]`;
+  const start = config.indexOf(header);
+  if (start < 0) return undefined;
+  const rest = config.slice(start + header.length);
+  const nextSection = rest.search(/^\[/m);
+  const body = nextSection >= 0 ? rest.slice(0, nextSection) : rest;
+  return body.match(/^\s*display_name\s*=\s*"([^"]+)"/m)?.[1];
+}

--- a/src/engines/kimi/executor.ts
+++ b/src/engines/kimi/executor.ts
@@ -1,248 +1,313 @@
-import { readFileSync } from 'node:fs';
-import { createSession, isLoggedIn, KimiPaths, parseConfig } from '@moonshot-ai/kimi-agent-sdk';
-import type { Session, Turn, StreamEvent, RunResult } from '@moonshot-ai/kimi-agent-sdk';
 import type { BotConfigBase } from '../../config.js';
 import type { Logger } from '../../utils/logger.js';
-import type {
-  ApiContext,
-  ExecutionHandle,
-  ExecutorOptions,
-  SDKMessage,
-} from '../claude/executor.js';
+import type { ApiContext, ExecutionHandle, ExecutorOptions, SDKMessage } from '../claude/executor.js';
+import {
+  KimiDaemonClient,
+  type KimiPendingQuestion,
+  type KimiPermissionMode,
+  type KimiSessionSnapshot,
+  type KimiSessionStatus,
+  type KimiSubagentTask,
+  type KimiWireMessage,
+} from './daemon-client.js';
+
+const SNAPSHOT_POLL_MS = 350;
+
+export interface KimiClientLike {
+  resolveModel(configured?: string): Promise<{ id: string; displayName: string }>;
+  openSession(cwd: string, sessionId?: string, model?: string): Promise<{ id: string }>;
+  getSnapshot(sessionId: string): Promise<KimiSessionSnapshot>;
+  getStatus(sessionId: string): Promise<KimiSessionStatus>;
+  getGoal(sessionId: string): Promise<Record<string, unknown> | null>;
+  submitPrompt(
+    sessionId: string,
+    text: string,
+    options?: { model?: string; thinking?: string; goalObjective?: string; permissionMode?: KimiPermissionMode },
+  ): Promise<{ prompt_id: string; status: 'running' | 'queued' | 'blocked' }>;
+  steer(sessionId: string, text: string, options?: { model?: string; thinking?: string }): Promise<void>;
+  abortSession(sessionId: string): Promise<void>;
+  setGoal(sessionId: string, objective: string): Promise<void>;
+  controlGoal(sessionId: string, action: 'pause' | 'resume' | 'cancel'): Promise<void>;
+  approve(sessionId: string, approvalId: string): Promise<void>;
+  respondQuestion(sessionId: string, question: KimiPendingQuestion, answers: Record<string, string>): Promise<void>;
+}
+
+interface ActiveKimiTurn {
+  sessionId?: string;
+  model?: string;
+  thinking?: string;
+  pendingSteers: number;
+  ready: Promise<void>;
+  resolveReady: () => void;
+  rejectReady: (error: unknown) => void;
+}
+
+interface KimiTurnState {
+  sessionId: string;
+  model: string;
+  contextWindow: number;
+  startTime: number;
+  baselineMessageIds: Set<string>;
+  emittedText: string;
+  toolInputs: Map<string, string>;
+  completedTools: Set<string>;
+  pendingQuestions: Map<string, KimiPendingQuestion>;
+  emittedQuestions: Set<string>;
+  approvedRequests: Set<string>;
+  subagentStates: Map<string, string>;
+  lastSnapshot?: KimiSessionSnapshot;
+}
 
 /**
- * Executor that drives `@moonshot-ai/kimi-agent-sdk` and translates its
- * event stream into Claude-shaped `SDKMessage` objects, so that the existing
- * `StreamProcessor` (which understands Claude's event shape) can render
- * Kimi sessions as Feishu cards without further changes.
+ * Kimi Code 0.27 executor backed by the official local Server API.
  *
- * Mapping (Kimi event → emitted SDKMessage):
- *   TurnBegin                      → system/init (carries session_id)
- *   ContentPart{type:'text'}       → stream_event(content_block_delta text_delta)
- *                                   + final assistant/text block when turn ends
- *   ContentPart{type:'think'}      → skipped (no equivalent card rendering yet)
- *   ToolCall                       → assistant/tool_use block
- *   ToolResult                     → user/tool_result block
- *   StatusUpdate                   → tracked locally for token usage
- *   TurnEnd + awaited RunResult    → result/success (or error for cancelled)
- *
- * Auth: the Kimi SDK spawns the `kimi` CLI which inherits OAuth tokens from
- * `~/.kimi/config.toml`. We pre-flight with `isLoggedIn()` and throw a clear
- * error if the user hasn't logged in — mirroring the Claude "run `claude login`"
- * troubleshooting path.
+ * This is the same frontend contract used by Kimi's own web UI. It gives the
+ * Feishu bridge durable Sessions, atomic live snapshots, native prompt queue
+ * steering, questions, cancellation, usage, and subagent activity without a
+ * bespoke runner or a long-lived per-chat process.
  */
 export class KimiExecutor {
-  constructor(
-    private config: BotConfigBase,
-    private logger: Logger,
-  ) {}
+  private readonly client: KimiClientLike;
+  private readonly activeTurns = new Map<string, ActiveKimiTurn>();
 
-  /**
-   * Pre-flight auth check. Runs once per executor construction.
-   * Using `isLoggedIn()` from the Kimi SDK which checks `~/.kimi/config.toml`.
-   */
-  private assertLoggedIn(): void {
-    try {
-      if (!isLoggedIn()) {
-        throw new Error(
-          'Kimi CLI is not logged in. Run `kimi login` in a separate terminal ' +
-          'to authenticate with your Moonshot subscription, then restart MetaBot.'
-        );
-      }
-    } catch (err: any) {
-      if (err.message?.includes('Kimi CLI is not logged in')) throw err;
-      this.logger.warn({ err }, 'Kimi isLoggedIn() check failed — continuing and letting SDK surface the real error');
-    }
+  constructor(
+    private readonly config: BotConfigBase,
+    private readonly logger: Logger,
+    client?: KimiClientLike,
+  ) {
+    this.client =
+      client ??
+      new KimiDaemonClient({
+        executable: config.kimi?.executable,
+        serverUrl: config.kimi?.serverUrl,
+        apiKey: config.kimi?.apiKey,
+      });
   }
 
   startExecution(options: ExecutorOptions): ExecutionHandle {
     const { prompt, cwd, sessionId, abortController, outputsDir, apiContext } = options;
-
-    this.assertLoggedIn();
-
-    this.logger.info(
-      { cwd, hasSession: !!sessionId, outputsDir, engine: 'kimi' },
-      'Starting Kimi execution (multi-turn)',
-    );
-
-    const session = this.createKimiSession(cwd, sessionId, options);
-
-    // The Kimi SDK has no `systemPrompt.append` equivalent. We prepend the
-    // MetaBot context (outputs directory, bot identity, group membership)
-    // to the user's message so Kimi bots receive the same instructions
-    // Claude bots do.
-    const fullPrompt = this.buildPromptWithContext(prompt, outputsDir, apiContext);
-    const turn: Turn = session.prompt(fullPrompt);
-
-    // Wire abort signal → turn.interrupt(). Kimi's SDK doesn't accept an
-    // AbortSignal directly, so we forward cancellation manually.
-    if (abortController.signal.aborted) {
-      turn.interrupt().catch(() => { /* already aborting */ });
-    } else {
-      abortController.signal.addEventListener(
-        'abort',
-        () => {
-          this.logger.info({ sessionId: session.sessionId }, 'Kimi turn aborted via signal');
-          turn.interrupt().catch((err) => this.logger.warn({ err }, 'turn.interrupt() rejected'));
-        },
-        { once: true },
-      );
-    }
-
-    // Local state used when accumulating deltas for the final assistant message
-    const kimiOpts = this.config.kimi ?? {};
-    const rawModel = session.model ?? options.model ?? kimiOpts.model ?? this.resolveDefaultModel();
-    const state: TurnState = {
-      sessionId: session.sessionId,
-      accumulatedText: '',
-      openToolCalls: new Map(),
-      startTime: Date.now(),
-      // Use the user-facing display name when available (e.g. "Kimi-k2.6"
-      // instead of "kimi-for-coding") so the Feishu card footer matches what
-      // users see in the Kimi CLI.
-      model: this.resolveDisplayName(rawModel) ?? rawModel,
-      // Kimi for Coding ships with a 256k context window. Override per-bot via
-      // `kimi.contextWindow` in bots.json if you're on a different model.
-      contextWindow: kimiOpts.contextWindow ?? 262144,
+    const turnKey = apiContext?.chatId ?? sessionId ?? `kimi:${Date.now()}`;
+    let resolveReady!: () => void;
+    let rejectReady!: (error: unknown) => void;
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    // A failed launch may have no steering waiter. Mark the rejection handled
+    // while preserving it for callers that do await active.ready.
+    void ready.catch(() => undefined);
+    const active: ActiveKimiTurn = {
+      pendingSteers: 0,
+      ready,
+      resolveReady,
+      rejectReady,
     };
+    this.activeTurns.set(turnKey, active);
 
+    const abort = () => {
+      const sid = active.sessionId;
+      if (sid) {
+        void this.client
+          .abortSession(sid)
+          .catch((error) =>
+            this.logger.warn({ error, sessionId: sid, engine: 'kimi' }, 'Failed to abort Kimi session'),
+          );
+      }
+    };
+    if (abortController.signal.aborted) abort();
+    else abortController.signal.addEventListener('abort', abort, { once: true });
+
+    const client = this.client;
+    const config = this.config;
     const logger = this.logger;
-
-    async function* wrapStream(): AsyncGenerator<SDKMessage> {
-      // Emit a synthetic init message so StreamProcessor captures session_id
-      yield {
-        type: 'system',
-        subtype: 'init',
-        session_id: state.sessionId,
-      };
-
+    const activeTurns = this.activeTurns;
+    const buildPromptWithContext = this.buildPromptWithContext.bind(this);
+    const resolveQuestion = this.resolveQuestion.bind(this);
+    let turnState: KimiTurnState | undefined;
+    async function* stream(): AsyncGenerator<SDKMessage> {
       try {
-        for await (const event of turn) {
-          const emitted = translateEvent(event, state, logger);
-          for (const msg of emitted) yield msg;
+        const model = await client.resolveModel(options.model ?? config.kimi?.model);
+        const session = await client.openSession(cwd, sessionId, model.id);
+        active.sessionId = session.id;
+        active.model = model.id;
+        active.thinking = config.kimi?.thinking === undefined ? undefined : config.kimi.thinking ? 'high' : 'off';
+
+        const initial = await client.getSnapshot(session.id);
+        turnState = {
+          sessionId: session.id,
+          model: model.displayName,
+          contextWindow: config.kimi?.contextWindow ?? 1_048_576,
+          startTime: Date.now(),
+          baselineMessageIds: new Set(initial.messages.items.map((message) => message.id)),
+          emittedText: '',
+          toolInputs: new Map(),
+          completedTools: new Set(),
+          pendingQuestions: new Map(),
+          emittedQuestions: new Set(),
+          approvedRequests: new Set(),
+          subagentStates: new Map(),
+        };
+        const state = turnState;
+
+        yield { type: 'system', subtype: 'init', session_id: session.id };
+
+        if (abortController.signal.aborted) {
+          await client.abortSession(session.id).catch(() => undefined);
+          throw abortError();
         }
 
-        // Turn iterator finished — await the RunResult for final status
-        const result: RunResult = await turn.result;
-        yield buildResultMessage(result, state);
-      } catch (err: any) {
-        if (abortController.signal.aborted || err?.name === 'AbortError') {
-          logger.info({ sessionId: state.sessionId }, 'Kimi execution aborted');
-          // Emit a cancelled-style result so the bridge still closes the card
+        const goal = parseGoalCommand(prompt);
+        if (goal.kind === 'control') {
+          await client.controlGoal(session.id, goal.action);
+          const result = goal.action === 'cancel' ? 'Goal cancelled.' : `Goal ${goal.action}d.`;
+          active.resolveReady();
+          yield localResult(session.id, state, result);
+          return;
+        }
+        if (goal.kind === 'status') {
+          const current = await client.getGoal(session.id);
+          const text = current ? formatGoalStatus(current) : 'No active Kimi goal.';
+          active.resolveReady();
+          yield localResult(session.id, state, text);
+          return;
+        }
+        if (goal.kind === 'start') await client.setGoal(session.id, goal.objective);
+
+        const fullPrompt = buildPromptWithContext(
+          goal.kind === 'start' ? goal.objective : prompt,
+          outputsDir,
+          apiContext,
+        );
+        const submitted = await client.submitPrompt(session.id, fullPrompt, {
+          model: model.id,
+          thinking: active.thinking,
+          permissionMode: config.kimi?.permissionMode ?? 'auto',
+        });
+        if (submitted.status === 'blocked') throw new Error('Kimi Code blocked the prompt before execution');
+        active.resolveReady();
+
+        for (;;) {
+          const snapshot = await client.getSnapshot(session.id);
+          state.lastSnapshot = snapshot;
+
+          if (snapshot.pending_approvals.length > 0) {
+            if (config.kimi?.permissionMode === 'yolo') {
+              for (const approval of snapshot.pending_approvals) {
+                if (state.approvedRequests.has(approval.approval_id)) continue;
+                state.approvedRequests.add(approval.approval_id);
+                await client.approve(session.id, approval.approval_id);
+              }
+            } else {
+              await client.abortSession(session.id).catch(() => undefined);
+              throw new Error(
+                'Kimi Code requested a tool approval that MetaBot did not auto-approve. ' +
+                'Run the action directly in Kimi Code, or explicitly set kimi.permissionMode to "yolo" only for a trusted workspace.',
+              );
+            }
+          }
+
+          for (const message of translateSnapshot(snapshot, state)) yield message;
+
+          if (
+            !snapshot.session.busy &&
+            snapshot.in_flight_turn === null &&
+            snapshot.pending_questions.length === 0 &&
+            active.pendingSteers === 0
+          ) {
+            break;
+          }
+          if (abortController.signal.aborted && !snapshot.session.busy) break;
+          await sleep(SNAPSHOT_POLL_MS);
+        }
+
+        const status = await client.getStatus(session.id).catch(() => undefined);
+        if (status) {
+          state.contextWindow = status.max_context_tokens || state.contextWindow;
+          if (status.model) state.model = status.model;
+        }
+        yield buildResult(state, status, abortController.signal.aborted);
+      } catch (error) {
+        active.rejectReady(error);
+        if (abortController.signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
           yield {
             type: 'result',
             subtype: 'error_cancelled',
-            session_id: state.sessionId,
-            duration_ms: Date.now() - state.startTime,
+            session_id: turnState?.sessionId ?? sessionId,
+            duration_ms: turnState ? Date.now() - turnState.startTime : 0,
             is_error: true,
             errors: ['Aborted by user'],
           };
-          return;
+        } else {
+          logger.error({ error, engine: 'kimi', cwd }, 'Kimi Code execution failed');
+          yield {
+            type: 'result',
+            subtype: 'error_during_execution',
+            session_id: turnState?.sessionId ?? sessionId,
+            duration_ms: turnState ? Date.now() - turnState.startTime : 0,
+            is_error: true,
+            errors: [error instanceof Error ? error.message : String(error)],
+          };
         }
-        logger.error({ err, sessionId: state.sessionId }, 'Kimi execution failed');
-        yield {
-          type: 'result',
-          subtype: 'error_during_execution',
-          session_id: state.sessionId,
-          duration_ms: Date.now() - state.startTime,
-          is_error: true,
-          errors: [err?.message || String(err)],
-        };
       } finally {
-        // Always close the Kimi session — sessionId is persisted on disk so
-        // the next turn resumes by passing the same sessionId.
-        try {
-          await session.close();
-        } catch (err) {
-          logger.warn({ err, sessionId: state.sessionId }, 'Failed to close Kimi session');
-        }
+        abortController.signal.removeEventListener('abort', abort);
+        if (activeTurns.get(turnKey) === active) activeTurns.delete(turnKey);
       }
     }
 
     return {
-      stream: wrapStream(),
-      sendAnswer: (_toolUseId: string, _sid: string, _answerText: string) => {
-        // Kimi uses `turn.respondQuestion(...)` for QuestionRequest events.
-        // Phase 2 MVP: AskUserQuestion is not yet wired through for Kimi.
-        // Log and no-op so the bridge doesn't crash.
-        logger.warn({ engine: 'kimi' }, 'sendAnswer called on Kimi executor — not yet implemented');
+      stream: stream(),
+      sendAnswer: (toolUseId: string, _sid: string, answerText: string) => {
+        const question = turnState?.pendingQuestions.get(toolUseId);
+        if (!question || !active.sessionId) return;
+        const answers = Object.fromEntries(question.questions.map((item) => [item.question, answerText]));
+        void resolveQuestion(active.sessionId, question, answers);
       },
-      resolveQuestion: (_toolUseId: string, _answers: Record<string, string>) => {
-        logger.warn({ engine: 'kimi' }, 'resolveQuestion called on Kimi executor — not yet implemented');
+      resolveQuestion: (toolUseId: string, answers: Record<string, string>) => {
+        const question = turnState?.pendingQuestions.get(toolUseId);
+        if (!question || !active.sessionId) return;
+        void resolveQuestion(active.sessionId, question, answers);
       },
-      finish: () => {
-        // No input queue to close — single-turn model.
-      },
+      finish: () => undefined,
     };
   }
 
   async *execute(options: ExecutorOptions): AsyncGenerator<SDKMessage> {
     const handle = this.startExecution(options);
     try {
-      for await (const msg of handle.stream) {
-        yield msg;
-      }
+      for await (const message of handle.stream) yield message;
     } finally {
       handle.finish();
     }
   }
 
-  private createKimiSession(
-    cwd: string,
-    sessionId: string | undefined,
-    options: ExecutorOptions,
-  ): Session {
-    const kimiOpts = this.config.kimi ?? {};
-    return createSession({
-      workDir: cwd,
-      sessionId,
-      model: options.model ?? kimiOpts.model,
-      thinking: kimiOpts.thinking,
-      yoloMode: true,
-      executable: kimiOpts.executable,
-    });
+  canSteer(chatId: string): boolean {
+    return this.activeTurns.has(chatId);
   }
 
-  /** Read the Kimi CLI's default model ID from `~/.kimi/config.toml`. */
-  private resolveDefaultModel(): string {
+  async steer(chatId: string, prompt: string): Promise<'steered' | 'no-active-turn'> {
+    const active = this.activeTurns.get(chatId);
+    if (!active) return 'no-active-turn';
+    active.pendingSteers += 1;
     try {
-      const cfg = parseConfig();
-      if (cfg.defaultModel) return cfg.defaultModel;
-    } catch (err) {
-      this.logger.warn({ err }, 'Kimi parseConfig failed — falling back to kimi-for-coding');
+      await active.ready;
+      if (!active.sessionId) return 'no-active-turn';
+      await this.client.steer(active.sessionId, prompt, { model: active.model, thinking: active.thinking });
+      return 'steered';
+    } finally {
+      active.pendingSteers -= 1;
     }
-    return 'kimi-for-coding';
   }
 
-  /**
-   * Look up `display_name` for `modelId` in the Kimi config TOML. The SDK's
-   * `parseConfig()` only exposes `id`/`name`/`capabilities` — `display_name`
-   * lives in the raw file, so we regex-scan the relevant [models."…"] block.
-   * Returns undefined when the section or key isn't present.
-   */
-  private resolveDisplayName(modelId: string): string | undefined {
+  private async resolveQuestion(
+    sessionId: string,
+    question: KimiPendingQuestion,
+    answers: Record<string, string>,
+  ): Promise<void> {
     try {
-      const toml = readFileSync(KimiPaths.config, 'utf-8');
-      // Split on section headers at line start; each piece begins with the
-      // section name (e.g. `models."kimi-code/kimi-for-coding"]`) followed by
-      // the section body. This avoids confusing `[` in array values with
-      // section boundaries.
-      const sections = toml.split(/^\[/m);
-      for (const section of sections) {
-        // Match either [models."id"] or [models."prefix/id"]
-        const headerMatch = section.match(/^models\."([^"]+)"\]/);
-        if (!headerMatch) continue;
-        const sectionId = headerMatch[1];
-        const shortId = sectionId.includes('/')
-          ? sectionId.slice(sectionId.lastIndexOf('/') + 1)
-          : sectionId;
-        if (sectionId !== modelId && shortId !== modelId) continue;
-        const displayName = section.match(/^\s*display_name\s*=\s*"([^"]+)"/m);
-        if (displayName) return displayName[1];
-      }
-      return undefined;
-    } catch {
-      return undefined;
+      await this.client.respondQuestion(sessionId, question, answers);
+      this.logger.info({ engine: 'kimi', questionId: question.question_id }, 'Resolved Kimi question from Feishu');
+    } catch (error) {
+      this.logger.warn({ error, engine: 'kimi', questionId: question.question_id }, 'Failed to resolve Kimi question');
     }
   }
 
@@ -252,233 +317,283 @@ export class KimiExecutor {
     apiContext: ApiContext | undefined,
   ): string {
     const sections: string[] = [];
-
     if (outputsDir) {
       sections.push(
-        `## Output Files\nWhen producing output files for the user (images, PDFs, documents, archives, code files, etc.), copy them to: ${outputsDir}\nThe bridge will automatically send files placed there to the user.`,
+        `## Output Files\nWhen producing output files for the user, copy them to: ${outputsDir}\nMetaBot will automatically send files placed there.`,
       );
     }
-
     if (apiContext) {
       sections.push(
-        `## MetaBot API\nYou are running as bot "${apiContext.botName}" in chat "${apiContext.chatId}".\nUse the /metabot skill for full API documentation (agent bus, scheduling, bot management).`,
+        `## MetaBot\nYou are Agent "${apiContext.botName}" in chat "${apiContext.chatId}". Use the metabot skill and CLI for Memory, T5T, Agent Bus, and Agent Teams.`,
       );
-
-      if (apiContext.groupMembers && apiContext.groupMembers.length > 0) {
-        const others = apiContext.groupMembers.filter((m) => m !== apiContext.botName);
-        const groupId = apiContext.groupId;
-        if (groupId) {
-          sections.push(
-            `## Group Chat\nYou are in a group chat (group: ${groupId}) with these bots: ${others.join(', ')}.\nTo talk to another bot, use: \`metabot talk <botName> grouptalk-${groupId}-<botName> "message"\``,
-          );
-        }
+      if (apiContext.groupMembers?.length) {
+        const peers = apiContext.groupMembers.filter((name) => name !== apiContext.botName);
+        if (peers.length) sections.push(`## Agent Organization\nOther Agents in this group: ${peers.join(', ')}.`);
       }
     }
-
-    if (sections.length === 0) return prompt;
-    return `${prompt}\n\n---\n\n${sections.join('\n\n')}`;
+    return sections.length > 0 ? `${prompt}\n\n---\n\n${sections.join('\n\n')}` : prompt;
   }
 }
 
-// --- Kimi → Claude event translation ---
-
-interface TurnState {
-  sessionId: string;
-  accumulatedText: string;
-  /** Kimi streams tool arguments across ToolCall + ToolCallPart events. */
-  openToolCalls: Map<string, { name: string; argsBuffer: string }>;
-  startTime: number;
-  /** Model ID used by the Kimi session (surfaced to the card's stats footer). */
-  model: string;
-  /** Context window size (tokens) — used when emitting modelUsage. */
-  contextWindow: number;
-  /** Last seen StatusUpdate token breakdown (summed into totalTokens). */
-  lastInputTokens?: number;
-  lastOutputTokens?: number;
-}
-
-function translateEvent(event: StreamEvent, state: TurnState, logger: Logger): SDKMessage[] {
-  // ParseError and WireRequest types are not AsyncIterable events we expect
-  // to process here with the current set of capabilities; log and skip.
-  if (event.type === 'error') {
-    logger.warn({ event }, 'Kimi emitted ParseError — skipping');
-    return [];
-  }
-
-  switch (event.type) {
-    case 'TurnBegin':
-    case 'StepBegin':
-    case 'StepInterrupted':
-    case 'CompactionBegin':
-    case 'CompactionEnd':
-    case 'HookTriggered':
-    case 'HookResolved':
-    case 'SteerInput':
-    case 'ApprovalResponse':
-      // Lifecycle events with no direct CardState equivalent; skip.
-      return [];
-
-    case 'ContentPart': {
-      const part = event.payload as { type: string; text?: string };
-      if (part.type === 'text' && part.text) {
-        state.accumulatedText += part.text;
-        // Emit a streaming text_delta so StreamProcessor appends it live.
-        return [{
+function translateSnapshot(snapshot: KimiSessionSnapshot, state: KimiTurnState): SDKMessage[] {
+  const messages: SDKMessage[] = [];
+  const currentMessages = snapshot.messages.items.filter((message) => !state.baselineMessageIds.has(message.id));
+  const fullText = collectAssistantText(currentMessages, snapshot.in_flight_turn?.assistant_text);
+  if (fullText !== state.emittedText) {
+    if (fullText.startsWith(state.emittedText)) {
+      const delta = fullText.slice(state.emittedText.length);
+      if (delta) {
+        messages.push({
           type: 'stream_event',
           session_id: state.sessionId,
-          event: {
-            type: 'content_block_delta',
-            delta: { type: 'text_delta', text: part.text },
-          },
-        }];
+          event: { type: 'content_block_delta', delta: { type: 'text_delta', text: delta } },
+        });
       }
-      // Thinking, images, audio, video — no rendering in the current card.
-      return [];
+    } else {
+      messages.push({
+        type: 'assistant',
+        session_id: state.sessionId,
+        message: { content: [{ type: 'text', text: fullText }] },
+      });
     }
+    state.emittedText = fullText;
+  }
 
-    case 'ToolCall': {
-      const call = event.payload;
-      const name = call.function.name;
-      const args = call.function.arguments ?? '';
-      state.openToolCalls.set(call.id, { name, argsBuffer: args });
-      const input = safeParseJson(args);
-      return [{
+  const tools = collectTools(currentMessages, snapshot);
+  for (const [id, tool] of tools) {
+    const signature = stableValue(tool.input);
+    if (state.toolInputs.get(id) !== signature) {
+      state.toolInputs.set(id, signature);
+      messages.push({
         type: 'assistant',
         session_id: state.sessionId,
         message: {
-          content: [{ type: 'tool_use', id: call.id, name, input }],
+          content: [{ type: 'tool_use', id, name: normalizeKimiToolName(tool.name), input: tool.input ?? {} }],
         },
-      }];
+      });
     }
-
-    case 'ToolCallPart':
-      // Streaming argument chunks. We already emitted the tool_use block on
-      // ToolCall; StreamProcessor just needs the name to update the card.
-      // Skip per-chunk emission to avoid duplicate card entries.
-      return [];
-
-    case 'ToolResult': {
-      const tr = event.payload;
-      state.openToolCalls.delete(tr.tool_call_id);
-      const output = typeof tr.return_value.output === 'string'
-        ? tr.return_value.output
-        : JSON.stringify(tr.return_value.output);
-      return [{
+    if (tool.completed && !state.completedTools.has(id)) {
+      state.completedTools.add(id);
+      messages.push({
         type: 'user',
         session_id: state.sessionId,
-        message: {
-          content: [{ type: 'tool_result', id: tr.tool_call_id, text: output }],
-        },
-      }];
+        message: { content: [{ type: 'tool_result', id, text: formatToolOutput(tool.output) }] },
+      });
     }
+  }
 
-    case 'StatusUpdate': {
-      // Kimi emits cumulative token usage and context usage on each step.
-      // We cache the latest values so the result message can report them as
-      // modelUsage (which the StreamProcessor reads to populate context/model
-      // stats on the Feishu card).
-      const payload = event.payload as {
-        context_usage?: number | null;
-        token_usage?: {
-          input_other: number;
-          output: number;
-          input_cache_read: number;
-          input_cache_creation: number;
-        } | null;
-      };
-      if (payload.token_usage) {
-        state.lastInputTokens = payload.token_usage.input_other
-          + payload.token_usage.input_cache_read
-          + payload.token_usage.input_cache_creation;
-        state.lastOutputTokens = payload.token_usage.output;
-      } else if (typeof payload.context_usage === 'number') {
-        // Fallback: only a single cumulative number is available.
-        state.lastInputTokens = payload.context_usage;
-        state.lastOutputTokens = 0;
-      }
-      return [];
-    }
-
-    case 'SubagentEvent': {
-      // Flatten nested subagent events — StreamProcessor already filters
-      // based on parent_tool_use_id. We pass through a minimal marker.
-      const inner = event.payload.event;
-      const msgs = translateEvent(inner as StreamEvent, state, logger);
-      return msgs.map((m) => ({ ...m, parent_tool_use_id: event.payload.parent_tool_call_id }));
-    }
-
-    case 'TurnEnd':
-      // Emit the final full assistant text block so StreamProcessor's
-      // "full message text replaces accumulated stream text" branch captures
-      // the complete answer text.
-      if (state.accumulatedText) {
-        return [{
-          type: 'assistant',
-          session_id: state.sessionId,
-          message: {
-            content: [{ type: 'text', text: state.accumulatedText }],
+  for (const question of snapshot.pending_questions) {
+    const toolUseId = question.tool_call_id ?? question.question_id;
+    state.pendingQuestions.set(toolUseId, question);
+    if (state.emittedQuestions.has(question.question_id)) continue;
+    state.emittedQuestions.add(question.question_id);
+    messages.push({
+      type: 'assistant',
+      session_id: state.sessionId,
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: toolUseId,
+            name: 'AskUserQuestion',
+            input: {
+              questions: question.questions.map((item) => ({
+                question: item.question,
+                header: item.header ?? '',
+                options: item.options.map((option) => ({
+                  label: option.label,
+                  description: option.description ?? '',
+                })),
+                multiSelect: item.multi_select === true,
+              })),
+            },
           },
-        }];
+        ],
+      },
+    });
+  }
+
+  for (const task of snapshot.subagents ?? []) messages.push(...translateSubagent(task, state));
+  return messages;
+}
+
+function collectAssistantText(messages: KimiWireMessage[], inFlightText?: string): string {
+  const durable = messages
+    .filter((message) => message.role === 'assistant')
+    .flatMap((message) => message.content)
+    .flatMap((content) => (content.type === 'text' && typeof content.text === 'string' ? [content.text] : []))
+    .join('');
+  return durable + (inFlightText ?? '');
+}
+
+function collectTools(
+  messages: KimiWireMessage[],
+  snapshot: KimiSessionSnapshot,
+): Map<string, { name: string; input?: unknown; output?: unknown; completed: boolean }> {
+  const tools = new Map<string, { name: string; input?: unknown; output?: unknown; completed: boolean }>();
+  for (const message of messages) {
+    for (const content of message.content) {
+      if (content.type === 'tool_use' && typeof content.tool_call_id === 'string') {
+        tools.set(content.tool_call_id, {
+          name: typeof content.tool_name === 'string' ? content.tool_name : 'Tool',
+          input: content.input,
+          completed: false,
+        });
+      } else if (content.type === 'tool_result' && typeof content.tool_call_id === 'string') {
+        const previous = tools.get(content.tool_call_id);
+        tools.set(content.tool_call_id, {
+          name: previous?.name ?? 'Tool',
+          input: previous?.input,
+          output: content.output,
+          completed: true,
+        });
       }
-      return [];
+    }
+  }
+  for (const tool of snapshot.in_flight_turn?.running_tools ?? []) {
+    const previous = tools.get(tool.tool_call_id);
+    tools.set(tool.tool_call_id, {
+      name: tool.name,
+      input: tool.args ?? previous?.input,
+      output: previous?.output,
+      completed: previous?.completed ?? false,
+    });
+  }
+  return tools;
+}
 
-    // WireRequest types that arrive in the iterator
-    case 'ApprovalRequest':
-      logger.info({ requestId: (event.payload as any).request_id }, 'Kimi ApprovalRequest — yoloMode should have allowed this');
-      return [];
-    case 'ToolCallRequest':
-    case 'QuestionRequest':
-    case 'HookRequest':
-      logger.info({ type: event.type }, 'Kimi wire request — not yet handled');
-      return [];
+function translateSubagent(task: KimiSubagentTask, state: KimiTurnState): SDKMessage[] {
+  const signature = `${task.status}:${task.subagent_phase ?? ''}:${task.output_preview ?? ''}`;
+  if (state.subagentStates.get(task.id) === signature) return [];
+  const previous = state.subagentStates.get(task.id);
+  state.subagentStates.set(task.id, signature);
+  const terminal = task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled';
+  return [
+    {
+      type: 'system',
+      subtype: terminal ? 'task_notification' : previous ? 'task_progress' : 'task_started',
+      session_id: state.sessionId,
+      task_id: task.id,
+      description: task.description || task.subagent_type || 'Kimi subagent',
+      status: terminal ? (task.status === 'completed' ? 'completed' : 'failed') : 'running',
+      summary: task.output_preview,
+    } as SDKMessage,
+  ];
+}
 
-    default:
-      return [];
+function buildResult(state: KimiTurnState, status: KimiSessionStatus | undefined, aborted: boolean): SDKMessage {
+  const snapshot = state.lastSnapshot;
+  const failed = snapshot?.session.last_turn_reason === 'failed';
+  const cancelled = aborted || snapshot?.session.last_turn_reason === 'cancelled';
+  // Kimi's durable session usage can lag the just-completed turn by one
+  // snapshot. The live status endpoint is authoritative for current context.
+  const usage = snapshot?.session.usage;
+  const outputTokens = usage?.output_tokens ?? 0;
+  const inputTokens =
+    usage?.input_tokens ?? Math.max(0, (status?.context_tokens || usage?.context_tokens || 0) - outputTokens);
+  return {
+    type: 'result',
+    subtype: cancelled ? 'error_cancelled' : failed ? 'error_during_execution' : 'success',
+    session_id: state.sessionId,
+    duration_ms: Date.now() - state.startTime,
+    result: state.emittedText,
+    is_error: failed || cancelled,
+    num_turns: snapshot?.session.usage?.turn_count,
+    modelUsage: {
+      [state.model]: {
+        contextWindow: status?.max_context_tokens || state.contextWindow,
+        inputTokens,
+        outputTokens,
+        costUSD: snapshot?.session.usage?.total_cost_usd ?? 0,
+      },
+    },
+    ...(failed ? { errors: ['Kimi Code turn failed'] } : {}),
+    ...(cancelled ? { errors: ['Aborted by user'] } : {}),
+  };
+}
+
+function localResult(sessionId: string, state: KimiTurnState, text: string): SDKMessage {
+  state.emittedText = text;
+  return {
+    type: 'result',
+    subtype: 'success',
+    session_id: sessionId,
+    duration_ms: Date.now() - state.startTime,
+    result: text,
+    is_error: false,
+    modelUsage: {
+      [state.model]: { contextWindow: state.contextWindow, inputTokens: 0, outputTokens: 0, costUSD: 0 },
+    },
+  };
+}
+
+function parseGoalCommand(
+  prompt: string,
+):
+  | { kind: 'none' }
+  | { kind: 'start'; objective: string }
+  | { kind: 'control'; action: 'pause' | 'resume' | 'cancel' }
+  | { kind: 'status' } {
+  const match = prompt.trim().match(/^\/goal(?:\s+(.*))?$/i);
+  if (!match) return { kind: 'none' };
+  const value = match[1]?.trim() ?? '';
+  if (!value || value.toLowerCase() === 'status') return { kind: 'status' };
+  const normalized = value.toLowerCase();
+  if (normalized === 'pause') return { kind: 'control', action: 'pause' };
+  if (normalized === 'resume') return { kind: 'control', action: 'resume' };
+  if (['clear', 'stop', 'off', 'reset', 'none', 'cancel'].includes(normalized)) {
+    return { kind: 'control', action: 'cancel' };
+  }
+  return { kind: 'start', objective: value };
+}
+
+function formatGoalStatus(goal: Record<string, unknown>): string {
+  const objective = typeof goal.objective === 'string' ? goal.objective : 'Kimi goal';
+  const status = typeof goal.status === 'string' ? goal.status : 'active';
+  const turns = typeof goal.turnsUsed === 'number' ? ` · ${goal.turnsUsed} turns` : '';
+  return `Goal ${status}: ${objective}${turns}`;
+}
+
+function normalizeKimiToolName(name: string): string {
+  const clean = name.replace(/_\d+$/, '');
+  const names: Record<string, string> = {
+    ReadFile: 'Read',
+    WriteFile: 'Write',
+    StrReplaceFile: 'Edit',
+    ReplaceFile: 'Edit',
+    Shell: 'Bash',
+    RunShellCommand: 'Bash',
+    FindFiles: 'Glob',
+    SearchFiles: 'Grep',
+    SearchWeb: 'WebSearch',
+    FetchURL: 'WebFetch',
+  };
+  return names[clean] ?? clean;
+}
+
+function stableValue(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? {});
+  } catch {
+    return String(value);
   }
 }
 
-function buildResultMessage(result: RunResult, state: TurnState): SDKMessage {
-  const isError = result.status !== 'finished';
-  const subtype = result.status === 'finished'
-    ? 'success'
-    : result.status === 'cancelled'
-      ? 'error_cancelled'
-      : 'error_max_steps';
-
-  // Mimic Claude's `modelUsage` shape so StreamProcessor can extract model,
-  // contextWindow, and totalTokens without any engine-specific branching.
-  // Kimi runs on a subscription — leave costUSD at 0 (the card omits $0).
-  const inputTokens = state.lastInputTokens ?? 0;
-  const outputTokens = state.lastOutputTokens ?? 0;
-  const modelUsage: Record<string, {
-    contextWindow: number;
-    inputTokens: number;
-    outputTokens: number;
-    costUSD: number;
-  }> = {
-    [state.model]: {
-      contextWindow: state.contextWindow,
-      inputTokens,
-      outputTokens,
-      costUSD: 0,
-    },
-  };
-
-  return {
-    type: 'result',
-    subtype,
-    session_id: state.sessionId,
-    duration_ms: Date.now() - state.startTime,
-    result: state.accumulatedText,
-    is_error: isError,
-    num_turns: result.steps,
-    modelUsage,
-    // Cost is unknown for Kimi (subscription model, no per-call price emitted).
-    // Leave total_cost_usd undefined — the card will omit the cost line.
-  };
+function formatToolOutput(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value ?? '');
+  }
 }
 
-function safeParseJson(s: string): unknown {
-  if (!s) return {};
-  try { return JSON.parse(s); } catch { return { _raw: s }; }
+function abortError(): Error {
+  const error = new Error('Aborted by user');
+  error.name = 'AbortError';
+  return error;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/engines/kimi/index.ts
+++ b/src/engines/kimi/index.ts
@@ -5,9 +5,9 @@ import { StreamProcessor } from '../claude/stream-processor.js';
 import { KimiExecutor } from './executor.js';
 
 /**
- * Kimi engine. Wraps `@moonshot-ai/kimi-agent-sdk` and reuses the Claude
- * `StreamProcessor` — the KimiExecutor translates Kimi's event stream into
- * Claude-shaped SDKMessage objects so the same card rendering logic applies.
+ * Kimi engine. Uses Kimi Code's official local Server API and reuses the
+ * Claude `StreamProcessor`, translating atomic frontend snapshots into the
+ * shared card event shape.
  */
 export class KimiEngine implements Engine {
   readonly name = 'kimi' as const;

--- a/src/engines/kimi/session-lister.ts
+++ b/src/engines/kimi/session-lister.ts
@@ -1,0 +1,52 @@
+import type { SessionSummary } from '../claude/session-lister.js';
+import { KimiDaemonClient, type KimiWireSession } from './daemon-client.js';
+
+export interface KimiSessionListerClient {
+  listSessions(cwd?: string): Promise<KimiWireSession[]>;
+}
+
+/** Read-only Kimi Code 0.27 session discovery for Feishu `/resume`. */
+export async function listKimiSessions(opts: {
+  workingDirectory: string;
+  currentSessionId?: string;
+  limit?: number;
+  previewMaxLen?: number;
+  executable?: string;
+  serverUrl?: string;
+  apiKey?: string;
+  client?: KimiSessionListerClient;
+}): Promise<SessionSummary[]> {
+  const {
+    workingDirectory,
+    currentSessionId,
+    limit = 10,
+    previewMaxLen = 80,
+    client = new KimiDaemonClient({
+      executable: opts.executable,
+      serverUrl: opts.serverUrl,
+      apiKey: opts.apiKey,
+    }),
+  } = opts;
+  try {
+    const sessions = await client.listSessions(workingDirectory);
+    return sessions
+      .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))
+      .slice(0, limit)
+      .map((session) => ({
+        sessionId: session.id,
+        preview: truncatePreview(session.last_prompt || session.title || '', previewMaxLen) || '(no preview)',
+        lastActive: Date.parse(session.updated_at) || 0,
+        // Kimi's Server API intentionally abstracts its storage layout. The
+        // picker does not need a byte size, so keep the cross-engine field at 0.
+        sizeBytes: 0,
+        isCurrent: session.id === currentSessionId,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function truncatePreview(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}…` : normalized;
+}

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -39,6 +39,9 @@ export interface Engine {
 export interface Executor {
   startExecution(options: ExecutorOptions): ExecutionHandle;
   execute(options: ExecutorOptions): AsyncGenerator<SDKMessage>;
+  /** Optional native mid-turn steering keyed by the bridge chat id. */
+  canSteer?(chatId: string): boolean;
+  steer?(chatId: string, prompt: string): Promise<'steered' | 'no-active-turn'>;
 }
 
 export type StreamProcessorLike = StreamProcessor;

--- a/tests/codex-build-args.test.ts
+++ b/tests/codex-build-args.test.ts
@@ -3,17 +3,17 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildCodexArgs, buildCodexEnv, resolveCodexModelMetadata, resolveCodexPath } from '../src/engines/codex/executor.js';
-import type { CodexBotConfig } from '../src/config.js';
+import { type CodexBotConfig, normalizeCodexReasoningEffort } from '../src/config.js';
 
 describe('buildCodexArgs', () => {
   const cwd = '/work/proj';
   const prompt = 'run pwd';
 
-  it('defaults approval policy to "never" and sandbox to "danger-full-access"', () => {
+  it('defaults approval policy to "never" and sandbox to "workspace-write"', () => {
     const args = buildCodexArgs({}, cwd, prompt, undefined, undefined);
     expect(args).toEqual([
       '-a', 'never',
-      '--sandbox', 'danger-full-access',
+      '--sandbox', 'workspace-write',
       '-C', cwd,
       'exec', '--json', '--color', 'never', '--skip-git-repo-check', prompt,
     ]);
@@ -64,6 +64,14 @@ describe('buildCodexArgs', () => {
   it('uses codex.reasoningEffort when no per-turn effort is provided', () => {
     const args = buildCodexArgs({ reasoningEffort: 'xhigh' }, cwd, prompt, undefined, undefined);
     expect(args).toContain('model_reasoning_effort="xhigh"');
+  });
+
+  it('passes max and ultra through as distinct Codex effort levels', () => {
+    expect(normalizeCodexReasoningEffort('ultracode')).toBeUndefined();
+    expect(normalizeCodexReasoningEffort('max')).toBe('max');
+    expect(normalizeCodexReasoningEffort('ultra')).toBe('ultra');
+    expect(buildCodexArgs({}, cwd, prompt, undefined, undefined, 'max')).toContain('model_reasoning_effort="max"');
+    expect(buildCodexArgs({}, cwd, prompt, undefined, undefined, 'ultra')).toContain('model_reasoning_effort="ultra"');
   });
 
   it('appends extraArgs verbatim between global flags and the exec subcommand', () => {

--- a/tests/codex-executor-terminal-result.test.ts
+++ b/tests/codex-executor-terminal-result.test.ts
@@ -1,0 +1,42 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { CodexExecutor } from '../src/engines/codex/executor.js';
+
+const logger = { debug() {}, info() {}, warn() {}, error() {} } as any;
+
+describe('CodexExecutor terminal result handling', () => {
+  it('finishes the stream and reaps Codex when the CLI hangs after turn.completed', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'metabot-codex-hang-'));
+    const executable = join(dir, 'codex');
+    const pidFile = join(dir, 'pid');
+    writeFileSync(
+      executable,
+      `#!/bin/sh\necho $$ > ${JSON.stringify(pidFile)}\nprintf '%s\\n' '{"type":"thread.started","thread_id":"thread-1"}'\nprintf '%s\\n' '{"type":"item.completed","item":{"id":"msg-1","type":"agent_message","text":"done"}}'\nprintf '%s\\n' '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":2}}'\nwhile true; do sleep 1; done\n`,
+    );
+    chmodSync(executable, 0o755);
+
+    try {
+      const executor = new CodexExecutor({ codex: { executable, model: 'test-model' } } as any, logger);
+      const messages: any[] = [];
+      const startedAt = Date.now();
+      for await (const message of executor.execute({
+        prompt: 'test',
+        cwd: dir,
+        abortController: new AbortController(),
+      })) {
+        messages.push(message);
+      }
+
+      expect(Date.now() - startedAt).toBeLessThan(900);
+      expect(messages.at(-1)).toMatchObject({ type: 'result', result: 'done', is_error: false });
+
+      const pid = Number(readFileSync(pidFile, 'utf8').trim());
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/command-handler-model-status.test.ts
+++ b/tests/command-handler-model-status.test.ts
@@ -82,8 +82,8 @@ function buildHandler(opts: BuildOpts = {}) {
   const config = {
     name: 'test-bot',
     claude: { model: 'claude-opus-4-6' },
-    kimi: { model: 'kimi-for-coding' },
-    codex: { model: 'gpt-5.5', displayModel: 'gpt-5.5' },
+    kimi: { model: 'kimi-code/k3' },
+    codex: { model: 'gpt-5.6', displayModel: 'gpt-5.6' },
   } as any;
 
   const handler = new CommandHandler(
@@ -170,7 +170,7 @@ describe('CommandHandler /status', () => {
   it('shows default model when no session model is set', async () => {
     const { handler, notices } = buildHandler({});
     await handler.handle(msg('/status'));
-    expect(notices[0].content).toContain('gpt-5.5');
+    expect(notices[0].content).toContain('gpt-5.6');
   });
 });
 
@@ -184,7 +184,7 @@ describe('CommandHandler /model', () => {
     const handled = await handler.handle(msg('/model'));
     expect(handled).toBe(true);
     expect(notices[0].title).toContain('Model');
-    expect(notices[0].content).toContain('gpt-5.5');
+    expect(notices[0].content).toContain('gpt-5.6');
   });
 
   it('lists claude models on /model list when engine is claude', async () => {
@@ -198,20 +198,24 @@ describe('CommandHandler /model', () => {
   it('lists kimi models on /model list when engine is kimi', async () => {
     const { handler, notices } = buildHandler({ engine: 'kimi' });
     await handler.handle(msg('/model list'));
-    expect(notices[0].content).toContain('kimi-for-coding');
-    expect(notices[0].content).toContain('kimi-k2');
+    expect(notices[0].content).toContain('kimi-code/k3');
+    expect(notices[0].content).toContain('kimi-code/kimi-for-coding-highspeed');
   });
 
   it('lists codex models on /model list when engine is codex', async () => {
     const { handler, notices } = buildHandler({ engine: 'codex' });
     await handler.handle(msg('/model list'));
+    expect(notices[0].content).toContain('gpt-5.6');
+    expect(notices[0].content).toContain('gpt-5.6-terra');
+    expect(notices[0].content).toContain('gpt-5.6-luna');
     expect(notices[0].content).toContain('gpt-5.5');
+    expect(notices[0].content).toContain('gpt-5.5-codex');
   });
 
   it('accepts /model ls as alias for list', async () => {
     const { handler, notices } = buildHandler({});
     await handler.handle(msg('/model ls'));
-    expect(notices[0].content).toContain('gpt-5.5');
+    expect(notices[0].content).toContain('gpt-5.6');
   });
 
   it('switches engine to kimi on /model kimi', async () => {
@@ -293,6 +297,8 @@ describe('CommandHandler /effort', () => {
     await handler.handle(msg('/effort'));
     expect(notices[0].title).toContain('Effort');
     expect(notices[0].content).toContain('codex');
+    expect(notices[0].content).toContain('/effort max');
+    expect(notices[0].content).toContain('/effort ultra');
   });
 
   it('sets Codex effort for the current session', async () => {
@@ -302,10 +308,16 @@ describe('CommandHandler /effort', () => {
     expect(notices[0].color).toBe('green');
   });
 
-  it('accepts max as an alias for xhigh', async () => {
+  it('keeps max as a distinct Codex effort', async () => {
     const { handler, getReasoningEffort } = buildHandler({});
     await handler.handle(msg('/effort max'));
-    expect(getReasoningEffort()).toBe('xhigh');
+    expect(getReasoningEffort()).toBe('max');
+  });
+
+  it('keeps ultra as a distinct Codex effort', async () => {
+    const { handler, getReasoningEffort } = buildHandler({});
+    await handler.handle(msg('/effort ultra'));
+    expect(getReasoningEffort()).toBe('ultra');
   });
 
   it('refuses effort changes when the active engine is not Codex', async () => {

--- a/tests/command-handler-resume.test.ts
+++ b/tests/command-handler-resume.test.ts
@@ -5,8 +5,8 @@ import type { SessionSummary } from '../src/engines/claude/session-lister.js';
 
 /**
  * Direct `/resume <id-prefix>` form. The bare `/resume` picker lives in the
- * bridge; here we cover the command-handler path: engine gate, running-turn
- * guard, prefix matching (unique / ambiguous / none), and the swap callback.
+ * bridge; here we cover the command-handler path: engine-aware resume, the
+ * running-turn guard, prefix matching (unique / ambiguous / none), and swap.
  */
 
 interface RecordedNotice {
@@ -100,12 +100,10 @@ describe('CommandHandler /resume', () => {
     expect(notices.at(-1)?.color).toBe('red');
   });
 
-  it('is gated to the claude engine (red) on a kimi chat', async () => {
-    const { handler, notices, resumed } = buildHandler({ engine: 'kimi' });
+  it('resumes a Kimi session on a Kimi chat', async () => {
+    const { handler, resumed } = buildHandler({ engine: 'kimi' });
     await handler.handle(msg('/resume abc12345'));
-    expect(resumed).toEqual([]);
-    expect(notices.at(-1)?.color).toBe('red');
-    expect(notices.at(-1)?.title).toContain('Claude-only');
+    expect(resumed).toEqual(['abc12345-1111-1111-1111-111111111111']);
   });
 
   it('refuses while a turn is running (orange)', async () => {

--- a/tests/install-engine-selection.test.ts
+++ b/tests/install-engine-selection.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const INSTALL_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf-8');
+const POWERSHELL_INSTALL_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'install.ps1'), 'utf-8');
 
 function extractGenerator(variable: string): string {
   const marker = `${variable}=$(node -e "`;
@@ -16,6 +17,17 @@ function extractGenerator(variable: string): string {
   const bodyEnd = INSTALL_SOURCE.indexOf('\n    " ', bodyStart);
   if (bodyEnd === -1) throw new Error(`Missing end of ${variable} generator in install.sh`);
   return INSTALL_SOURCE.slice(bodyStart, bodyEnd);
+}
+
+function extractPowerShellGenerator(variable: string): string {
+  const marker = `$${variable} = node -e "`;
+  const start = POWERSHELL_INSTALL_SOURCE.indexOf(marker);
+  if (start === -1) throw new Error(`Missing ${variable} generator in install.ps1`);
+
+  const bodyStart = start + marker.length;
+  const bodyEnd = POWERSHELL_INSTALL_SOURCE.indexOf('" $', bodyStart);
+  if (bodyEnd === -1) throw new Error(`Missing end of ${variable} generator in install.ps1`);
+  return POWERSHELL_INSTALL_SOURCE.slice(bodyStart, bodyEnd);
 }
 
 const platforms = [
@@ -36,13 +48,26 @@ const platforms = [
   },
 ] as const;
 
+const powerShellPlatforms = [
+  {
+    name: 'PowerShell Feishu',
+    generator: extractPowerShellGenerator('FeishuBotsJson'),
+    args: ['bot', 'cli_test', 'secret', 'C:\\workspace'],
+  },
+  {
+    name: 'PowerShell Telegram',
+    generator: extractPowerShellGenerator('TelegramBotsJson'),
+    args: ['bot', 'telegram-token', 'C:\\workspace'],
+  },
+] as const;
+
 function generateBot(generator: string, args: readonly string[], engine: string): Record<string, unknown> {
   const output = execFileSync(process.execPath, ['-e', generator, ...args, engine], { encoding: 'utf-8' });
   return JSON.parse(output)[0] as Record<string, unknown>;
 }
 
 describe('interactive installer engine selection', () => {
-  for (const platform of platforms) {
+  for (const platform of [...platforms, ...powerShellPlatforms]) {
     it(`${platform.name} persists Claude explicitly`, () => {
       const bot = generateBot(platform.generator, platform.args, 'claude');
 
@@ -55,7 +80,7 @@ describe('interactive installer engine selection', () => {
       const bot = generateBot(platform.generator, platform.args, 'kimi');
 
       expect(bot.engine).toBe('kimi');
-      expect(bot.kimi).toEqual({ thinking: true });
+      expect(bot.kimi).toEqual({ model: 'kimi-code/k3', thinking: true, permissionMode: 'auto' });
       expect(bot.codex).toBeUndefined();
     });
 

--- a/tests/install-runtime-prereqs.test.ts
+++ b/tests/install-runtime-prereqs.test.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SH_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf-8');
+const PS_SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'install.ps1'), 'utf-8');
+
+function extractBashFunction(name: string): string {
+  const startMarker = `${name}() {`;
+  const start = SH_SOURCE.indexOf(startMarker);
+  if (start === -1) throw new Error(`Missing ${name} in install.sh`);
+  const end = SH_SOURCE.indexOf('\n}\n', start);
+  if (end === -1) throw new Error(`Missing end of ${name} in install.sh`);
+  return SH_SOURCE.slice(start, end + 3);
+}
+
+describe('installer runtime prerequisites', () => {
+  it('enforces the Node.js 22.19.0 semantic-version floor', () => {
+    const versionFunction = extractBashFunction('version_at_least');
+    const script = `${versionFunction}
+version_at_least v22.19.0 22.19.0
+! version_at_least v22.18.9 22.19.0
+version_at_least v23.0.0 22.19.0
+`;
+    expect(() => execFileSync('bash', ['-c', script])).not.toThrow();
+    expect(SH_SOURCE).toContain('MIN_NODE_VERSION="22.19.0"');
+    expect(PS_SOURCE).toContain('$MinimumNodeVersion = "22.19.0"');
+    expect(PS_SOURCE).toContain('Test-VersionAtLeast $NodeVer $MinimumNodeVersion');
+  });
+
+  it('installs and verifies Kimi Code 0.27+ from npm on both platforms', () => {
+    for (const source of [SH_SOURCE, PS_SOURCE]) {
+      expect(source).toContain('@moonshot-ai/kimi-code@latest');
+      expect(source).toContain('0.27.0');
+      expect(source).toContain('kimi-code/k3');
+      expect(source).not.toContain('uv tool install kimi-cli');
+      expect(source).not.toContain('astral.sh/uv');
+    }
+  });
+
+  it('mirrors MetaBot skills to user and workspace Agent Skills roots', () => {
+    expect(SH_SOURCE).toContain('AGENTS_SKILLS_DIR="$HOME/.agents/skills"');
+    expect(SH_SOURCE).toContain('AGENTS_SKILLS_DEST="$DEPLOY_WORK_DIR/.agents/skills"');
+    expect(PS_SOURCE).toContain('$AgentsSkillsDir = Join-Path $env:USERPROFILE ".agents\\skills"');
+    expect(PS_SOURCE).toContain('$AgentsSkillsDest = Join-Path $DeployWorkDir ".agents\\skills"');
+
+    for (const source of [SH_SOURCE, PS_SOURCE]) {
+      expect(source.replaceAll('\\', '/')).toContain('packages/skills/metabot');
+      expect(source).toContain('metabot-team');
+    }
+  });
+
+  it('preserves workspace instructions and derives AGENTS.md from the current CLAUDE.md', () => {
+    expect(SH_SOURCE).toContain('Preserved existing CLAUDE.md');
+    expect(SH_SOURCE).toContain('ln -s CLAUDE.md AGENTS.md');
+    expect(PS_SOURCE).toContain('Preserved existing CLAUDE.md');
+    expect(PS_SOURCE).toContain('Copy-Item $deployClaude $workspaceAgents -Force');
+  });
+});

--- a/tests/kimi-daemon-client.test.ts
+++ b/tests/kimi-daemon-client.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { KimiDaemonClient, KimiDaemonError } from '../src/engines/kimi/daemon-client.js';
+
+function response<T>(data: T): Response {
+  return new Response(JSON.stringify({ code: 0, msg: 'success', data, request_id: 'req-test' }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('KimiDaemonClient', () => {
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(os.tmpdir(), 'metabot-kimi-client-'));
+    previousHome = process.env.KIMI_CODE_HOME;
+    process.env.KIMI_CODE_HOME = home;
+    await writeFile(path.join(home, 'server.token'), 'test-token\n', { mode: 0o600 });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    if (previousHome === undefined) delete process.env.KIMI_CODE_HOME;
+    else process.env.KIMI_CODE_HOME = previousHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('uses the official prompt queue and steer endpoints', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockResolvedValueOnce(
+        response({ prompt_id: 'prompt-steer', user_message_id: 'message-steer', status: 'queued' }),
+      )
+      .mockResolvedValueOnce(response({ steered: true, prompt_ids: ['prompt-steer'] }));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KimiDaemonClient();
+
+    await client.steer('session-1', 'also optimize mobile', {
+      model: 'kimi-code/k3',
+      thinking: 'high',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('/api/v1/sessions/session-1/prompts');
+    expect(JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)).toMatchObject({
+      content: [{ type: 'text', text: 'also optimize mobile' }],
+      permission_mode: 'auto',
+      model: 'kimi-code/k3',
+      thinking: 'high',
+    });
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain('/api/v1/sessions/session-1/prompts:steer');
+    expect(JSON.parse(fetchMock.mock.calls[2]?.[1]?.body as string)).toEqual({
+      prompt_ids: ['prompt-steer'],
+    });
+    expect((fetchMock.mock.calls[1]?.[1]?.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
+  });
+
+  it('resolves short model names against the live Kimi Code config', async () => {
+    await writeFile(
+      path.join(home, 'config.toml'),
+      [
+        'default_model = "kimi-code/k3"',
+        '',
+        '[models."kimi-code/k3"]',
+        'display_name = "Kimi K3"',
+        '',
+        '[models."kimi-code/kimi-for-coding-highspeed"]',
+        'display_name = "Kimi Highspeed"',
+      ].join('\n'),
+    );
+    const client = new KimiDaemonClient();
+
+    await expect(client.resolveModel('k3')).resolves.toEqual({ id: 'kimi-code/k3', displayName: 'Kimi K3' });
+    await expect(client.resolveModel('kimi-for-coding-highspeed')).resolves.toEqual({
+      id: 'kimi-code/kimi-for-coding-highspeed',
+      displayName: 'Kimi Highspeed',
+    });
+  });
+
+  it('rejects non-loopback servers before reading or sending the local daemon token', () => {
+    expect(() => new KimiDaemonClient({ serverUrl: 'https://kimi.example.com' })).toThrow(KimiDaemonError);
+  });
+});

--- a/tests/kimi-executor.test.ts
+++ b/tests/kimi-executor.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BotConfigBase } from '../src/config.js';
+import { StreamProcessor } from '../src/engines/claude/stream-processor.js';
+import { KimiExecutor, type KimiClientLike } from '../src/engines/kimi/executor.js';
+import type { KimiPendingQuestion, KimiSessionSnapshot, KimiSessionStatus } from '../src/engines/kimi/daemon-client.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: () => logger,
+} as any;
+
+function config(): BotConfigBase {
+  return {
+    name: 'kimi-test',
+    engine: 'kimi',
+    kimi: { model: 'k3', contextWindow: 1_048_576, thinking: true },
+    claude: {
+      defaultWorkingDirectory: '/tmp',
+      maxTurns: undefined,
+      maxBudgetUsd: undefined,
+      model: undefined,
+      apiKey: undefined,
+      outputsBaseDir: '/tmp',
+      downloadsDir: '/tmp',
+      backend: 'pty',
+    },
+  };
+}
+
+function snapshot(overrides: Partial<KimiSessionSnapshot> = {}): KimiSessionSnapshot {
+  return {
+    as_of_seq: 1,
+    epoch: 'ep-test',
+    session: {
+      id: 'session-kimi-1',
+      title: 'test',
+      created_at: '2026-07-19T00:00:00.000Z',
+      updated_at: '2026-07-19T00:00:01.000Z',
+      busy: false,
+      last_turn_reason: 'completed',
+      metadata: { cwd: '/tmp' },
+      agent_config: { model: 'kimi-code/k3' },
+      usage: {
+        input_tokens: 120,
+        output_tokens: 12,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        total_cost_usd: 0,
+        context_tokens: 132,
+        context_limit: 1_048_576,
+        turn_count: 1,
+      },
+    },
+    messages: { items: [], has_more: false },
+    in_flight_turn: null,
+    subagents: [],
+    pending_approvals: [],
+    pending_questions: [],
+    ...overrides,
+  };
+}
+
+class FakeKimiClient implements KimiClientLike {
+  submitted = false;
+  answered = false;
+  afterSubmit: () => Promise<KimiSessionSnapshot> = async () => snapshot();
+  steer = vi.fn(async () => undefined);
+  abortSession = vi.fn(async () => undefined);
+  setGoal = vi.fn(async () => undefined);
+  controlGoal = vi.fn(async () => undefined);
+  approve = vi.fn(async () => undefined);
+  respondQuestion = vi.fn(async () => {
+    this.answered = true;
+  });
+  submitPrompt = vi.fn(async () => {
+    this.submitted = true;
+    return { prompt_id: 'prompt-1', status: 'running' as const };
+  });
+
+  async resolveModel(): Promise<{ id: string; displayName: string }> {
+    return { id: 'kimi-code/k3', displayName: 'Kimi K3' };
+  }
+
+  async openSession(): Promise<{ id: string }> {
+    return { id: 'session-kimi-1' };
+  }
+
+  async getSnapshot(): Promise<KimiSessionSnapshot> {
+    return this.submitted ? this.afterSubmit() : snapshot();
+  }
+
+  async getStatus(): Promise<KimiSessionStatus> {
+    return {
+      busy: false,
+      model: 'Kimi K3',
+      thinking_level: 'high',
+      permission: 'yolo',
+      context_tokens: 132,
+      max_context_tokens: 1_048_576,
+      context_usage: 132 / 1_048_576,
+    };
+  }
+
+  async getGoal(): Promise<Record<string, unknown> | null> {
+    return null;
+  }
+}
+
+async function collect(stream: AsyncGenerator<any>): Promise<any[]> {
+  const messages: any[] = [];
+  for await (const message of stream) messages.push(message);
+  return messages;
+}
+
+describe('KimiExecutor Feishu parity', () => {
+  it('renders Kimi Code Server tools, usage, text, and subagent activity', async () => {
+    const client = new FakeKimiClient();
+    client.afterSubmit = async () =>
+      snapshot({
+        messages: {
+          has_more: false,
+          items: [
+            {
+              id: 'assistant-tool',
+              session_id: 'session-kimi-1',
+              role: 'assistant',
+              prompt_id: 'prompt-1',
+              created_at: '2026-07-19T00:00:02.000Z',
+              content: [
+                {
+                  type: 'tool_use',
+                  tool_call_id: 'tool-1',
+                  tool_name: 'ReadFile',
+                  input: { path: '/repo/src/App.tsx' },
+                },
+              ],
+            },
+            {
+              id: 'tool-result',
+              session_id: 'session-kimi-1',
+              role: 'tool',
+              prompt_id: 'prompt-1',
+              created_at: '2026-07-19T00:00:03.000Z',
+              content: [{ type: 'tool_result', tool_call_id: 'tool-1', output: 'file contents' }],
+            },
+            {
+              id: 'assistant-text',
+              session_id: 'session-kimi-1',
+              role: 'assistant',
+              prompt_id: 'prompt-1',
+              created_at: '2026-07-19T00:00:04.000Z',
+              content: [{ type: 'text', text: 'done' }],
+            },
+          ],
+        },
+        subagents: [
+          {
+            id: 'subagent-1',
+            session_id: 'session-kimi-1',
+            description: 'Implement responsive frontend',
+            status: 'completed',
+            subagent_phase: 'completed',
+            output_preview: 'mobile layout complete',
+          },
+        ],
+      });
+
+    const executor = new KimiExecutor(config(), logger, client);
+    const handle = executor.startExecution({
+      prompt: 'inspect app',
+      cwd: '/tmp',
+      abortController: new AbortController(),
+      apiContext: { botName: 'kimi-test', chatId: 'oc-kimi-tools' },
+    });
+    const processor = new StreamProcessor('inspect app');
+    let final: any;
+    for (const message of await collect(handle.stream)) final = processor.processMessage(message);
+
+    expect(final).toMatchObject({
+      status: 'complete',
+      responseText: 'done',
+      model: 'Kimi K3',
+      totalTokens: 132,
+      contextWindow: 1_048_576,
+      toolCalls: [{ name: 'Read', detail: '`.../src/App.tsx`', status: 'done' }],
+      backgroundEvents: [
+        expect.objectContaining({
+          taskId: 'subagent-1',
+          description: 'Implement responsive frontend',
+          status: 'completed',
+        }),
+      ],
+    });
+  });
+
+  it('surfaces a Kimi question and routes the Feishu answer to the daemon', async () => {
+    const client = new FakeKimiClient();
+    const question: KimiPendingQuestion = {
+      question_id: 'question-1',
+      session_id: 'session-kimi-1',
+      tool_call_id: 'tool-question-1',
+      questions: [
+        {
+          id: 'q1',
+          question: 'Continue deployment?',
+          header: 'Confirm',
+          options: [{ id: 'continue', label: 'Continue', description: 'Proceed now' }],
+        },
+      ],
+    };
+    client.afterSubmit = async () =>
+      client.answered
+        ? snapshot({
+            messages: {
+              has_more: false,
+              items: [
+                {
+                  id: 'answer',
+                  session_id: 'session-kimi-1',
+                  role: 'assistant',
+                  created_at: '2026-07-19T00:00:04.000Z',
+                  content: [{ type: 'text', text: 'deployment continued' }],
+                },
+              ],
+            },
+          })
+        : snapshot({
+            session: { ...snapshot().session, busy: true, pending_interaction: 'question' },
+            pending_questions: [question],
+          });
+
+    const executor = new KimiExecutor(config(), logger, client);
+    const handle = executor.startExecution({
+      prompt: 'deploy',
+      cwd: '/tmp',
+      abortController: new AbortController(),
+      apiContext: { botName: 'kimi-test', chatId: 'oc-kimi-question' },
+    });
+
+    await expect(handle.stream.next()).resolves.toMatchObject({ value: { type: 'system' } });
+    const request = await handle.stream.next();
+    expect(request.value).toMatchObject({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            id: 'tool-question-1',
+            name: 'AskUserQuestion',
+            input: { questions: [{ question: 'Continue deployment?' }] },
+          },
+        ],
+      },
+    });
+
+    handle.resolveQuestion('tool-question-1', { 'Continue deployment?': 'Continue' });
+    await vi.waitFor(() =>
+      expect(client.respondQuestion).toHaveBeenCalledWith('session-kimi-1', question, {
+        'Continue deployment?': 'Continue',
+      }),
+    );
+    const remaining = await collect(handle.stream);
+    expect(remaining.at(-1)).toMatchObject({ type: 'result', subtype: 'success', result: 'deployment continued' });
+  });
+
+  it('uses the native Kimi prompt queue steering path during an active turn', async () => {
+    const client = new FakeKimiClient();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    client.afterSubmit = async () => {
+      await gate;
+      return snapshot({
+        messages: {
+          has_more: false,
+          items: [
+            {
+              id: 'steered-answer',
+              session_id: 'session-kimi-1',
+              role: 'assistant',
+              created_at: '2026-07-19T00:00:03.000Z',
+              content: [{ type: 'text', text: 'mobile layout complete' }],
+            },
+          ],
+        },
+      });
+    };
+
+    const executor = new KimiExecutor(config(), logger, client);
+    const handle = executor.startExecution({
+      prompt: 'build frontend',
+      cwd: '/tmp',
+      abortController: new AbortController(),
+      apiContext: { botName: 'kimi-test', chatId: 'oc-kimi-steer' },
+    });
+    await handle.stream.next();
+    const pending = handle.stream.next();
+    await vi.waitFor(() => expect(client.submitPrompt).toHaveBeenCalled());
+
+    expect(executor.canSteer('oc-kimi-steer')).toBe(true);
+    await expect(executor.steer('oc-kimi-steer', 'also optimize mobile')).resolves.toBe('steered');
+    expect(client.steer).toHaveBeenCalledWith('session-kimi-1', 'also optimize mobile', {
+      model: 'kimi-code/k3',
+      thinking: 'high',
+    });
+    release();
+    await pending;
+    await collect(handle.stream);
+    expect(executor.canSteer('oc-kimi-steer')).toBe(false);
+  });
+
+  it('maps /stop aborts to the active Kimi Code session and closes the turn', async () => {
+    const client = new FakeKimiClient();
+    let releaseAbort!: () => void;
+    const aborted = new Promise<void>((resolve) => {
+      releaseAbort = resolve;
+    });
+    client.abortSession = vi.fn(async () => {
+      releaseAbort();
+    });
+    client.afterSubmit = async () => {
+      await aborted;
+      return snapshot({
+        session: { ...snapshot().session, last_turn_reason: 'cancelled' },
+      });
+    };
+    const abortController = new AbortController();
+    const executor = new KimiExecutor(config(), logger, client);
+    const handle = executor.startExecution({
+      prompt: 'long frontend task',
+      cwd: '/tmp',
+      abortController,
+      apiContext: { botName: 'kimi-test', chatId: 'oc-kimi-stop' },
+    });
+    await handle.stream.next();
+    const pending = handle.stream.next();
+    await vi.waitFor(() => expect(client.submitPrompt).toHaveBeenCalled());
+
+    abortController.abort();
+    const terminal = await pending;
+    await collect(handle.stream);
+
+    expect(client.abortSession).toHaveBeenCalledWith('session-kimi-1');
+    expect(terminal.value).toMatchObject({ type: 'result', subtype: 'error_cancelled', is_error: true });
+  });
+
+  it('does not auto-approve a pending tool request in the default permission mode', async () => {
+    const client = new FakeKimiClient();
+    client.afterSubmit = async () =>
+      snapshot({
+        session: { ...snapshot().session, busy: true, pending_interaction: 'approval' },
+        pending_approvals: [
+          {
+            approval_id: 'approval-1',
+            session_id: 'session-kimi-1',
+            tool_call_id: 'tool-1',
+            tool_name: 'Shell',
+          },
+        ],
+      });
+
+    const executor = new KimiExecutor(config(), logger, client);
+    const messages = await collect(
+      executor.startExecution({
+        prompt: 'run a sensitive command',
+        cwd: '/tmp',
+        abortController: new AbortController(),
+        apiContext: { botName: 'kimi-test', chatId: 'oc-kimi-approval' },
+      }).stream,
+    );
+
+    expect(client.approve).not.toHaveBeenCalled();
+    expect(client.abortSession).toHaveBeenCalledWith('session-kimi-1');
+    expect(messages.at(-1)).toMatchObject({ type: 'result', subtype: 'error_during_execution', is_error: true });
+    expect(messages.at(-1)?.errors?.[0]).toContain('did not auto-approve');
+  });
+
+  it('maps /goal to Kimi Code native goal state and submits only the objective', async () => {
+    const client = new FakeKimiClient();
+    const executor = new KimiExecutor(config(), logger, client);
+    await collect(
+      executor.startExecution({
+        prompt: '/goal ship the frontend',
+        cwd: '/tmp',
+        abortController: new AbortController(),
+        apiContext: { botName: 'kimi-test', chatId: 'oc-kimi-goal' },
+      }).stream,
+    );
+
+    expect(client.setGoal).toHaveBeenCalledWith('session-kimi-1', 'ship the frontend');
+    expect(client.submitPrompt).toHaveBeenCalledWith(
+      'session-kimi-1',
+      expect.stringContaining('ship the frontend'),
+      expect.objectContaining({ model: 'kimi-code/k3', permissionMode: 'auto' }),
+    );
+    expect(client.submitPrompt.mock.calls[0]?.[1]).not.toContain('/goal');
+  });
+});

--- a/tests/kimi-session-lister.test.ts
+++ b/tests/kimi-session-lister.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { listKimiSessions } from '../src/engines/kimi/session-lister.js';
+import type { KimiWireSession } from '../src/engines/kimi/daemon-client.js';
+
+function session(id: string, updatedAt: string, prompt: string): KimiWireSession {
+  return {
+    id,
+    title: id,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    busy: false,
+    metadata: { cwd: '/repo' },
+    agent_config: { model: 'kimi-code/k3' },
+    last_prompt: prompt,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+      total_cost_usd: 0,
+      context_tokens: 0,
+      context_limit: 1_048_576,
+      turn_count: 0,
+    },
+  };
+}
+
+describe('listKimiSessions', () => {
+  it('lists current Kimi Code Server sessions newest-first for /resume', async () => {
+    const client = {
+      listSessions: vi.fn(async () => [
+        session('session-old', '2026-07-18T00:00:00.000Z', 'old prompt'),
+        session('session-new', '2026-07-19T00:00:00.000Z', 'new\nfrontend prompt'),
+      ]),
+    };
+    const result = await listKimiSessions({
+      workingDirectory: '/repo',
+      currentSessionId: 'session-new',
+      client,
+    });
+
+    expect(client.listSessions).toHaveBeenCalledWith('/repo');
+    expect(result).toEqual([
+      expect.objectContaining({ sessionId: 'session-new', preview: 'new frontend prompt', isCurrent: true }),
+      expect.objectContaining({ sessionId: 'session-old', preview: 'old prompt', isCurrent: false }),
+    ]);
+  });
+
+  it('degrades to an empty picker if the local Kimi server is unavailable', async () => {
+    const client = { listSessions: vi.fn(async () => Promise.reject(new Error('offline'))) };
+    await expect(listKimiSessions({ workingDirectory: '/repo', client })).resolves.toEqual([]);
+  });
+});

--- a/tests/session-lister.test.ts
+++ b/tests/session-lister.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import Database from 'better-sqlite3';
 import {
   claudeProjectsDir,
   listClaudeSessions,
 } from '../src/engines/claude/session-lister.js';
+import { listCodexSessions } from '../src/engines/codex/session-lister.js';
 
 /**
  * session-lister backs the Feishu `/resume` command. It reads the on-disk
@@ -126,5 +128,51 @@ describe('listClaudeSessions', () => {
     // newest two: index 4 then 3
     expect(out[0].preview).toBe('prompt 4');
     expect(out[1].preview).toBe('prompt 3');
+  });
+});
+
+describe('listCodexSessions', () => {
+  it('reads cwd-filtered Codex threads from state_5.sqlite', () => {
+    const codexHome = path.join(home, '.codex');
+    fs.mkdirSync(codexHome, { recursive: true });
+    const db = new Database(path.join(codexHome, 'state_5.sqlite'));
+    db.exec(`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        rollout_path TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        model_provider TEXT NOT NULL,
+        cwd TEXT NOT NULL,
+        title TEXT NOT NULL,
+        sandbox_policy TEXT NOT NULL,
+        approval_mode TEXT NOT NULL,
+        archived INTEGER NOT NULL DEFAULT 0,
+        updated_at_ms INTEGER,
+        first_user_message TEXT NOT NULL DEFAULT '',
+        preview TEXT NOT NULL DEFAULT ''
+      );
+    `);
+    const insert = db.prepare(`
+      INSERT INTO threads
+      (id, rollout_path, created_at, updated_at, source, model_provider, cwd, title, sandbox_policy, approval_mode, archived, updated_at_ms, first_user_message, preview)
+      VALUES (?, ?, ?, ?, 'vscode', 'openai', ?, ?, 'workspace-write', 'never', 0, ?, ?, ?)
+    `);
+    insert.run('codex-old', 'sessions/old.jsonl', 1, 1, CWD, 'old title', 1000, 'old prompt', '');
+    insert.run('codex-new', 'sessions/new.jsonl', 2, 2, CWD, 'new title', 3000, 'new prompt', 'new preview');
+    insert.run('codex-other', 'sessions/other.jsonl', 3, 3, '/other/project', 'other title', 4000, 'other prompt', '');
+    db.close();
+
+    const out = listCodexSessions({
+      workingDirectory: CWD,
+      homeDir: home,
+      currentSessionId: 'codex-old',
+    });
+
+    expect(out.map((s) => s.sessionId)).toEqual(['codex-new', 'codex-old']);
+    expect(out[0].preview).toBe('new preview');
+    expect(out[1].preview).toBe('old prompt');
+    expect(out[1].isCurrent).toBe(true);
   });
 });

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.6.1",
+        "react-router-dom": "^7.18.1",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "zustand": "^5.0.5"
@@ -2963,9 +2963,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2985,12 +2985,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.6.1",
+    "react-router-dom": "^7.18.1",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "zustand": "^5.0.5"

--- a/web/src/components/LoginPage.tsx
+++ b/web/src/components/LoginPage.tsx
@@ -87,11 +87,11 @@ export function LoginPage() {
         <div className={styles.footer}>
           Powered by{' '}
           <a
-            href="https://github.com/anthropics/claude-code"
+            href="https://github.com/xvirobotics/metabot"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Claude Code Agent SDK
+            MetaBot Personal Edition · Codex · Kimi Code
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- migrate the personal-edition Kimi adapter from the retired SDK/wire path to Kimi Code 0.27+ local Server API
- add Kimi and Codex session discovery/resume, Kimi snapshots/questions/stop/tools/subagents/goals, and Codex terminal-result process reaping
- recommend GPT-5.6 models, support six Codex effort levels, and keep the public Codex sandbox at workspace-write
- upgrade installers to Node >=22.19, Codex-first selection, npm-installed Kimi Code, and three-engine Skill mirroring
- simplify README.md and README_EN.md to 207/209 lines with Codex and Kimi Code first
- harden production dependencies to zero npm audit findings

## Personal-edition boundaries

- Kimi Server URL is loopback-only; the local server token cannot be sent to a remote host
- Kimi permissions default to auto; pending tool approvals are not auto-approved unless yolo is explicitly configured for a trusted workspace
- no Feilian, OIDC, employee directory, private domain, or internal credentials
- Codex app-server and Feishu mid-turn steering remain deferred until the shared reliability foundation lands

## Verification

- focused engine/installer suite: 157 passing
- full suite with SESSION_STORE_DIR unset: 1121 passing
- bridge TypeScript build and full production build: passing
- ESLint: zero errors, eight pre-existing warnings
- MkDocs strict build: passing
- root and web production npm audit: zero vulnerabilities
- personal GitHub package: SHA256, manifest, extraction, runtime contents, clean production npm ci and audit all passing
