### PR TITLE
release: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-24
+
+### Added
+
+- The repository now ships a concise root `AGENTS.md` baseline for public contributors while preserving user-owned workspace `AGENTS.md` and `CLAUDE.md` files during install and package updates.
+- Agent prompts now include dynamic Current MetaBot Context and compact Team Context sections consistently across Codex, Kimi Code, and Claude compatibility paths.
+
+### Changed
+
+- The packaged `metabot` and `metabot-team` Skills are now the canonical CLI and durable-state references, without duplicate source mirrors or workspace policy.
+- The documentation site has a redesigned landing page and a unified theme across inner pages, with outdated Personal Edition pages removed from navigation.
+- GitHub Actions now test supported Node.js 22 and use Node.js 24-compatible action runtimes.
+
 ## [1.2.0] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Skills、T5T、Teams 和 CLI Access 共用同一 Token 与同一套导航。
 | `/background <提示>`                           | 在 Chat 继续使用时运行受支持的后台任务           |
 | `@Bot /group-reply mention\|all\|status`       | 控制一个飞书 Bot 在一个群里的回复模式            |
 | `metabot update`                               | 将 Package 管理的个人版升级到最新 GitHub Release |
-| `metabot update --package --version 1.2.0`     | 精确安装不可变的 v1.2.0 Release 包               |
+| `metabot update --package --version 1.3.0`     | 精确安装不可变的 v1.3.0 Release 包               |
 
 完整命令详见[聊天命令](docs/usage/chat-commands.zh.md)、[CLI 参考](docs/reference/cli-metabot.zh.md)和 [REST API](docs/reference/api.zh.md)。
 
@@ -192,7 +192,7 @@ Release。需要可复现版本时可固定不可变 Release；源码 checkout �
 
 ```bash
 metabot update                                  # 最新 GitHub Release
-metabot update --package --version 1.2.0        # 精确安装 v1.2.0
+metabot update --package --version 1.3.0        # 精确安装 v1.3.0
 metabot update --git                            # 源码 checkout
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -176,7 +176,7 @@ Each bot has its own channel credentials, engine, workspace, and sessions. Bots 
 | `/background <prompt>`                         | Run a supported background task while the chat continues               |
 | `@Bot /group-reply mention\|all\|status`       | Control one Feishu bot's reply mode in one group                       |
 | `metabot update`                               | Update a package-managed personal edition to the latest GitHub Release |
-| `metabot update --package --version 1.2.0`     | Install exactly the immutable v1.2.0 Release package                   |
+| `metabot update --package --version 1.3.0`     | Install exactly the immutable v1.3.0 Release package                   |
 
 See [Chat Commands](docs/usage/chat-commands.md), the [CLI Reference](docs/reference/cli-metabot.md), and the [REST API](docs/reference/api.md) for the complete surfaces.
 
@@ -195,7 +195,7 @@ source checkouts retain an explicit Git path:
 
 ```bash
 metabot update                                  # latest GitHub Release
-metabot update --package --version 1.2.0        # exactly v1.2.0
+metabot update --package --version 1.3.0        # exactly v1.3.0
 metabot update --git                            # source checkout
 ```
 

--- a/bin/metabot
+++ b/bin/metabot
@@ -1618,7 +1618,7 @@ print_help() {
   echo "  Process control:"
   echo "    metabot update            Auto: git checkout pulls; package install downloads release"
   echo "    metabot update --package  Refresh from the latest GitHub Release package"
-  echo "    metabot update --package --version 1.2.0  Install one immutable release"
+  echo "    metabot update --package --version 1.3.0  Install one immutable release"
   echo "    metabot update --git      Git pull, rebuild, and restart"
   echo "    metabot start      Start MetaBot with PM2"
   echo "    metabot stop       Stop MetaBot"

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -80,7 +80,7 @@ Do not reuse the Core token as the Bridge secret.
 
 ```bash
 metabot update                                  # latest verified release
-metabot update --package --version 1.2.0        # known immutable release
+metabot update --package --version 1.3.0        # known immutable release
 metabot doctor
 ```
 

--- a/docs/deployment/production.zh.md
+++ b/docs/deployment/production.zh.md
@@ -76,7 +76,7 @@ Shell 历史或共享配置。
 
 ```bash
 metabot update                                  # 最新已校验 Release
-metabot update --package --version 1.2.0        # 已知不可变 Release
+metabot update --package --version 1.3.0        # 已知不可变 Release
 metabot doctor
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -86,11 +86,11 @@ metabot update
 To install one immutable release instead of following `latest`:
 
 ```bash
-metabot update --package --version 1.2.0
+metabot update --package --version 1.3.0
 ```
 
 The pinned form downloads `install.sh`, `metabot-runtime.tgz`, and
-`SHA256SUMS` from the GitHub v1.2.0 Release. Package updates verify the runtime
+`SHA256SUMS` from the GitHub v1.3.0 Release. Package updates verify the runtime
 SHA256, validate the complete personal-edition manifest and semantic version,
 and fail closed if a pinned package reports a different version.
 

--- a/docs/getting-started/installation.zh.md
+++ b/docs/getting-started/installation.zh.md
@@ -84,10 +84,10 @@ metabot update
 需要固定不可变 Release、不跟随 `latest` 时：
 
 ```bash
-metabot update --package --version 1.2.0
+metabot update --package --version 1.3.0
 ```
 
