### PR TITLE
fix(bridge): stop replaying delivered output files on follow-up turns

### DIFF
--- a/src/bridge/output-handler.ts
+++ b/src/bridge/output-handler.ts
@@ -49,10 +49,12 @@ export class OutputHandler {
     // 1. Scan the outputs directory for any files the agent placed there
     const outputFiles = this.outputsManager.scanOutputs(outputsDir);
     for (const file of outputFiles) {
+      let delivered = false;
       try {
         if (file.isImage && file.sizeBytes <= IMAGE_MAX_BYTES) {
           this.logger.info({ filePath: file.filePath }, 'Sending output image from outputs dir');
           await this.sender.sendImageFile(chatId, file.filePath);
+          delivered = true;
         } else if (!file.isImage && file.sizeBytes <= FILE_MAX_BYTES) {
           this.logger.info({ filePath: file.filePath }, 'Sending output file from outputs dir');
           const sent = await this.sender.sendLocalFile(chatId, file.filePath, file.fileName);
@@ -61,15 +63,25 @@ export class OutputHandler {
             const content = fs.readFileSync(file.filePath, 'utf-8');
             await this.sender.sendText(chatId, `📄 ${file.fileName}\n\n${content}`);
           }
+          delivered = true;
         } else {
           // Track for a single end-of-batch notice so users know files exist
           // but were dropped — silently logging warn was the original bug.
           this.logger.warn({ filePath: file.filePath, sizeBytes: file.sizeBytes }, 'Output file too large to send');
           oversized.push({ fileName: file.fileName, sizeBytes: file.sizeBytes, isImage: file.isImage });
+          delivered = true;
         }
         sentPaths.add(file.filePath);
       } catch (err) {
         this.logger.warn({ err, filePath: file.filePath }, 'Failed to send output file');
+      }
+      // Bind delivery to deletion: once a file is sent (or accounted for via
+      // the oversized notice), remove it so the next turn does not rescan
+      // and resend it. Without this, every subsequent user message within
+      // the 5-min retention window replays the entire outputs directory.
+      if (delivered) {
+        try { fs.unlinkSync(file.filePath); }
+        catch (err) { this.logger.warn({ err, filePath: file.filePath }, 'Failed to unlink sent output file'); }
       }
     }
 

--- a/src/bridge/output-handler.ts
+++ b/src/bridge/output-handler.ts
@@ -22,6 +22,10 @@ interface OversizedFile {
   fileName:  string;
   sizeBytes: number;
   isImage:   boolean;
+  /** Set only for outputs-dir files — these are deleted once the notice
+   *  reaches the user. Fallback-scan images live outside the outputs dir
+   *  and are never deleted. */
+  filePath?: string;
 }
 
 function formatBytes(bytes: number): string {
@@ -53,32 +57,35 @@ export class OutputHandler {
       try {
         if (file.isImage && file.sizeBytes <= IMAGE_MAX_BYTES) {
           this.logger.info({ filePath: file.filePath }, 'Sending output image from outputs dir');
-          await this.sender.sendImageFile(chatId, file.filePath);
-          delivered = true;
+          delivered = await this.sender.sendImageFile(chatId, file.filePath);
         } else if (!file.isImage && file.sizeBytes <= FILE_MAX_BYTES) {
           this.logger.info({ filePath: file.filePath }, 'Sending output file from outputs dir');
           const sent = await this.sender.sendLocalFile(chatId, file.filePath, file.fileName);
-          if (!sent && OutputsManager.isTextFile(file.extension) && file.sizeBytes < 30 * 1024) {
+          if (sent) {
+            delivered = true;
+          } else if (OutputsManager.isTextFile(file.extension) && file.sizeBytes < 30 * 1024) {
             this.logger.info({ filePath: file.filePath }, 'File upload failed, sending as text message');
             const content = fs.readFileSync(file.filePath, 'utf-8');
             await this.sender.sendText(chatId, `📄 ${file.fileName}\n\n${content}`);
+            delivered = true;
           }
-          delivered = true;
         } else {
           // Track for a single end-of-batch notice so users know files exist
           // but were dropped — silently logging warn was the original bug.
+          // Deletion is deferred until that notice actually reaches the user.
           this.logger.warn({ filePath: file.filePath, sizeBytes: file.sizeBytes }, 'Output file too large to send');
-          oversized.push({ fileName: file.fileName, sizeBytes: file.sizeBytes, isImage: file.isImage });
-          delivered = true;
+          oversized.push({ fileName: file.fileName, sizeBytes: file.sizeBytes, isImage: file.isImage, filePath: file.filePath });
         }
         sentPaths.add(file.filePath);
       } catch (err) {
         this.logger.warn({ err, filePath: file.filePath }, 'Failed to send output file');
       }
-      // Bind delivery to deletion: once a file is sent (or accounted for via
-      // the oversized notice), remove it so the next turn does not rescan
-      // and resend it. Without this, every subsequent user message within
-      // the 5-min retention window replays the entire outputs directory.
+      // Bind delivery to deletion: only once a file actually reached the user
+      // (send resolved true, or the text fallback succeeded) remove it so the
+      // next turn does not rescan and resend it. Without this, every user
+      // message within the 5-min retention window replays the entire outputs
+      // directory. Files whose send returned false or threw stay on disk so
+      // the next turn retries them.
       if (delivered) {
         try { fs.unlinkSync(file.filePath); }
         catch (err) { this.logger.warn({ err, filePath: file.filePath }, 'Failed to unlink sent output file'); }
@@ -118,11 +125,21 @@ export class OutputHandler {
     //    the file. One coalesced notice for the whole batch instead of one
     //    per file so a 10-file batch with all-oversized doesn't spam.
     if (oversized.length > 0) {
-      await this.sendOversizedNotice(chatId, oversized);
+      const noticed = await this.sendOversizedNotice(chatId, oversized);
+      // Oversized files count as "accounted for" only once the notice reached
+      // the user — if it failed, keep them so the next turn re-raises it.
+      if (noticed) {
+        for (const f of oversized) {
+          if (!f.filePath) continue;
+          try { fs.unlinkSync(f.filePath); }
+          catch (err) { this.logger.warn({ err, filePath: f.filePath }, 'Failed to unlink oversized output file'); }
+        }
+      }
     }
   }
 
-  private async sendOversizedNotice(chatId: string, files: OversizedFile[]): Promise<void> {
+  /** @returns true when the notice reached the user. */
+  private async sendOversizedNotice(chatId: string, files: OversizedFile[]): Promise<boolean> {
     const lines = [
       `Cannot send **${files.length}** file${files.length === 1 ? '' : 's'} because ${files.length === 1 ? 'it exceeds' : 'they exceed'} the Feishu upload limit (max ${IMAGE_MAX_BYTES / 1024 / 1024}MB images, ${FILE_MAX_BYTES / 1024 / 1024}MB files):`,
       '',
@@ -130,8 +147,10 @@ export class OutputHandler {
     ];
     try {
       await this.sender.sendTextNotice(chatId, '⚠️ Files Too Large', lines.join('\n'), 'orange');
+      return true;
     } catch (err) {
       this.logger.warn({ err, chatId, count: files.length }, 'Failed to send oversized-file notice');
+      return false;
     }
   }
 }

--- a/tests/output-handler.test.ts
+++ b/tests/output-handler.test.ts
@@ -163,9 +163,12 @@ describe('OutputHandler.sendOutputFiles', () => {
  * scanOutputs is a stateless directory walk — so without binding delivery
  * to deletion, EVERY follow-up message inside that window replays the whole
  * outputs directory to the chat ("thanks" → here is report.pdf again).
- * Delivered files (sent, text-fallback, or accounted for via the oversized
- * notice) are therefore unlinked; files whose send THREW stay on disk so the
- * next turn retries them.
+ * Delivered files are therefore unlinked — but ONLY on proof of delivery:
+ * a send that resolved true, a text fallback that resolved, or an oversized
+ * notice that reached the user. A send that returned false, a send that
+ * threw, and a failed notice all leave the file on disk so the next turn
+ * retries it. Deleting on a false return would silently destroy the file
+ * the user never received.
  */
 describe('OutputHandler resend prevention', () => {
   let tmpDir:  string;
@@ -232,5 +235,64 @@ describe('OutputHandler resend prevention', () => {
 
     await handler.sendOutputFiles('chat-1', outputs.prepareDir('chat-1'), mockProcessor, emptyState());
     expect(sends).toHaveLength(1);  // retry succeeded on the follow-up turn
+  });
+
+  it('keeps an image whose upload returned false, so the next turn can retry it', async () => {
+    fs.writeFileSync(path.join(chatDir, 'pic.png'), Buffer.alloc(1024));
+    const { sender, sends } = buildSender({ failImage: true });
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toEqual([expect.objectContaining({ type: 'image' })]);   // attempted
+    expect(fs.existsSync(path.join(chatDir, 'pic.png'))).toBe(true);      // NOT deleted
+
+    // Next turn with a healthy sender: delivers, then deletes.
+    const { sender: okSender, sends: okSends } = buildSender();
+    await new OutputHandler(mockLogger, okSender, outputs).sendOutputFiles('chat-1', outputs.prepareDir('chat-1'), mockProcessor, emptyState());
+    expect(okSends).toEqual([expect.objectContaining({ type: 'image' })]);
+    expect(fs.existsSync(path.join(chatDir, 'pic.png'))).toBe(false);
+  });
+
+  it('keeps a file whose upload returned false when no text fallback applies', async () => {
+    // .pdf is not an isTextFile format, so a false return has no fallback:
+    // nothing reached the user and the file must survive for the next turn.
+    fs.writeFileSync(path.join(chatDir, 'report.pdf'), Buffer.alloc(1024));
+    const { sender, sends } = buildSender({ failFile: true });
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toEqual([expect.objectContaining({ type: 'file' })]);
+    expect(fs.existsSync(path.join(chatDir, 'report.pdf'))).toBe(true);
+  });
+
+  it('deletes a file delivered via the text fallback after a false upload return', async () => {
+    fs.writeFileSync(path.join(chatDir, 'notes.txt'), 'hello from the agent');
+    const { sender, sends } = buildSender({ failFile: true });
+    await new OutputHandler(mockLogger, sender, outputs).sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends.filter((s) => s.type === 'text')).toHaveLength(1);       // fallback fired
+    expect(fs.existsSync(path.join(chatDir, 'notes.txt'))).toBe(false);   // delivered → deleted
+  });
+
+  it('keeps an oversized file when the notice fails, and re-raises it next turn', async () => {
+    fs.writeFileSync(path.join(chatDir, 'huge.png'), Buffer.alloc(10 * 1024 * 1024 + 1));
+    const noticed: string[] = [];
+    let noticeCalls = 0;
+    const flakyNoticeSender = {
+      sendText:      async () => {},
+      sendImageFile: async () => true,
+      sendLocalFile: async () => true,
+      sendTextNotice: async (_chat: string, _title: string, content: string) => {
+        noticeCalls++;
+        if (noticeCalls === 1) throw new Error('feishu hiccup');
+        noticed.push(content);
+      },
+    } as any;
+    const handler = new OutputHandler(mockLogger, flakyNoticeSender, outputs);
+
+    await handler.sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    // Notice never reached the user — the file must survive, or the user
+    // would never learn it existed.
+    expect(fs.existsSync(path.join(chatDir, 'huge.png'))).toBe(true);
+
+    await handler.sendOutputFiles('chat-1', outputs.prepareDir('chat-1'), mockProcessor, emptyState());
+    expect(noticed).toHaveLength(1);                                      // re-raised and delivered
+    expect(noticed[0]).toContain('huge.png');
+    expect(fs.existsSync(path.join(chatDir, 'huge.png'))).toBe(false);    // now accounted for
   });
 });

--- a/tests/output-handler.test.ts
+++ b/tests/output-handler.test.ts
@@ -155,3 +155,82 @@ describe('OutputHandler.sendOutputFiles', () => {
     expect(notices[0].content).not.toMatch(/files because they/);
   });
 });
+
+/**
+ * Resend prevention across turns.
+ *
+ * prepareDir keeps files younger than the 5-minute retention window, and
+ * scanOutputs is a stateless directory walk — so without binding delivery
+ * to deletion, EVERY follow-up message inside that window replays the whole
+ * outputs directory to the chat ("thanks" → here is report.pdf again).
+ * Delivered files (sent, text-fallback, or accounted for via the oversized
+ * notice) are therefore unlinked; files whose send THREW stay on disk so the
+ * next turn retries them.
+ */
+describe('OutputHandler resend prevention', () => {
+  let tmpDir:  string;
+  let outputs: OutputsManager;
+  let chatDir: string;
+
+  beforeEach(() => {
+    tmpDir  = fs.mkdtempSync(path.join(os.tmpdir(), 'metabot-output-resend-'));
+    outputs = new OutputsManager(tmpDir, mockLogger);
+    chatDir = outputs.prepareDir('chat-1');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not resend a delivered file on the next turn within the retention window', async () => {
+    fs.writeFileSync(path.join(chatDir, 'report.pdf'), Buffer.alloc(1024));
+    const { sender, sends } = buildSender();
+    const handler = new OutputHandler(mockLogger, sender, outputs);
+
+    await handler.sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toHaveLength(1);  // first turn delivers it
+
+    // Follow-up message moments later: retention keeps recent files, so only
+    // delivery-bound deletion stands between the user and a replay.
+    const chatDir2 = outputs.prepareDir('chat-1');
+    await handler.sendOutputFiles('chat-1', chatDir2, mockProcessor, emptyState());
+    expect(sends).toHaveLength(1);  // nothing resent
+  });
+
+  it('does not repeat the oversized notice on the next turn', async () => {
+    fs.writeFileSync(path.join(chatDir, 'huge.png'), Buffer.alloc(10 * 1024 * 1024 + 1));
+    const { sender, notices } = buildSender();
+    const handler = new OutputHandler(mockLogger, sender, outputs);
+
+    await handler.sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(notices).toHaveLength(1);
+
+    await handler.sendOutputFiles('chat-1', outputs.prepareDir('chat-1'), mockProcessor, emptyState());
+    expect(notices).toHaveLength(1);  // still the single original notice
+  });
+
+  it('keeps a file whose send threw, so the next turn can retry it', async () => {
+    fs.writeFileSync(path.join(chatDir, 'flaky.pdf'), Buffer.alloc(1024));
+    const sends: string[] = [];
+    let calls = 0;
+    const throwingSender = {
+      sendTextNotice: async () => {},
+      sendText:       async () => {},
+      sendImageFile:  async () => true,
+      sendLocalFile:  async (_chat: string, filePath: string) => {
+        calls++;
+        if (calls === 1) throw new Error('feishu hiccup');
+        sends.push(filePath);
+        return true;
+      },
+    } as any;
+    const handler = new OutputHandler(mockLogger, throwingSender, outputs);
+
+    await handler.sendOutputFiles('chat-1', chatDir, mockProcessor, emptyState());
+    expect(sends).toHaveLength(0);                                    // first turn failed
+    expect(fs.existsSync(path.join(chatDir, 'flaky.pdf'))).toBe(true); // file survives for retry
+
+    await handler.sendOutputFiles('chat-1', outputs.prepareDir('chat-1'), mockProcessor, emptyState());
+    expect(sends).toHaveLength(1);  // retry succeeded on the follow-up turn
+  });
+});


### PR DESCRIPTION
## Problem

Every follow-up message within 5 minutes of a task that produced output files replays the **entire outputs directory** to the chat — say "thanks" after receiving `report.pdf`, and the bot sends `report.pdf` again (and repeats the oversized-file notice too).

Three pieces line up to cause it:

1. `OutputsManager.prepareDir` intentionally keeps files younger than the 5-minute retention window (`RETENTION_MS`),
2. `scanOutputs` is a stateless directory walk with no delivered-file filter,
3. `sentPaths` in `OutputHandler.sendOutputFiles` is method-local — it only dedupes within a single call, with zero memory across turns.

## Fix

Bind delivery to deletion: once a file is **sent**, **text-fallbacked**, or **accounted for via the oversized notice**, unlink it so the next turn's scan doesn't see it. Files whose send **threw** are deliberately kept on disk (`delivered` stays false), so the follow-up turn retries them — the retention window still garbage-collects them eventually.

## Tests (red/green verified)

`tests/output-handler.test.ts` gains a "resend prevention" suite; the two resend cases **fail on the unfixed code**:

```
× does not resend a delivered file on the next turn within the retention window
× does not repeat the oversized notice on the next turn
✓ keeps a file whose send threw, so the next turn can retry it   (semantics lock)
```

With the fix: file suite 9/9, full root suite 63 files / 665 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)