### PR TITLE
fix(installer): pin Windows CLI wrappers to Git Bash

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -142,5 +142,10 @@ On failure it prints only bounded PM2 and log diagnostics. It does not install,
 stop, or delete a Core/MetaMemory service. Configure an existing Core with
 `METABOT_CORE_URL` and `METABOT_CORE_TOKEN`; standalone port `8100` is obsolete.
 
+The generated wrapper records the absolute, quoted Git Bash path. The legacy
+`C:\Windows\System32\bash.exe` WSL launcher is intentionally rejected because
+it cannot execute the wrapper's Windows-style script path. If Git Bash is
+missing, install Git for Windows and rerun `install.ps1`.
+
 Next: [Quick Setup](quick-setup.md) or the detailed
 [Feishu App Setup](feishu-app-setup.md).

--- a/docs/getting-started/installation.zh.md
+++ b/docs/getting-started/installation.zh.md
@@ -137,4 +137,9 @@ PM2 信息和日志。PowerShell 安装器不会安装、停止或删除 Core/Me
 服务；请通过 `METABOT_CORE_URL` 和 `METABOT_CORE_TOKEN` 连接已有 Core，
 旧的独立 `8100` 端口已废弃。
 
+生成的 wrapper 会保存带引号的 Git Bash 绝对路径。安装器会主动拒绝旧的
+`C:\Windows\System32\bash.exe` WSL launcher，因为它无法执行 wrapper 中的
+Windows 风格脚本路径。若未找到 Git Bash，请安装 Git for Windows 后重新运行
+`install.ps1`。
+
 下一步：[快速配置](quick-setup.md)或详细的[飞书应用配置](feishu-app-setup.md)。

--- a/install.ps1
+++ b/install.ps1
@@ -210,6 +210,72 @@ function Write-BridgeDiagnostics {
     }
 }
 