-固定版本会从 GitHub v1.2.0 Release 下载 `install.sh`、
+固定版本会从 GitHub v1.3.0 Release 下载 `install.sh`、
 `metabot-runtime.tgz` 和 `SHA256SUMS`。Package 更新会验证 runtime SHA256，
 校验完整个人版 Manifest 和语义版本；固定包报告的版本不匹配时会失败关闭。
 

--- a/docs/reference/cli-metabot.md
+++ b/docs/reference/cli-metabot.md
@@ -20,7 +20,7 @@ Installed automatically by the MetaBot installer to `~/.local/bin/metabot`.
 ```bash
 metabot update                                  # package install: latest GitHub Release
 metabot update --package                        # force latest GitHub Release package
-metabot update --package --version 1.2.0        # pin immutable Release v1.2.0
+metabot update --package --version 1.3.0        # pin immutable Release v1.3.0
 metabot update --git                            # force git pull + rebuild + restart
 metabot start                       # start with PM2
 metabot stop                        # stop
@@ -33,7 +33,7 @@ For a normal package-managed personal edition, `metabot update` defaults to the
 latest GitHub Release. A source checkout is auto-detected and keeps its Git
 update path; use `--package` to force a Release overlay.
 
-`metabot update --package --version 1.2.0` selects the immutable v1.2.0 assets
+`metabot update --package --version 1.3.0` selects the immutable v1.3.0 assets
 instead of `latest`. Package updating performs:
 
 1. Download `install.sh`, `metabot-runtime.tgz`, and `SHA256SUMS` from the latest or pinned GitHub Release.

--- a/docs/reference/cli-metabot.zh.md
+++ b/docs/reference/cli-metabot.zh.md
@@ -19,7 +19,7 @@ MetaBot 安装器自动安装到 `~/.local/bin/metabot`。
 ```bash
 metabot update                                  # Package 安装：最新 GitHub Release
 metabot update --package                        # 强制使用最新 GitHub Release 包
-metabot update --package --version 1.2.0        # 固定不可变 Release v1.2.0
+metabot update --package --version 1.3.0        # 固定不可变 Release v1.3.0
 metabot update --git                            # 强制 git pull + 构建 + 重启
 metabot start                       # 启动（PM2）
 metabot stop                        # 停止
@@ -32,7 +32,7 @@ metabot status                      # PM2 进程状态
 Release。源码 checkout 会被自动识别并保留 Git 更新路径；用 `--package`
 可以强制进行 Release 覆盖。
 
-`metabot update --package --version 1.2.0` 选择不可变 v1.2.0 资源而不是
+`metabot update --package --version 1.3.0` 选择不可变 v1.3.0 资源而不是
 `latest`。Package 更新依次执行：
 
 1. 从最新或固定 GitHub Release 下载 `install.sh`、`metabot-runtime.tgz` 和 `SHA256SUMS`。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -96,7 +96,7 @@ metabot doctor
 For a reproducible rollback, install a known release explicitly:
 
 ```bash
-metabot update --package --version 1.2.0
+metabot update --package --version 1.3.0
 ```
 
 Updates preserve `.env`, `bots.json`, `data/`, `logs/`, `~/.metabot/`, and

--- a/docs/troubleshooting.zh.md
+++ b/docs/troubleshooting.zh.md
@@ -91,7 +91,7 @@ metabot doctor
 需要可复现回退时，显式安装已知版本：
 
 ```bash
-metabot update --package --version 1.2.0
+metabot update --package --version 1.3.0
 ```
 
 更新会保留 `.env`、`bots.json`、`data/`、`logs/`、`~/.metabot/` 和

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metabot",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metabot",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "workspaces": [
         "packages/cli",
         "packages/cli-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metabot",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "metabotEdition": "personal",
   "description": "MetaBot Personal Edition — use Codex and Kimi Code from IM channels and the local Web UI",
   "main": "dist/index.js",

--- a/packages/server/tests/pack-github-release.test.ts
+++ b/packages/server/tests/pack-github-release.test.ts
@@ -57,7 +57,7 @@ describe('GitHub release package', () => {
     );
     expect(manifest).toMatchObject({
       package: 'metabot-personal-edition',
-      version: '1.2.0',
+      version: '1.3.0',
       includesCore: true,
       includesWebUi: true,
     });


### PR DESCRIPTION
## Summary

- bump Personal Edition package metadata from 1.2.0 to 1.3.0
- add the v1.3.0 changelog entry for the documentation, Actions runtime, and Harness updates since v1.2.0
- refresh current pinned-release examples and the GitHub release manifest contract

## Validation

- release package contracts: 24/24
- root suite (isolated, serial scheduler persistence): 670/670
- workspace suites: 467/467
- `npx tsc --noEmit`
- `npm run lint` (0 errors; 8 pre-existing warnings)
- `npm run build`
- `npm run pack:github` plus checksum/tar validation
- extracted runtime install/build/Core health/auth/UI/token-leak smoke

## Release

After exact-head CI and Release checks pass and this PR is merged, tag the merged `main` commit as `v1.3.0` to publish the GitHub Release.