### PR TITLE
fix(build): make pack-metabot.sh work with BSD tar on macOS

### DIFF
--- a/packages/server/scripts/pack-metabot.sh
+++ b/packages/server/scripts/pack-metabot.sh
@@ -135,8 +135,12 @@ done
 mkdir -p "$SERVER_STATIC_DIR"
 
 TMP_EXTRA_DIR="$(mktemp -d -t metabot-pack-extra.XXXXXX)"
+STAGE_DIR=""
 cleanup() {
   rm -rf "$TMP_EXTRA_DIR"
+  if [[ -n "$STAGE_DIR" ]]; then
+    rm -rf "$STAGE_DIR"
+  fi
 }
 trap cleanup EXIT
 
@@ -206,23 +210,64 @@ const manifest = {
 fs.writeFileSync(dest, `${JSON.stringify(manifest, null, 2)}\n`);
 NODE
 
-EXTRA_TAR_ARGS=(-C "$TMP_EXTRA_DIR" 'package.json' 'tsconfig.json' '.metabot-package/manifest.json')
+EXTRA_MEMBERS=('package.json' 'tsconfig.json' '.metabot-package/manifest.json')
 if [[ -f "$TMP_EXTRA_DIR/.metabot-package/default.env" ]]; then
-  EXTRA_TAR_ARGS+=(-C "$TMP_EXTRA_DIR" '.metabot-package/default.env')
+  EXTRA_MEMBERS+=('.metabot-package/default.env')
 fi
+EXTRA_TAR_ARGS=(-C "$TMP_EXTRA_DIR" "${EXTRA_MEMBERS[@]}")
 
 echo "==> Writing $SERVER_STATIC_DIR/$TARBALL_NAME (atomic)"
 # Sort+mtime flags produce a deterministic tarball — easier diffs across
 # builds and avoids spurious rsync churn on the deploy host. -C anchors all
 # include paths to the repo root.
-tar --sort=name \
-    --owner=0 --group=0 --numeric-owner \
-    --mtime='UTC 2026-01-01' \
-    "${TAR_EXCLUDES[@]}" \
-    -czf "$SERVER_STATIC_DIR/$TARBALL_NAME.new" \
-    -C "$REPO_ROOT" \
-    "${PRESENT_INCLUDES[@]}" \
-    "${EXTRA_TAR_ARGS[@]}"
+#
+# --sort/--owner/--group/--mtime are GNU tar extensions. Linux ships GNU tar
+# as `tar`, but macOS ships BSD tar (bsdtar), which rejects them
+# ("Option --sort=name is not supported"). Prefer GNU tar when present
+# (Homebrew installs it as `gtar`), otherwise emulate the same determinism
+# guarantees with a BSD-compatible pipeline.
+GNU_TAR=""
+for tar_candidate in tar gtar; do
+  if "$tar_candidate" --version 2>/dev/null | grep -q 'GNU tar'; then
+    GNU_TAR="$tar_candidate"
+    break
+  fi
+done
+
+if [[ -n "$GNU_TAR" ]]; then
+  "$GNU_TAR" --sort=name \
+      --owner=0 --group=0 --numeric-owner \
+      --mtime='UTC 2026-01-01' \
+      "${TAR_EXCLUDES[@]}" \
+      -czf "$SERVER_STATIC_DIR/$TARBALL_NAME.new" \
+      -C "$REPO_ROOT" \
+      "${PRESENT_INCLUDES[@]}" \
+      "${EXTRA_TAR_ARGS[@]}"
+else
+  # BSD tar fallback (stock macOS). Reproduce the GNU flags in three steps:
+  #   1. Stage the payload with bsdtar itself, so the TAR_EXCLUDES patterns
+  #      keep their create-time recursion semantics (bsdtar matches path
+  #      components the same way GNU tar does).
+  #   2. Pin every staged mtime to the instant GNU's --mtime pins
+  #      (2026-01-01 00:00:00 UTC).
+  #   3. Archive an explicitly pre-sorted member list with tar recursion
+  #      disabled (-n) — the --sort=name replacement — forcing uid/gid 0
+  #      like --owner/--group, and gzip -n for a timestamp-free header.
+  STAGE_DIR="$(mktemp -d -t metabot-pack-stage.XXXXXX)"
+  tar "${TAR_EXCLUDES[@]}" -cf - -C "$REPO_ROOT" "${PRESENT_INCLUDES[@]}" \
+    | tar -xpf - -C "$STAGE_DIR"
+  tar -cf - -C "$TMP_EXTRA_DIR" "${EXTRA_MEMBERS[@]}" \
+    | tar -xpf - -C "$STAGE_DIR"
+  TZ=UTC0 find "$STAGE_DIR" -exec touch -h -t 202601010000.00 {} +
+  (
+    cd "$STAGE_DIR" \
+      && find . -mindepth 1 \
+        | sed 's,^\./,,' \
+        | LC_ALL=C sort \
+        | tar --format gnutar --uid 0 --gid 0 --numeric-owner -n -cf - -T - \
+        | gzip -n
+  ) > "$SERVER_STATIC_DIR/$TARBALL_NAME.new"
+fi
 
 # Post-pack sanity: confirm SKILL_SENTINEL actually landed in the tarball.
 # Catches cases where an --exclude pattern accidentally swallowed it.


### PR DESCRIPTION
## Problem

`npm run build` always fails on macOS at its last step (`npm run pack:metabot -w @xvirobotics/metabot-core-server`):

```
==> Writing .../packages/server/static/install/latest.tgz (atomic)
tar: Option --sort=name is not supported
```

The deterministic-archive flags used by `packages/server/scripts/pack-metabot.sh` — `--sort=name`, `--owner`/`--group`, `--mtime` — are GNU tar extensions. macOS ships BSD tar (bsdtar), which rejects them, so macOS contributors cannot complete a full build at all.

## Fix

`pack-metabot.sh` now picks a tar strategy at the pack step:

- **GNU tar available** (`tar` reports GNU — the Linux CI case — or Homebrew's `gtar`): run the exact original invocation, so behavior on Linux CI is byte-for-byte unchanged.
- **BSD tar only** (stock macOS): emulate the same determinism guarantees with a BSD-compatible pipeline:
  1. Stage the payload through bsdtar itself, so the `TAR_EXCLUDES` patterns keep their create-time recursion semantics (bsdtar matches path components the same way GNU tar does — verified empirically).
  2. Pin every staged mtime to 2026-01-01 00:00:00 UTC, the same instant GNU's `--mtime='UTC 2026-01-01'` pins.
  3. Archive an explicitly pre-sorted member list (`find | LC_ALL=C sort` fed via `-T -` with recursion disabled) — the `--sort=name` replacement — with uid/gid forced to 0 (`--uid 0 --gid 0 --numeric-owner`), in `gnutar` format (no pax headers that could embed varying atime/ctime), piped through `gzip -n` for a timestamp-free gzip header.

The generated-manifest members were factored into an `EXTRA_MEMBERS` array reused by both paths, and the staging directory is covered by the existing cleanup trap.

This is the only `--sort=name` in the repo, and `scripts/pack-github-release.sh` delegates to this script, so the release path is covered too.

## Verification (macOS 26.5, bsdtar 3.5.3 / libarchive 3.7.4, no gtar installed)

- `bash -n packages/server/scripts/pack-metabot.sh` passes (same check as release.yml).
- `npm run pack:metabot -w @xvirobotics/metabot-core-server` now succeeds and produces `packages/server/static/install/latest.tgz` (459K).
- Determinism: two consecutive packs produce byte-identical tarballs (same SHA-256: `375e77c6...`).
- Archive spot-check: all entries owned by `0/0` with mtime `Jan 1 2026`, exec bits preserved, and zero `node_modules/`, `dist/`, or `packages/server/` entries in the bridge flavor.
- `METABOT_PACKAGE_FLAVOR=personal` pack succeeds, including the script's built-in `packages/server/static` leak self-check.
- Vitest smoke suite: `npm exec --workspace @xvirobotics/metabot-core-server -- vitest run tests/pack-metabot.test.ts` — 15/15 passed.
- Full `npm run build` (tsc, web-ui, pack:standalone, pack:metabot) completes with no errors.

On Linux CI, `tar` self-reports GNU, so the original code path runs with identical flags and output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)