### PR TITLE
fix(installer): verify Windows bridge startup

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -136,5 +136,11 @@ for the `metabot` CLI. It requires Git for Windows. The complete local
 Core/Web UI lifecycle remains provided by the Linux/macOS Release installer
 until Windows reaches packaging parity.
 
+The installer fails if dependency installation, the build, or PM2 startup
+fails, and waits for the Bridge health endpoint at `http://127.0.0.1:9100/api/health`.
+On failure it prints only bounded PM2 and log diagnostics. It does not install,
+stop, or delete a Core/MetaMemory service. Configure an existing Core with
+`METABOT_CORE_URL` and `METABOT_CORE_TOKEN`; standalone port `8100` is obsolete.
+
 Next: [Quick Setup](quick-setup.md) or the detailed
 [Feishu App Setup](feishu-app-setup.md).

--- a/docs/getting-started/installation.zh.md
+++ b/docs/getting-started/installation.zh.md
@@ -131,4 +131,10 @@ PowerShell 安装器会配置 Bridge，并为 `metabot` CLI 安装 `.cmd` wrappe
 Git for Windows。完整本地 Core/Web UI 生命周期目前仍由 Linux/macOS Release
 安装器提供，直到 Windows 打包能力达到同等水平。
 
+依赖安装、构建或 PM2 启动失败时，安装器会立即失败；启动后还会等待
+`http://127.0.0.1:9100/api/health` 返回成功。失败诊断只输出有限行数的
+PM2 信息和日志。PowerShell 安装器不会安装、停止或删除 Core/MetaMemory
+服务；请通过 `METABOT_CORE_URL` 和 `METABOT_CORE_TOKEN` 连接已有 Core，
+旧的独立 `8100` 端口已废弃。
+
 下一步：[快速配置](quick-setup.md)或详细的[飞书应用配置](feishu-app-setup.md)。

--- a/install.ps1
+++ b/install.ps1
@@ -157,6 +157,59 @@ function Test-VersionAtLeast {
     }
 }
 