+function Test-GitBashPath {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $fullPath = [System.IO.Path]::GetFullPath($Path)
+        $system32 = [System.IO.Path]::GetFullPath((Join-Path $env:WINDIR "System32"))
+        if ($fullPath.StartsWith($system32, [System.StringComparison]::OrdinalIgnoreCase)) {
+            # C:\Windows\System32\bash.exe is the legacy WSL launcher. It
+            # cannot execute a Windows path such as C:\Users\...\metabot.
+            return $false
+        }
+        if ([System.IO.Path]::GetFileName($fullPath) -ine "bash.exe") {
+            return $false
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Resolve-GitBashPath {
+    $roots = New-Object System.Collections.Generic.List[string]
+
+    # Derive the installation root from the Git executable first. This works
+    # for custom locations as well as the default "Program Files\Git" path.
+    try {
+        $gitCommand = Get-Command git -CommandType Application -ErrorAction Stop |
+            Select-Object -First 1
+        $gitDir = Split-Path -Parent $gitCommand.Source
+        $gitDirName = Split-Path -Leaf $gitDir
+        if ($gitDirName -ieq "cmd" -or $gitDirName -ieq "bin") {
+            $candidateRoot = Split-Path -Parent $gitDir
+            if ((Split-Path -Leaf $candidateRoot) -ieq "mingw64") {
+                $candidateRoot = Split-Path -Parent $candidateRoot
+            }
+            $roots.Add($candidateRoot)
+        }
+    } catch {}
+
+    if ($env:ProgramFiles) {
+        $roots.Add((Join-Path $env:ProgramFiles "Git"))
+    }
+    if (${env:ProgramFiles(x86)}) {
+        $roots.Add((Join-Path ${env:ProgramFiles(x86)} "Git"))
+    }
+    if ($env:LOCALAPPDATA) {
+        $roots.Add((Join-Path $env:LOCALAPPDATA "Programs\Git"))
+    }
+
+    $seen = @{}
+    foreach ($root in $roots) {
+        foreach ($relativePath in @("bin\bash.exe", "usr\bin\bash.exe")) {
+            $candidate = Join-Path $root $relativePath
+            if ($seen.ContainsKey($candidate)) { continue }
+            $seen[$candidate] = $true
+            if (Test-GitBashPath $candidate) {
+                return [System.IO.Path]::GetFullPath($candidate)
+            }
+        }
+    }
+    return $null
+}
+
 function Get-KimiCodeVersion {
     if (-not (Test-Command "kimi")) { return $null }
     try {
@@ -866,12 +932,12 @@ if ($DeployWorkDir) {
 $LocalBin = Join-Path $env:USERPROFILE ".local\bin"
 New-Item -ItemType Directory -Path $LocalBin -Force | Out-Null
 
-$HasBash = Test-Command "bash"
+$GitBashPath = Resolve-GitBashPath
 
 $cliTools = @("metabot")
 if ($HasFeishu) { $cliTools += "fd" }
 
-if ($HasBash) {
+if ($GitBashPath) {
     foreach ($cli in $cliTools) {
         $srcScript = Join-Path $MetabotHome "bin\$cli"
         if (Test-Path $srcScript) {
@@ -884,8 +950,9 @@ if ($HasBash) {
                 (Get-Content $scriptPath -Raw) -replace 'changeme', $ApiSecret | Set-Content $scriptPath -NoNewline
             }
 
-            # Create .cmd wrapper: @bash "%~dp0metabot" %*
-            $cmdContent = "@bash `"%~dp0$cli`" %*"
+            # Pin the wrapper to Git Bash. Quoting both absolute paths keeps
+            # installs under "Program Files" and user profiles with spaces safe.
+            $cmdContent = "@`"$GitBashPath`" `"%~dp0$cli`" %*"
             $cmdContent | Out-File -FilePath (Join-Path $LocalBin "$cli.cmd") -Encoding ascii -NoNewline
         }
     }
@@ -912,8 +979,8 @@ if ($HasBash) {
         Write-Success "metabot CLI installed to $LocalBin (with .cmd wrapper)"
     }
 } else {
-    Write-Warn "Git Bash not found. The metabot CLI requires bash."
-    Write-Warn "Install Git for Windows (https://git-scm.com) to enable CLI tools."
+    Write-Warn "Git Bash was not found. The WSL/System32 bash launcher is not compatible with Windows CLI wrappers."
+    Write-Warn "Install Git for Windows (https://git-scm.com) and re-run this installer."
 }
 
 # Persist METABOT_HOME for non-default install paths so the CLI tool

--- a/tests/install-powershell-git-bash.test.ts
+++ b/tests/install-powershell-git-bash.test.ts
@@ -1,0 +1,27 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE = fs.readFileSync(path.join(REPO_ROOT, 'install.ps1'), 'utf-8');
+
+describe('PowerShell Git Bash wrapper contracts', () => {
+  it('resolves Git Bash from the Git for Windows installation', () => {
+    expect(SOURCE).toContain('function Resolve-GitBashPath');
+    expect(SOURCE).toContain('Get-Command git -CommandType Application');
+    expect(SOURCE).toContain('"bin\\bash.exe", "usr\\bin\\bash.exe"');
+    expect(SOURCE).not.toContain('$HasBash = Test-Command "bash"');
+  });
+
+  it('rejects the System32 WSL launcher', () => {
+    expect(SOURCE).toContain('function Test-GitBashPath');
+    expect(SOURCE).toContain('Join-Path $env:WINDIR "System32"');
+    expect(SOURCE).toContain('The WSL/System32 bash launcher is not compatible');
+  });
+
+  it('quotes the absolute Bash and script paths in the cmd wrapper', () => {
+    expect(SOURCE).toContain('$cmdContent = "@`"$GitBashPath`" `"%~dp0$cli`" %*"');
+    expect(SOURCE).not.toContain('$cmdContent = "@bash');
+  });
+});


### PR DESCRIPTION
## Summary

- resolve Git Bash from the Git for Windows installation
- reject the legacy `C:\Windows\System32\bash.exe` WSL launcher
- write the absolute quoted Git Bash path into the generated `metabot.cmd` wrapper
- document and test paths containing spaces and incompatible WSL launchers

## Testing

- `npm exec vitest run tests/install-powershell-git-bash.test.ts`
- `npm run build`
- `npm test`
- `npm run lint` (passes with pre-existing warnings)

Fixes #85
