### PR TITLE
fix(kimi): avoid replaying non-idempotent daemon requests

### DIFF
--- a/src/engines/kimi/daemon-client.ts
+++ b/src/engines/kimi/daemon-client.ts
@@ -342,10 +342,16 @@ export class KimiDaemonClient {
     try {
       return await this.rawRequest(resource, body, query);
     } catch (error) {
-      // Recover once from a daemon restart or half-open local connection. API
-      // validation/provider errors carry a numeric code and must not restart.
+      // A transport failure means the cached readiness is stale even when the
+      // failed request cannot be retried. API validation/provider errors carry
+      // a numeric code and do not invalidate daemon readiness.
       if (!(error instanceof KimiDaemonError) || error.code !== undefined) throw error;
       this.ready = false;
+      // Recover a bodyless GET once after a daemon restart or half-open local
+      // connection. Never replay POSTs: the daemon may have accepted the
+      // operation before the response was lost, so retrying could duplicate a
+      // prompt or another side effect.
+      if (body !== undefined) throw error;
       await this.ensureRunning();
       return this.rawRequest(resource, body, query);
     }

--- a/tests/kimi-daemon-client.test.ts
+++ b/tests/kimi-daemon-client.test.ts
@@ -60,6 +60,65 @@ describe('KimiDaemonClient', () => {
     expect((fetchMock.mock.calls[1]?.[1]?.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
   });
 
+  it('does not replay a prompt when its response is lost', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockRejectedValueOnce(new Error('socket closed after request'));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KimiDaemonClient();
+
+    await expect(client.submitPrompt('session-1', 'run this once')).rejects.toThrow(
+      'Kimi Code server request failed: socket closed after request',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('/api/v1/sessions/session-1/prompts');
+  });
+
+  it('probes again before a later POST after a daemon transport failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockRejectedValueOnce(new Error('daemon exited during create'))
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockResolvedValueOnce(response({ id: 'session-recovered' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KimiDaemonClient();
+
+    await expect(client.createSession('/tmp/first')).rejects.toThrow(
+      'Kimi Code server request failed: daemon exited during create',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await expect(client.createSession('/tmp/second')).resolves.toMatchObject({
+      id: 'session-recovered',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/api/v1/healthz');
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('/api/v1/sessions');
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain('/api/v1/healthz');
+    expect(String(fetchMock.mock.calls[3]?.[0])).toContain('/api/v1/sessions');
+  });
+
+  it('reconnects and retries a bodyless GET after a transport failure', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockRejectedValueOnce(new Error('stale connection'))
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockResolvedValueOnce(response({ as_of_seq: 17 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KimiDaemonClient();
+
+    await expect(client.getSnapshot('session-1')).resolves.toMatchObject({ as_of_seq: 17 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('/api/v1/sessions/session-1/snapshot');
+    expect(String(fetchMock.mock.calls[3]?.[0])).toContain('/api/v1/sessions/session-1/snapshot');
+  });
+
   it('resolves short model names against the live Kimi Code config', async () => {
     await writeFile(
       path.join(home, 'config.toml'),


### PR DESCRIPTION
## Summary

- Invalidate cached daemon readiness after transport failures.
- Retry only bodyless GET requests after reconnecting.
- Preserve one-shot semantics for prompts, session creation, and other POST operations.

## Why

This is a follow-up to #344. With the Kimi Server API integration, a local transport failure can happen after the daemon has already accepted a POST but before MetaBot receives its response. Automatically replaying that request can duplicate prompts or other side effects. GET requests remain safe to retry once after the daemon is made ready again.

## Tests

- npx vitest run tests/kimi-daemon-client.test.ts
- npm run build
- npm test
- npm run lint (no errors; existing unrelated warnings remain)