+function Assert-NativeSuccess {
+    param([string]$Operation)
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Operation failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Wait-BridgeHealth {
+    param(
+        [string]$Url,
+        [int]$Attempts = 15,
+        [int]$DelaySeconds = 1
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 2
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                return $true
+            }
+        } catch {
+            # The bridge can take a few seconds to load dependencies and bots.
+        }
+        if ($attempt -lt $Attempts) {
+            Start-Sleep -Seconds $DelaySeconds
+        }
+    }
+    return $false
+}
+
+function Write-BridgeDiagnostics {
+    param(
+        [string]$InstallDir,
+        [int]$MaxLogLines = 40
+    )
+
+    Write-Warn "Bridge health check failed. Showing bounded diagnostics:"
+    try {
+        & pm2 describe metabot 2>&1 | Select-Object -First 80 | Out-Host
+    } catch {
+        Write-Warn "Unable to read PM2 process details: $($_.Exception.Message)"
+    }
+
+    foreach ($relativePath in @("logs\error.log", "logs\out.log")) {
+        $logPath = Join-Path $InstallDir $relativePath
+        if (Test-Path $logPath) {
+            Write-Host ""
+            Write-Host "--- Last $MaxLogLines lines of $relativePath ---" -ForegroundColor Yellow
+            Get-Content -LiteralPath $logPath -Tail $MaxLogLines -ErrorAction SilentlyContinue | Out-Host
+        }
+    }
+}
+
 function Get-KimiCodeVersion {
     if (-not (Test-Command "kimi")) { return $null }
     try {
@@ -384,6 +437,7 @@ if (Test-Path (Join-Path $MetabotHome ".git")) {
 } else {
     Write-Info "Cloning MetaBot..."
     git clone $MetabotRepo $MetabotHome
+    Assert-NativeSuccess "git clone"
 }
 Write-Success "MetaBot code ready at $MetabotHome"
 
@@ -395,12 +449,14 @@ Write-Step "Phase 3: Installing dependencies"
 Push-Location $MetabotHome
 Write-Info "Running npm install..."
 npm install --production=false
+Assert-NativeSuccess "npm install"
 Write-Success "npm dependencies installed"
 
 # PM2
 if (-not (Test-Command "pm2")) {
     Write-Info "Installing PM2 globally..."
     npm install -g pm2
+    Assert-NativeSuccess "PM2 installation"
     Write-Success "PM2 installed"
 } else {
     Write-Success "PM2 already installed"
@@ -598,7 +654,7 @@ if (-not $SkipConfig) {
 
     $ApiPort = "9100"
     $LogLevel = "info"
-    $MemoryServerUrl = "http://localhost:8100"
+    $CoreUrl = if ($env:METABOT_CORE_URL) { $env:METABOT_CORE_URL } else { "http://localhost:9200" }
 
     # Claude executable path
     $ClaudePath = ""
@@ -654,8 +710,9 @@ LOG_LEVEL=$LogLevel
 
     $envContent += @"
 
-# MetaMemory
-META_MEMORY_URL=$MemoryServerUrl
+# Optional Core service (not installed by the Windows Bridge installer)
+METABOT_CORE_URL=$CoreUrl
+# METABOT_CORE_TOKEN=
 "@
 
     [System.IO.File]::WriteAllText($EnvFile, $envContent, [System.Text.UTF8Encoding]::new($false))
@@ -869,48 +926,31 @@ if ($MetabotHome -ne $DefaultMetabotHome) {
 }
 
 # ============================================================================
-# Phase 7: MetaMemory
+# Phase 7: Core status
 # ============================================================================
-Write-Step "Phase 7: MetaMemory"
+Write-Step "Phase 7: Checking optional Core service"
 
-$MetamemoryInstalled = $false
-
-Write-Info "MetaMemory is embedded in MetaBot (no separate server needed)."
-New-Item -ItemType Directory -Path (Join-Path $MetabotHome "data") -Force | Out-Null
-
-# Migrate existing database from standalone MetaMemory if found
-$OldDb = Join-Path $env:USERPROFILE ".metamemory-data\metamemory.db"
-$NewDb = Join-Path $MetabotHome "data\metamemory.db"
-if ((Test-Path $OldDb) -and -not (Test-Path $NewDb)) {
-    Write-Info "Migrating existing MetaMemory database..."
-    Copy-Item $OldDb $NewDb -Force
-    Write-Success "Database migrated from ~/.metamemory-data/"
+$ConfiguredCoreUrl = if ($env:METABOT_CORE_URL) { $env:METABOT_CORE_URL } else { "http://localhost:9200" }
+if (Test-Path $EnvFile) {
+    $coreLine = Get-Content -LiteralPath $EnvFile -ErrorAction SilentlyContinue |
+        Where-Object { $_ -match '^\s*METABOT_CORE_URL=' } |
+        Select-Object -Last 1
+    if ($coreLine) {
+        $ConfiguredCoreUrl = ($coreLine -replace '^\s*METABOT_CORE_URL=', '').Trim().Trim('"').Trim("'")
+    }
 }
 
-# Stop old standalone MetaMemory PM2 process if running
+Write-Info "The Windows installer manages the MetaBot Bridge only."
+Write-Info "Core Console and MetaMemory require a separately running Core service."
 try {
-    $pm2Desc = pm2 describe metamemory 2>$null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Info "Stopping old standalone MetaMemory PM2 process..."
-        pm2 delete metamemory 2>$null
-        Write-Success "Old MetaMemory process removed"
+    $coreHealth = Invoke-WebRequest -Uri "$($ConfiguredCoreUrl.TrimEnd('/'))/health" -UseBasicParsing -TimeoutSec 3
+    if ($coreHealth.StatusCode -ge 200 -and $coreHealth.StatusCode -lt 300) {
+        Write-Success "Core service is reachable at $ConfiguredCoreUrl"
     }
-} catch {}
-
-# Kill any process occupying port 8100
-try {
-    $port8100 = Get-NetTCPConnection -LocalPort 8100 -ErrorAction SilentlyContinue
-    if ($port8100) {
-        foreach ($conn in $port8100) {
-            Write-Info "Killing old process on port 8100 (PID: $($conn.OwningProcess))..."
-            Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
-        }
-        Start-Sleep -Seconds 1
-    }
-} catch {}
-
-$MetamemoryInstalled = $true
-Write-Success "MetaMemory will start automatically with MetaBot on port 8100"
+} catch {
+    Write-Warn "Core service is not reachable at $ConfiguredCoreUrl. The Bridge can still serve IM bots."
+    Write-Warn "Set METABOT_CORE_URL and METABOT_CORE_TOKEN in $EnvFile when Core is available."
+}
 
 # ============================================================================
 # Phase 8: Build + Start MetaBot with PM2
@@ -920,27 +960,43 @@ Write-Step "Phase 8: Starting MetaBot"
 Push-Location $MetabotHome
 
 Write-Info "Building TypeScript..."
-try {
-    npm run build 2>$null
-    Write-Success "Build complete"
-} catch {
-    Write-Warn "Build failed, will use tsx directly via PM2"
-}
+npm run build
+Assert-NativeSuccess "MetaBot build"
+Write-Success "Build complete"
 
 # Always delete + start fresh
-try {
-    $pm2Desc = pm2 describe metabot 2>$null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Info "Removing old MetaBot PM2 process..."
-        pm2 delete metabot 2>$null
-    }
-} catch {}
+pm2 describe metabot 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    Write-Info "Removing old MetaBot PM2 process..."
+    pm2 delete metabot 2>$null
+    Assert-NativeSuccess "removing the old MetaBot PM2 process"
+}
 
 Write-Info "Starting MetaBot with PM2..."
 pm2 start ecosystem.config.cjs
+Assert-NativeSuccess "PM2 start"
 
-try { pm2 save --force 2>$null } catch {}
-Write-Success "MetaBot is running!"
+pm2 save --force 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warn "PM2 started MetaBot, but saving the process list failed with exit code $LASTEXITCODE."
+}
+
+$HealthPort = if ($ApiPort) { $ApiPort } else { "9100" }
+if (Test-Path $EnvFile) {
+    $portLine = Get-Content -LiteralPath $EnvFile -ErrorAction SilentlyContinue |
+        Where-Object { $_ -match '^\s*API_PORT=' } |
+        Select-Object -Last 1
+    if ($portLine) {
+        $HealthPort = ($portLine -replace '^\s*API_PORT=', '').Trim().Trim('"').Trim("'")
+    }
+}
+$BridgeHealthUrl = "http://127.0.0.1:$HealthPort/api/health"
+if (-not (Wait-BridgeHealth -Url $BridgeHealthUrl)) {
+    Write-BridgeDiagnostics -InstallDir $MetabotHome
+    throw "MetaBot Bridge did not become healthy at $BridgeHealthUrl."
+}
+
+Write-Success "MetaBot Bridge is healthy at $BridgeHealthUrl"
 Pop-Location
 
 # ============================================================================
@@ -964,9 +1020,7 @@ if (-not $SkipConfig) {
         Write-Host "  Provider:       " -ForegroundColor White -NoNewline; Write-Host $ProviderName
     }
 }
-if ($MetamemoryInstalled) {
-    Write-Host "  MetaMemory:     " -ForegroundColor White -NoNewline; Write-Host "http://localhost:8100"
-}
+Write-Host "  Core Console:   " -ForegroundColor White -NoNewline; Write-Host "$ConfiguredCoreUrl (separate service)"
 
 Write-Host ""
 Write-Host "  Commands:" -ForegroundColor White

--- a/tests/install-powershell-health.test.ts
+++ b/tests/install-powershell-health.test.ts
@@ -1,0 +1,33 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'install.ps1'), 'utf-8');
+
+describe('PowerShell installer health contracts', () => {
+  it('checks critical native command exit codes before reporting success', () => {
+    expect(SOURCE).toContain('function Assert-NativeSuccess');
+    expect(SOURCE).toMatch(/npm install --production=false\s+Assert-NativeSuccess "npm install"/);
+    expect(SOURCE).toMatch(/npm run build\s+Assert-NativeSuccess "MetaBot build"/);
+    expect(SOURCE).toMatch(/pm2 start ecosystem\.config\.cjs\s+Assert-NativeSuccess "PM2 start"/);
+  });
+
+  it('waits for Bridge health and emits bounded diagnostics on failure', () => {
+    expect(SOURCE).toContain('function Wait-BridgeHealth');
+    expect(SOURCE).toContain('/api/health');
+    expect(SOURCE).toContain('function Write-BridgeDiagnostics');
+    expect(SOURCE).toContain('Select-Object -First 80');
+    expect(SOURCE).toContain('Get-Content -LiteralPath $logPath -Tail $MaxLogLines');
+  });
+
+  it('does not configure, kill, or advertise the obsolete MetaMemory port', () => {
+    expect(SOURCE).not.toContain('META_MEMORY_URL=');
+    expect(SOURCE).not.toContain('localhost:8100');
+    expect(SOURCE).not.toContain('Get-NetTCPConnection -LocalPort 8100');
+    expect(SOURCE).not.toContain('pm2 delete metamemory');
+    expect(SOURCE).toContain('METABOT_CORE_URL=$CoreUrl');
+    expect(SOURCE).toContain('The Windows installer manages the MetaBot Bridge only.');
+  });
+});


### PR DESCRIPTION
## Summary

- fail fast when dependency installation, build, or PM2 startup fails
- poll the Bridge health endpoint before reporting a successful installation
- show bounded PM2 and log diagnostics on failure
- remove obsolete standalone MetaMemory port 8100 handling and document the Bridge-only Windows behavior

## Testing

- `npm exec vitest run tests/install-powershell-health.test.ts`
- `npm run build`
- `npm test`
- `npm run lint` (passes with pre-existing warnings)

Addresses #228
