### PR TITLE
feat(runtime): coordinate multi-bot restart recovery

### DIFF
--- a/bin/metabot
+++ b/bin/metabot
@@ -431,8 +431,16 @@ cmd_update() {
   fi
 
   info "Restarting MetaBot..."
-  _write_restart_breadcrumb
-  pm2 restart metabot 2>/dev/null || pm2 start ecosystem.config.cjs
+  local metabot_pid=""
+  metabot_pid="$(pm2 pid metabot 2>/dev/null | head -n 1 || true)"
+  if [[ "$metabot_pid" =~ ^[1-9][0-9]*$ ]]; then
+    cmd_restart --source update --reason "MetaBot update" --allow-legacy-prepare
+  else
+    # There is no running Bridge to quiesce or recover. Preserve the previous
+    # update behavior for stopped/fresh installations.
+    warn "MetaBot is not running; starting it without restart recovery."
+    pm2 start ecosystem.config.cjs
+  fi
   pm2 save --force 2>/dev/null || true
 
   success "MetaBot updated and restarted!"
@@ -469,21 +477,176 @@ _update_core_workspace() {
   ) && success "metabot-core workspace updated" || warn "metabot-core workspace update incomplete (feature CLI may be stale)"
 }
 
-# Drop a breadcrumb so the bridge knows it was just restarted. After
-# `pm2 restart` the node process (and every Claude session) is killed and
-# respawned, so the agent that issued the restart loses all memory of having
-# done so — without this it sees "please restart" in resumed history and
-# restarts again in a loop. The bridge reads + deletes this file at boot and
-# injects a one-shot "you just restarted, don't restart again" system-reminder.
+# Persist a breadcrumb only after the running Bridge has checkpointed and
+# notified every affected chat. The new process consumes it after it queues all
+# continuation turns and sends completion cards.
 _write_restart_breadcrumb() {
+  local request_id="$1"
+  local requester_bot="$2"
+  local requester_chat="$3"
+  local source="$4"
+  local reason="$5"
+  local resume="$6"
   local dir="${SESSION_STORE_DIR:-$HOME/.metabot}"
-  mkdir -p "$dir" 2>/dev/null || return 0
-  printf '{"restartedAt": %s}\n' "$(date +%s)" > "$dir/last-restart.json" 2>/dev/null || true
+  RESTART_STATE_DIR="$dir" \
+  RESTART_REQUEST_ID="$request_id" \
+  RESTART_REQUESTER_BOT="$requester_bot" \
+  RESTART_REQUESTER_CHAT="$requester_chat" \
+  RESTART_SOURCE="$source" \
+  RESTART_REASON="$reason" \
+  RESTART_RESUME="$resume" \
+    node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const dir = process.env.RESTART_STATE_DIR;
+if (!dir) throw new Error('restart state directory is missing');
+fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+const file = path.join(dir, 'last-restart.json');
+const temp = `${file}.${process.pid}.tmp`;
+const value = {
+  version: 1,
+  restartedAt: Math.floor(Date.now() / 1000),
+  requestId: process.env.RESTART_REQUEST_ID,
+  source: process.env.RESTART_SOURCE || 'cli',
+  resume: process.env.RESTART_RESUME !== 'false',
+};
+if (process.env.RESTART_REQUESTER_BOT) value.botName = process.env.RESTART_REQUESTER_BOT;
+if (process.env.RESTART_REQUESTER_CHAT) value.chatId = process.env.RESTART_REQUESTER_CHAT;
+if (process.env.RESTART_REASON) value.reason = process.env.RESTART_REASON;
+fs.writeFileSync(temp, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+fs.renameSync(temp, file);
+NODE
+}
+
+_clear_restart_breadcrumb() {
+  local request_id="$1"
+  local dir="${SESSION_STORE_DIR:-$HOME/.metabot}"
+  RESTART_STATE_DIR="$dir" RESTART_REQUEST_ID="$request_id" node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const file = path.join(process.env.RESTART_STATE_DIR, 'last-restart.json');
+try {
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (!parsed.requestId || parsed.requestId === process.env.RESTART_REQUEST_ID) fs.unlinkSync(file);
+} catch {}
+NODE
+}
+
+_restart_payload() {
+  RESTART_REQUEST_ID="$1" \
+  RESTART_REQUESTER_BOT="$2" \
+  RESTART_REQUESTER_CHAT="$3" \
+  RESTART_SOURCE="$4" \
+  RESTART_REASON="$5" \
+  RESTART_RESUME="$6" \
+  RESTART_FORCE="$7" \
+    node <<'NODE'
+const value = {
+  requestId: process.env.RESTART_REQUEST_ID,
+  source: process.env.RESTART_SOURCE || 'cli',
+  resume: process.env.RESTART_RESUME !== 'false',
+  force: process.env.RESTART_FORCE === 'true',
+};
+if (process.env.RESTART_REQUESTER_BOT) value.requesterBot = process.env.RESTART_REQUESTER_BOT;
+if (process.env.RESTART_REQUESTER_CHAT) value.requesterChat = process.env.RESTART_REQUESTER_CHAT;
+if (process.env.RESTART_REASON) value.reason = process.env.RESTART_REASON;
+process.stdout.write(JSON.stringify(value));
+NODE
+}
+
+_prepare_controlled_restart() {
+  local payload="$1"
+  _load_bridge_api_config
+  local response_file
+  response_file="$(mktemp)"
+  local http_code
+  if ! http_code="$(curl -sS --connect-timeout 3 --max-time 30 -o "$response_file" -w '%{http_code}' \
+    -X POST -H "$METABOT_AUTH" -H 'Content-Type: application/json' \
+    --data "$payload" "$METABOT_URL/api/runtime/restart/prepare")"; then
+    rm -f "$response_file"
+    return 2
+  fi
+  if [[ "$http_code" == 2* ]]; then
+    cat "$response_file"
+    rm -f "$response_file"
+    return 0
+  fi
+  if [[ "$http_code" == "404" ]]; then
+    rm -f "$response_file"
+    return 44
+  fi
+  error "Bridge rejected controlled restart preparation (HTTP $http_code): $(cat "$response_file")"
+  rm -f "$response_file"
+  return 1
+}
+
+_cancel_controlled_restart() {
+  local request_id="$1"
+  _load_bridge_api_config
+  local payload
+  payload="$(RESTART_REQUEST_ID="$request_id" node -e 'process.stdout.write(JSON.stringify({requestId: process.env.RESTART_REQUEST_ID}))')"
+  curl -fsS -X POST -H "$METABOT_AUTH" -H 'Content-Type: application/json' \
+    --data "$payload" "$METABOT_URL/api/runtime/restart/cancel" >/dev/null 2>&1 || true
 }
 
 cmd_start()   { pm2 start "$METABOT_HOME/ecosystem.config.cjs"; pm2 save --force 2>/dev/null || true; }
 cmd_stop()    { pm2 stop metabot; }
-cmd_restart() { _write_restart_breadcrumb; pm2 restart metabot; }
+cmd_restart() {
+  local request_id=""
+  local requester_bot="${METABOT_BOT_NAME:-}"
+  local requester_chat="${METABOT_CHAT_ID:-}"
+  local source="cli"
+  local reason="MetaBot Bridge restart"
+  local resume=true
+  local force=false
+  local allow_legacy_prepare=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --request-id) request_id="${2:?--request-id requires a value}"; shift 2 ;;
+      --bot) requester_bot="${2:?--bot requires a value}"; shift 2 ;;
+      --chat) requester_chat="${2:?--chat requires a value}"; shift 2 ;;
+      --source) source="${2:?--source requires a value}"; shift 2 ;;
+      --reason) reason="${2:?--reason requires a value}"; shift 2 ;;
+      --resume) resume=true; shift ;;
+      --no-resume) resume=false; shift ;;
+      --force) force=true; shift ;;
+      --allow-legacy-prepare) allow_legacy_prepare=true; shift ;;
+      --help|-h)
+        echo "Usage: metabot restart [--request-id ID] [--bot NAME --chat ID] [--reason TEXT] [--resume|--no-resume] [--force]"
+        return 0
+        ;;
+      *) error "Unknown restart option: $1"; return 2 ;;
+    esac
+  done
+
+  request_id="${request_id:-restart-$(node -e 'console.log(require("node:crypto").randomUUID())')}"
+  local payload
+  payload="$(_restart_payload "$request_id" "$requester_bot" "$requester_chat" "$source" "$reason" "$resume" "$force")"
+  local prepared=false
+  local prepare_rc=0
+  if _prepare_controlled_restart "$payload" >/dev/null; then
+    prepared=true
+  else
+    prepare_rc=$?
+    if [[ "$prepare_rc" -eq 44 && "$allow_legacy_prepare" == true ]]; then
+      warn "Running Bridge predates coordinated restart preparation; proceeding once for upgrade compatibility."
+    elif [[ "$force" == true ]]; then
+      warn "Controlled restart preparation failed; --force accepts that active work may not resume."
+    else
+      error "Restart cancelled because the Bridge could not checkpoint and notify all affected chats."
+      return 1
+    fi
+  fi
+
+  _write_restart_breadcrumb "$request_id" "$requester_bot" "$requester_chat" "$source" "$reason" "$resume"
+  if ! pm2 restart metabot; then
+    [[ "$prepared" == true ]] && _cancel_controlled_restart "$request_id"
+    _clear_restart_breadcrumb "$request_id"
+    error "PM2 rejected controlled restart $request_id; Bridge quiesce was cancelled."
+    return 1
+  fi
+  success "Controlled restart submitted (requestId: $request_id)."
+}
 cmd_logs()    { pm2 logs metabot "${@}"; }
 cmd_status()  { pm2 describe metabot; }
 
@@ -1622,7 +1785,7 @@ print_help() {
   echo "    metabot update --git      Git pull, rebuild, and restart"
   echo "    metabot start      Start MetaBot with PM2"
   echo "    metabot stop       Stop MetaBot"
-  echo "    metabot restart    Restart MetaBot"
+  echo "    metabot restart    Coordinated restart: checkpoint and resume all affected bot chats"
   echo "    metabot logs       View live logs (pass -n 100 etc.)"
   echo "    metabot status     Show PM2 process status"
   echo "    metabot doctor     Agent-readable runtime diagnostics (--json)"
@@ -1647,7 +1810,7 @@ case "${1:-}" in
   update|up)    shift; cmd_update "$@" ;;
   start)        cmd_start ;;
   stop)         cmd_stop ;;
-  restart|rs)   cmd_restart ;;
+  restart|rs)   shift; cmd_restart "$@" ;;
   logs|log)     shift; cmd_logs "$@" ;;
   status|st)    cmd_status ;;
   doctor)       shift; cmd_doctor "$@" ;;

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -76,6 +76,18 @@ required:
 
 Do not reuse the Core token as the Bridge secret.
 
+## Restart safety
+
+Use `metabot restart` instead of calling `pm2 restart metabot` directly. The
+CLI coordinates the process-wide restart with every active bot chat, persists
+the handoff, and resumes interrupted user-facing turns after the new Bridge is
+listening. Direct PM2 commands bypass that contract and can interrupt all bots
+without preparation or completion cards.
+
+The first update that introduces this protocol may see a 404 from the still-old
+Bridge. `metabot update` permits that one compatibility handoff; subsequent
+updates require coordinated preparation. No database migration is involved.
+
 ## Update and rollback
 
 ```bash
@@ -88,6 +100,10 @@ Package overlays preserve `.env`, `bots.json`, `data/`, `logs/`, and user/Core
 state under `~/.metabot/` and `~/.metabot-core/`. If a new release fails your
 smoke checks, reinstall the previously known version explicitly instead of
 editing installed package files.
+
+Rollback does not require changing `sessions.db`. Reinstall the previous
+release and remove a stale `~/.metabot/controlled-restart.json` only after
+confirming no restart is in progress; older releases ignore that file.
 
 ## Source deployments
 

--- a/docs/deployment/production.zh.md
+++ b/docs/deployment/production.zh.md
@@ -72,6 +72,17 @@ Shell 历史或共享配置。
 
 不要复用 Core Token 作为 Bridge Secret。
 
+## 重启安全
+
+请使用 `metabot restart`，不要直接运行 `pm2 restart metabot`。CLI 会在整个 Bridge
+进程重启前协调所有存在活跃任务的 Bot 会话、持久化交接状态，并在新 Bridge 开始监听
+后续接被中断的用户任务。直接调用 PM2 会绕过这份协议，导致所有 Bot 未经准备就被
+中断，也不会发送完成卡片。
+
+首次升级到支持该协议的版本时，仍在运行的旧 Bridge 会对准备接口返回 404；
+`metabot update` 只为这次过渡允许兼容降级。之后的更新必须先成功完成协调准备。
+该功能不需要数据库迁移。
+
 ## 更新与回退
 
 ```bash
@@ -83,6 +94,9 @@ metabot doctor
 Package 覆盖会保留 `.env`、`bots.json`、`data/`、`logs/`，以及
 `~/.metabot/`、`~/.metabot-core/` 中的用户/Core 状态。如果新版本 smoke 失败，
 应显式重装上一已知版本，不要直接修改已安装包文件。
+
+回滚不需要改动 `sessions.db`。重新安装上一版本后，只有在确认当前没有重启进行中时，
+才清理残留的 `~/.metabot/controlled-restart.json`；旧版本本来也会忽略该文件。
 
 ## 源码部署
 

--- a/docs/reference/cli-metabot.md
+++ b/docs/reference/cli-metabot.md
@@ -24,7 +24,10 @@ metabot update --package --version 1.3.0        # pin immutable Release v1.3.0
 metabot update --git                            # force git pull + rebuild + restart
 metabot start                       # start with PM2
 metabot stop                        # stop
-metabot restart                     # restart
+metabot restart                     # coordinated Bridge restart
+metabot restart --bot admin --chat oc_x --reason "upgrade"  # report back to a chat
+metabot restart --no-resume         # notify, but do not queue interrupted turns
+metabot restart --force             # emergency override if prepare cannot complete
 metabot logs                        # view live logs (pass -n 100 etc.)
 metabot status                      # PM2 process status
 ```
@@ -48,6 +51,26 @@ instead of `latest`. Package updating performs:
 Override the package installer mirror with `METABOT_UPDATE_INSTALLER_URL`.
 `--version` accepts only `x.y.z` (an optional leading `v` is normalized) and
 cannot be combined with `--git`.
+
+### Coordinated restart
+
+`metabot restart` first asks the authenticated local Bridge to prepare. The
+Bridge briefly stops accepting new work, snapshots every active task across
+all registered bots, and sends a **Restart Preparing** notice to each affected
+chat using that bot's own channel identity. If any affected chat cannot be
+notified, the restart is cancelled and normal work is unfrozen. `--force` is
+the explicit emergency override.
+
+After PM2 starts the new Bridge, each affected bot updates its interrupted
+card, sends a **Restart Complete** notice, and queues exactly one continuation
+turn. A stable `--request-id` deduplicates retries. `--bot` plus `--chat` also
+reports the result to an idle requester chat; idle bots without a destination
+chat are not sent unsolicited messages.
+
+The handoff is stored atomically under `SESSION_STORE_DIR` (normally
+`~/.metabot/`) in `controlled-restart.json` and `last-restart.json`. It does not
+modify the session database. If PM2 rejects the restart, the CLI cancels the
+Bridge's prepare state and removes the breadcrumb before returning an error.
 
 ## 2. Bridge daemon API
 

--- a/docs/reference/cli-metabot.zh.md
+++ b/docs/reference/cli-metabot.zh.md
@@ -23,7 +23,10 @@ metabot update --package --version 1.3.0        # 固定不可变 Release v1.3.0
 metabot update --git                            # 强制 git pull + 构建 + 重启
 metabot start                       # 启动（PM2）
 metabot stop                        # 停止
-metabot restart                     # 重启
+metabot restart                     # 多 Bot 协调式 Bridge 重启
+metabot restart --bot admin --chat oc_x --reason "升级"  # 向指定会话回报
+metabot restart --no-resume         # 只通知，不自动续接被中断任务
+metabot restart --force             # 准备失败时的紧急显式覆盖
 metabot logs                        # 查看实时日志（可传 -n 100 等）
 metabot status                      # PM2 进程状态
 ```
@@ -46,6 +49,22 @@ Release。源码 checkout 会被自动识别并保留 Git 更新路径；用 `--
 
 可用 `METABOT_UPDATE_INSTALLER_URL` 覆盖 Package 镜像地址。`--version` 只接受
 `x.y.z`（可选前导 `v` 会被标准化），且不能与 `--git` 组合。
+
+### 协调式重启
+
+`metabot restart` 会先请求已鉴权的本地 Bridge 进入准备状态。Bridge 短暂停止接收新
+工作，快照所有已注册 Bot 的活跃任务，并使用每个 Bot 自己的渠道身份向受影响会话
+发送 **Restart Preparing** 卡片。如果任何受影响会话无法收到通知，重启会取消，
+Bridge 也会恢复接收工作；`--force` 是明确的紧急覆盖开关。
+
+PM2 启动新 Bridge 后，每个受影响 Bot 都会更新被中断的任务卡片、发送
+**Restart Complete** 卡片，并且只排队一次续接任务。稳定的 `--request-id` 用于去重。
+`--bot` 与 `--chat` 还能让没有活跃任务的发起会话收到结果；没有目标 chat ID 的空闲
+Bot 不会收到无目的消息。
+
+交接状态以原子写入方式保存在 `SESSION_STORE_DIR`（通常为 `~/.metabot/`）下的
+`controlled-restart.json` 和 `last-restart.json`，不会修改 session 数据库。如果 PM2
+拒绝重启，CLI 会先取消 Bridge 的准备状态并删除 breadcrumb，再返回错误。
 
 ## 2. bridge 守护进程 API
 

--- a/src/api/http-server.ts
+++ b/src/api/http-server.ts
@@ -46,6 +46,7 @@ import {
   handleSessionRoutes,
   handleExecutorRoutes,
   handleAgentTeamRoutes,
+  handleRestartRoutes,
   parseCoreChatRunRequest,
 } from './routes/index.js';
 import type { RouteContext } from './routes/index.js';
@@ -270,6 +271,7 @@ export function startApiServer(options: ApiServerOptions): http.Server {
 
   // Route handlers in priority order
   const routeHandlers = [
+    handleRestartRoutes,
     handleCoreChatRoutes,
     handleVoiceRoutes,
     handleFileRoutes,

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -16,5 +16,6 @@ export { handleRtcRoutes } from './rtc-routes.js';
 export { handleSessionRoutes } from './session-routes.js';
 export { handleExecutorRoutes } from './executor-routes.js';
 export { handleAgentTeamRoutes } from './agent-team-routes.js';
+export { handleRestartRoutes } from './restart-routes.js';
 export { jsonResponse, readBody, parseJsonBody } from './helpers.js';
 export type { RouteContext, RouteHandler } from './types.js';

--- a/src/api/routes/restart-routes.ts
+++ b/src/api/routes/restart-routes.ts
@@ -1,0 +1,65 @@
+import type { RouteHandler } from './types.js';
+import { jsonResponse, parseJsonBody } from './helpers.js';
+import {
+  cancelControlledRestart,
+  prepareControlledRestart,
+  RestartPreparationError,
+} from '../../bridge/restart-coordinator.js';
+
+export const handleRestartRoutes: RouteHandler = async (ctx, req, res, method, url) => {
+  if (method === 'POST' && url === '/api/runtime/restart/prepare') {
+    const body = await parseJsonBody(req);
+    const requestId = stringField(body.requestId);
+    if (!requestId) {
+      jsonResponse(res, 400, { error: 'requestId is required' });
+      return true;
+    }
+    try {
+      const plan = await prepareControlledRestart({
+        registry: ctx.registry,
+        logger: ctx.logger,
+        request: {
+          requestId,
+          ...(stringField(body.requesterBot) ? { requesterBot: stringField(body.requesterBot) } : {}),
+          ...(stringField(body.requesterChat) ? { requesterChat: stringField(body.requesterChat) } : {}),
+          ...(stringField(body.source) ? { source: stringField(body.source) } : {}),
+          ...(stringField(body.reason) ? { reason: stringField(body.reason) } : {}),
+          resume: body.resume !== false,
+          force: body.force === true,
+        },
+      });
+      jsonResponse(res, 200, {
+        requestId: plan.requestId,
+        status: plan.status,
+        participantCount: plan.participants.length,
+        activeCount: plan.participants.filter((participant) => participant.wasActive).length,
+        prepareNoticesDelivered: plan.participants.filter((participant) => participant.prepareNotice === 'delivered').length,
+      });
+    } catch (error) {
+      if (error instanceof RestartPreparationError) {
+        jsonResponse(res, error.statusCode, { error: error.message });
+      } else {
+        throw error;
+      }
+    }
+    return true;
+  }
+
+  if (method === 'POST' && url === '/api/runtime/restart/cancel') {
+    const body = await parseJsonBody(req);
+    const requestId = stringField(body.requestId);
+    if (!requestId) {
+      jsonResponse(res, 400, { error: 'requestId is required' });
+      return true;
+    }
+    const plan = cancelControlledRestart({ registry: ctx.registry, requestId });
+    jsonResponse(res, 200, { requestId, status: plan?.status ?? 'not-found' });
+    return true;
+  }
+
+  return false;
+};
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -27,6 +27,7 @@ import { ExecutorRegistry } from '../engines/claude/executor-registry.js';
 import { RateLimiter } from './rate-limiter.js';
 import { OutputsManager } from './outputs-manager.js';
 import { shouldRemindRestart, markReminded, restartSecondsAgo } from './restart-notice.js';
+import type { RestartTaskSnapshot } from './restart-coordinator.js';
 import { MemoryClient } from '../memory/memory-client.js';
 import { AuditLogger } from '../utils/audit-logger.js';
 import { CommandHandler } from './command-handler.js';
@@ -117,6 +118,8 @@ interface RunningTask {
   processor: StreamProcessor;
   rateLimiter: RateLimiter;
   chatId: string;
+  source: 'chat' | 'api';
+  sendCards: boolean;
   /** Live snapshot of the active Agent Team, accumulated from team hooks. */
   teamState?: TeamState;
 }
@@ -125,6 +128,9 @@ interface StartingTask {
   startTime: number;
   abortController: AbortController;
   cancelled: boolean;
+  userPrompt: string;
+  source: 'chat' | 'api';
+  sendCards: boolean;
 }
 
 export interface ApiTaskOptions {
@@ -191,6 +197,8 @@ export class MessageBridge {
   /** Chats that have begun task setup but do not have an ExecutionHandle yet. */
   private startingTasks = new Map<string, StartingTask>();
   private runningTasks = new Map<string, RunningTask>(); // keyed by chatId
+  /** Set only during the short prepare -> PM2 restart window. */
+  private restartQuiesceRequestId?: string;
   private messageQueues = new Map<string, IncomingMessage[]>(); // per-chatId message queue
   private pendingBatches = new Map<string, PendingBatch>(); // media debounce batches
   /**
@@ -477,12 +485,20 @@ export class MessageBridge {
     return this.startingTasks.has(chatId) || this.runningTasks.has(chatId);
   }
 
-  private reserveTaskStart(chatId: string): StartingTask | undefined {
-    if (this.isChatBusy(chatId)) return undefined;
+  private reserveTaskStart(
+    chatId: string,
+    userPrompt: string,
+    source: 'chat' | 'api',
+    sendCards: boolean,
+  ): StartingTask | undefined {
+    if (this.restartQuiesceRequestId || this.isChatBusy(chatId)) return undefined;
     const task: StartingTask = {
       startTime: Date.now(),
       abortController: new AbortController(),
       cancelled: false,
+      userPrompt,
+      source,
+      sendCards,
     };
     this.startingTasks.set(chatId, task);
     return task;
@@ -515,6 +531,50 @@ export class MessageBridge {
       chatId,
       startTime: task.startTime,
     }));
+  }
+
+  /** Freeze new work while the CLI checkpoints every affected chat. */
+  beginRestartQuiesce(requestId: string): void {
+    this.restartQuiesceRequestId = requestId;
+  }
+
+  /** Release a failed/cancelled prepare without disturbing another request. */
+  cancelRestartQuiesce(requestId: string): void {
+    if (this.restartQuiesceRequestId !== requestId) return;
+    this.restartQuiesceRequestId = undefined;
+    for (const chatId of this.messageQueues.keys()) {
+      if (!this.isChatBusy(chatId)) this.processQueue(chatId);
+    }
+  }
+
+  /** Snapshot all work that a process-wide Bridge restart would interrupt. */
+  getRestartTaskSnapshots(): RestartTaskSnapshot[] {
+    const snapshots: RestartTaskSnapshot[] = [];
+    for (const [chatId, task] of this.startingTasks) {
+      snapshots.push({
+        botName: this.config.name,
+        chatId,
+        userPrompt: task.userPrompt,
+        startedAt: task.startTime,
+        source: task.source,
+        sendCards: task.sendCards,
+        queuedPrompts: this.messageQueues.get(chatId)?.map((message) => message.text),
+      });
+    }
+    for (const [chatId, task] of this.runningTasks) {
+      snapshots.push({
+        botName: this.config.name,
+        chatId,
+        ...(task.cardMessageId ? { messageId: task.cardMessageId } : {}),
+        userPrompt: task.processor.getCurrentState().userPrompt,
+        startedAt: task.startTime,
+        source: task.source,
+        sendCards: task.sendCards,
+        cardState: task.processor.getCurrentState(),
+        queuedPrompts: this.messageQueues.get(chatId)?.map((message) => message.text),
+      });
+    }
+    return snapshots;
   }
 
   /** Stop a running task for the given chatId. Returns true if a task was stopped. */
@@ -1531,6 +1591,7 @@ export class MessageBridge {
    *                                    → clear goal (per Claude docs aliases)
    */
   private processQueue(chatId: string): void {
+    if (this.restartQuiesceRequestId) return;
     const queue = this.messageQueues.get(chatId);
     if (!queue || queue.length === 0) {
       this.messageQueues.delete(chatId);
@@ -1593,6 +1654,16 @@ export class MessageBridge {
 
   async handleMessage(msg: IncomingMessage): Promise<void> {
     const { chatId, text } = msg;
+
+    if (this.restartQuiesceRequestId) {
+      await this.sender.sendTextNotice(
+        chatId,
+        'MetaBot Restart Preparing',
+        `Controlled restart ${this.restartQuiesceRequestId} is already in progress. Please resend this message after the completion card arrives.`,
+        'orange',
+      );
+      return;
+    }
 
     // Feishu users often type command names without the leading slash. Treat
     // an exact bare "reset" as /reset so it can abort a running PTY turn and
@@ -1956,7 +2027,7 @@ export class MessageBridge {
   }
 
   private async startQuery(msg: IncomingMessage): Promise<void> {
-    const startingTask = this.reserveTaskStart(msg.chatId);
+    const startingTask = this.reserveTaskStart(msg.chatId, msg.text, 'chat', true);
     if (!startingTask) {
       throw new Error(`Chat ${msg.chatId} is busy with another task`);
     }
@@ -2218,6 +2289,8 @@ export class MessageBridge {
       processor,
       rateLimiter,
       chatId,
+      source: 'chat',
+      sendCards: true,
     };
     this.releaseTaskStart(chatId, startingTask);
     this.runningTasks.set(chatId, runningTask);
@@ -2644,7 +2717,14 @@ export class MessageBridge {
 
   async executeApiTask(options: ApiTaskOptions): Promise<ApiTaskResult> {
     const { chatId } = options;
-    const startingTask = this.reserveTaskStart(chatId);
+    if (this.restartQuiesceRequestId) {
+      return {
+        success: false,
+        responseText: '',
+        error: `Bridge is preparing controlled restart ${this.restartQuiesceRequestId}`,
+      };
+    }
+    const startingTask = this.reserveTaskStart(chatId, options.prompt, 'api', options.sendCards === true);
     if (!startingTask) {
       return { success: false, responseText: '', error: 'Chat is busy with another task' };
     }
@@ -2800,6 +2880,8 @@ export class MessageBridge {
       processor,
       rateLimiter,
       chatId,
+      source: 'api',
+      sendCards,
     };
     this.releaseTaskStart(chatId, startingTask);
     this.runningTasks.set(chatId, runningTask);

--- a/src/bridge/restart-coordinator.ts
+++ b/src/bridge/restart-coordinator.ts
@@ -1,0 +1,605 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { BotRegistry, RegisteredBot } from '../api/bot-registry.js';
+import type { TaskScheduler } from '../scheduler/task-scheduler.js';
+import type { CardState } from '../types.js';
+import type { Logger } from '../utils/logger.js';
+import {
+  clearRestartBreadcrumb,
+  getRestartBreadcrumb,
+} from './restart-notice.js';
+
+export interface RestartTaskSnapshot {
+  botName: string;
+  chatId: string;
+  messageId?: string;
+  userPrompt: string;
+  startedAt: number;
+  source: 'chat' | 'api';
+  sendCards: boolean;
+  cardState?: CardState;
+  queuedPrompts?: string[];
+}
+
+export interface ControlledRestartRequest {
+  requestId: string;
+  requesterBot?: string;
+  requesterChat?: string;
+  source?: string;
+  reason?: string;
+  resume?: boolean;
+  force?: boolean;
+}
+
+export interface ControlledRestartParticipant extends RestartTaskSnapshot {
+  platform: RegisteredBot['platform'];
+  wasActive: boolean;
+  prepareNotice?: 'delivered' | 'failed' | 'skipped';
+  completionNotice?: 'delivered' | 'failed' | 'skipped';
+  continuationTaskId?: string;
+  continuationOutcome?: 'scheduled' | 'skipped' | 'failed';
+  recoveredAt?: number;
+}
+
+export interface ControlledRestartPlan {
+  version: 1;
+  requestId: string;
+  status: 'preparing' | 'prepared' | 'cancelled' | 'completed';
+  requesterBot?: string;
+  requesterChat?: string;
+  source: string;
+  reason?: string;
+  resume: boolean;
+  force: boolean;
+  participants: ControlledRestartParticipant[];
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  cancelledAt?: number;
+}
+
+export class RestartPreparationError extends Error {
+  constructor(message: string, readonly statusCode = 409) {
+    super(message);
+    this.name = 'RestartPreparationError';
+  }
+}
+
+const PLAN_FILENAME = 'controlled-restart.json';
+const PLAN_TTL_MS = 24 * 60 * 60 * 1000;
+const PREPARE_LEASE_MS = 2 * 60 * 1000;
+const RECOVERY_WINDOW_MS = 15 * 60 * 1000;
+const NOTICE_TIMEOUT_MS = 10_000;
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const preparationLeases = new Map<string, ReturnType<typeof setTimeout>>();
+
+export async function prepareControlledRestart(input: {
+  registry: BotRegistry;
+  logger: Logger;
+  request: ControlledRestartRequest;
+  now?: number;
+}): Promise<ControlledRestartPlan> {
+  const now = input.now ?? Date.now();
+  assertRequestId(input.request.requestId);
+  if (!!input.request.requesterBot !== !!input.request.requesterChat) {
+    throw new RestartPreparationError('requesterBot and requesterChat must be provided together', 400);
+  }
+  if (input.request.requesterBot && !input.registry.get(input.request.requesterBot)) {
+    throw new RestartPreparationError(`Requester bot ${input.request.requesterBot} is not registered`, 400);
+  }
+  const existing = readControlledRestartPlan();
+  if (existing?.requestId === input.request.requestId) {
+    if (existing.status === 'prepared') {
+      for (const bot of input.registry.listRegistered()) bot.bridge.beginRestartQuiesce(input.request.requestId);
+      armPreparationLease(input.registry, input.logger, input.request.requestId);
+      return existing;
+    }
+    if (existing.status === 'preparing') {
+      throw new RestartPreparationError(`Restart request ${input.request.requestId} is still preparing; retry shortly`);
+    }
+    throw new RestartPreparationError(
+      `Restart request ${input.request.requestId} is already ${existing.status}; use a new request ID`,
+    );
+  }
+  if (existing && existing.status !== 'completed' && existing.status !== 'cancelled'
+    && now - existing.updatedAt <= PLAN_TTL_MS) {
+    throw new RestartPreparationError(`Restart ${existing.requestId} is already being prepared`);
+  }
+
+  const registered = input.registry.listRegistered();
+  for (const bot of registered) bot.bridge.beginRestartQuiesce(input.request.requestId);
+
+  try {
+    const participants = collectParticipants(registered, input.request);
+    let plan: ControlledRestartPlan = {
+      version: 1,
+      requestId: input.request.requestId,
+      status: 'preparing',
+      ...(input.request.requesterBot ? { requesterBot: input.request.requesterBot } : {}),
+      ...(input.request.requesterChat ? { requesterChat: input.request.requesterChat } : {}),
+      source: input.request.source?.trim() || 'cli',
+      ...(input.request.reason?.trim() ? { reason: input.request.reason.trim().slice(0, 1000) } : {}),
+      resume: input.request.resume !== false,
+      force: input.request.force === true,
+      participants,
+      createdAt: now,
+      updatedAt: now,
+    };
+    writeControlledRestartPlan(plan);
+
+    const noticeResults = await Promise.all(participants.map(async (participant) => {
+      if (!participant.sendCards) return 'skipped' as const;
+      const bot = resolveParticipantBot(input.registry, participant);
+      if (!bot) return 'failed' as const;
+      try {
+        await withTimeout(bot.sender.sendTextNotice(
+          participant.chatId,
+          'MetaBot Restart Preparing',
+          buildPreparingNotice(plan, participant),
+          'orange',
+        ), NOTICE_TIMEOUT_MS, 'restart prepare notice timed out');
+        return 'delivered' as const;
+      } catch (error) {
+        input.logger.warn(
+          { err: error, requestId: plan.requestId, botName: participant.botName, chatId: participant.chatId },
+          'Controlled restart prepare notice failed',
+        );
+        return 'failed' as const;
+      }
+    }));
+
+    plan = {
+      ...plan,
+      status: 'prepared',
+      participants: refreshParticipants(
+        registered,
+        plan.participants.map((participant, index) => ({
+          ...participant,
+          prepareNotice: noticeResults[index] ?? 'failed',
+        })),
+      ),
+      updatedAt: input.now ?? Date.now(),
+    };
+    const failedNotices = plan.participants.filter((participant) => participant.prepareNotice === 'failed');
+    if (failedNotices.length > 0 && !plan.force) {
+      plan = {
+        ...plan,
+        status: 'cancelled',
+        cancelledAt: input.now ?? Date.now(),
+        updatedAt: input.now ?? Date.now(),
+      };
+      writeControlledRestartPlan(plan);
+      releaseQuiesce(registered, plan.requestId);
+      throw new RestartPreparationError(
+        `Restart preparation could not notify ${failedNotices.length} affected chat(s); no restart was performed`,
+      );
+    }
+    writeControlledRestartPlan(plan);
+    armPreparationLease(input.registry, input.logger, plan.requestId);
+    return plan;
+  } catch (error) {
+    releaseQuiesce(registered, input.request.requestId);
+    throw error;
+  }
+}
+
+export function cancelControlledRestart(input: {
+  registry: BotRegistry;
+  requestId: string;
+  now?: number;
+}): ControlledRestartPlan | undefined {
+  assertRequestId(input.requestId);
+  clearPreparationLease(input.requestId);
+  const plan = readControlledRestartPlan();
+  releaseQuiesce(input.registry.listRegistered(), input.requestId);
+  if (!plan || plan.requestId !== input.requestId || plan.status === 'completed') return plan;
+  const now = input.now ?? Date.now();
+  const cancelled: ControlledRestartPlan = {
+    ...plan,
+    status: 'cancelled',
+    cancelledAt: plan.cancelledAt ?? now,
+    updatedAt: now,
+  };
+  writeControlledRestartPlan(cancelled);
+  return cancelled;
+}
+
+export async function recoverControlledRestartAfterStartup(input: {
+  registry: BotRegistry;
+  scheduler: TaskScheduler;
+  logger: Logger;
+  now?: number;
+}): Promise<ControlledRestartPlan | undefined> {
+  const breadcrumb = getRestartBreadcrumb();
+  const plan = readControlledRestartPlan();
+  const now = input.now ?? Date.now();
+  if (!breadcrumb) {
+    // The CLI can be interrupted after prepare but before it writes its final
+    // breadcrumb. A fresh prepared plan is sufficient proof that this process
+    // replaced the quiesced one, so recover it instead of losing active work.
+    if (!plan || plan.status !== 'prepared' || now - plan.updatedAt > RECOVERY_WINDOW_MS) {
+      if (plan?.status === 'preparing' || plan?.status === 'prepared') {
+        cancelControlledRestart({ registry: input.registry, requestId: plan.requestId, now });
+      }
+      return plan;
+    }
+  }
+  if (breadcrumb && !breadcrumb.requestId) {
+    // Legacy breadcrumb: keep its in-memory one-shot reminder, but do not leave
+    // the file around to retrigger on a later cold start.
+    clearRestartBreadcrumb();
+    return undefined;
+  }
+  const requestId = breadcrumb?.requestId ?? plan?.requestId;
+  if (!requestId || !plan || plan.requestId !== requestId || plan.status === 'cancelled') {
+    if (breadcrumb) clearRestartBreadcrumb(breadcrumb.requestId);
+    return plan;
+  }
+  clearPreparationLease(plan.requestId);
+  if (plan.status === 'completed') {
+    if (breadcrumb) clearRestartBreadcrumb(plan.requestId);
+    return plan;
+  }
+
+  let next = plan;
+  for (const participant of plan.participants) {
+    if (participant.recoveredAt) continue;
+    const now = input.now ?? Date.now();
+    const bot = resolveParticipantBot(input.registry, participant);
+    const continuationRequired = plan.resume
+      && participant.wasActive
+      && !isInternalExecutionChat(participant.chatId);
+    let continuationOutcome: ControlledRestartParticipant['continuationOutcome'] = 'skipped';
+    let continuationTaskId: string | undefined;
+    let completionNotice: ControlledRestartParticipant['completionNotice'] = participant.sendCards ? 'failed' : 'skipped';
+
+    if (!bot) {
+      input.logger.warn(
+        { requestId: plan.requestId, botName: participant.botName, platform: participant.platform },
+        'Controlled restart recovery skipped because the bot is not registered',
+      );
+      continuationOutcome = 'failed';
+    } else {
+      if (continuationRequired) {
+        try {
+          const scheduleInput = {
+            botName: participant.botName,
+            chatId: participant.chatId,
+            prompt: buildContinuationPrompt(plan, participant),
+            delaySeconds: 2,
+            sendCards: participant.sendCards,
+            label: `Continue after restart ${plan.requestId}`,
+            dedupeKey: continuationKey(plan.requestId, participant),
+          };
+          const durableScheduler = input.scheduler as TaskScheduler & {
+            scheduleTaskDurably?: (value: typeof scheduleInput) => ReturnType<TaskScheduler['scheduleTask']>;
+          };
+          const task = durableScheduler.scheduleTaskDurably
+            ? durableScheduler.scheduleTaskDurably(scheduleInput)
+            : durableScheduler.scheduleTask(scheduleInput);
+          continuationTaskId = task.id;
+          continuationOutcome = 'scheduled';
+        } catch (error) {
+          continuationOutcome = 'failed';
+          input.logger.error(
+            { err: error, requestId: plan.requestId, botName: participant.botName, chatId: participant.chatId },
+            'Controlled restart continuation scheduling failed',
+          );
+        }
+      }
+
+      if (participant.wasActive && participant.messageId) {
+        try {
+          await withTimeout(bot.sender.updateCard(
+            participant.messageId,
+            buildRecoveredCard(participant, continuationOutcome === 'scheduled', now),
+          ), NOTICE_TIMEOUT_MS, 'restart interrupted-card update timed out');
+        } catch (error) {
+          input.logger.warn(
+            { err: error, requestId: plan.requestId, botName: participant.botName, chatId: participant.chatId },
+            'Controlled restart interrupted-card update failed',
+          );
+        }
+      }
+
+      if (participant.sendCards) try {
+        await withTimeout(bot.sender.sendTextNotice(
+          participant.chatId,
+          'MetaBot Restart Complete',
+          buildCompletionNotice(plan, participant, continuationOutcome),
+          continuationOutcome === 'failed' ? 'red' : 'green',
+        ), NOTICE_TIMEOUT_MS, 'restart completion notice timed out');
+        completionNotice = 'delivered';
+      } catch (error) {
+        input.logger.warn(
+          { err: error, requestId: plan.requestId, botName: participant.botName, chatId: participant.chatId },
+          'Controlled restart completion notice failed',
+        );
+      }
+    }
+
+    next = {
+      ...next,
+      participants: next.participants.map((candidate) => participantKey(candidate) === participantKey(participant)
+        ? {
+          ...candidate,
+          completionNotice,
+          continuationOutcome,
+          ...(continuationTaskId ? { continuationTaskId } : {}),
+          ...(bot
+            && (!continuationRequired || continuationOutcome === 'scheduled')
+            && (!participant.sendCards || completionNotice === 'delivered')
+            ? { recoveredAt: now }
+            : {}),
+        }
+        : candidate),
+      updatedAt: now,
+    };
+    writeControlledRestartPlan(next);
+  }
+
+  if (next.participants.some((participant) => !participant.recoveredAt)) {
+    input.logger.error(
+      { requestId: plan.requestId },
+      'Controlled restart participant recovery remains incomplete; retaining durable handoff for startup replay',
+    );
+    return next;
+  }
+
+  const completedAt = input.now ?? Date.now();
+  next = {
+    ...next,
+    status: 'completed',
+    participants: next.participants.map((participant) => {
+      const redacted = { ...participant, userPrompt: '' };
+      delete redacted.cardState;
+      delete redacted.queuedPrompts;
+      return redacted;
+    }),
+    completedAt,
+    updatedAt: completedAt,
+  };
+  writeControlledRestartPlan(next);
+  if (breadcrumb) clearRestartBreadcrumb(next.requestId);
+  return next;
+}
+
+export function readControlledRestartPlan(): ControlledRestartPlan | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(controlledRestartPlanPath(), 'utf8')) as ControlledRestartPlan;
+    if (!isControlledRestartPlan(parsed)) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+export function controlledRestartPlanPath(): string {
+  const dir = process.env.SESSION_STORE_DIR || path.join(os.homedir(), '.metabot');
+  return path.join(dir, PLAN_FILENAME);
+}
+
+function collectParticipants(
+  registered: RegisteredBot[],
+  request: ControlledRestartRequest,
+): ControlledRestartParticipant[] {
+  const participants = new Map<string, ControlledRestartParticipant>();
+  for (const bot of registered) {
+    for (const task of bot.bridge.getRestartTaskSnapshots()) {
+      const participant: ControlledRestartParticipant = {
+        ...task,
+        botName: bot.name,
+        platform: bot.platform,
+        wasActive: true,
+      };
+      participants.set(participantKey(participant), participant);
+    }
+  }
+
+  if (request.requesterBot && request.requesterChat) {
+    const bot = registered.find((candidate) => candidate.name === request.requesterBot);
+    if (bot) {
+      const key = `${bot.platform}\0${bot.name}\0${request.requesterChat}`;
+      if (!participants.has(key)) {
+        participants.set(key, {
+          botName: bot.name,
+          platform: bot.platform,
+          chatId: request.requesterChat,
+          userPrompt: request.reason || 'MetaBot restart requested from this chat.',
+          startedAt: Date.now(),
+          source: 'api',
+          sendCards: true,
+          wasActive: false,
+        });
+      }
+    }
+  }
+  return [...participants.values()].sort((a, b) => a.startedAt - b.startedAt);
+}
+
+function refreshParticipants(
+  registered: RegisteredBot[],
+  participants: ControlledRestartParticipant[],
+): ControlledRestartParticipant[] {
+  const active = new Map<string, RestartTaskSnapshot>();
+  for (const bot of registered) {
+    for (const task of bot.bridge.getRestartTaskSnapshots()) {
+      active.set(`${bot.platform}\0${bot.name}\0${task.chatId}`, task);
+    }
+  }
+  return participants.map((participant) => {
+    const current = active.get(participantKey(participant));
+    if (!current) return { ...participant, wasActive: false };
+    return {
+      ...participant,
+      ...current,
+      botName: participant.botName,
+      platform: participant.platform,
+      wasActive: true,
+    };
+  });
+}
+
+function resolveParticipantBot(registry: BotRegistry, participant: ControlledRestartParticipant): RegisteredBot | undefined {
+  return registry.getByPlatform(participant.botName, participant.platform) ?? registry.get(participant.botName);
+}
+
+function releaseQuiesce(registered: RegisteredBot[], requestId: string): void {
+  for (const bot of registered) bot.bridge.cancelRestartQuiesce(requestId);
+}
+
+function armPreparationLease(registry: BotRegistry, logger: Logger, requestId: string): void {
+  clearPreparationLease(requestId);
+  const timer = setTimeout(() => {
+    const plan = readControlledRestartPlan();
+    if (!plan || plan.requestId !== requestId || (plan.status !== 'preparing' && plan.status !== 'prepared')) return;
+    cancelControlledRestart({ registry, requestId });
+    clearRestartBreadcrumb(requestId);
+    logger.warn({ requestId }, 'Controlled restart preparation expired; Bridge quiesce was released');
+  }, PREPARE_LEASE_MS);
+  timer.unref?.();
+  preparationLeases.set(requestId, timer);
+}
+
+function clearPreparationLease(requestId: string): void {
+  const timer = preparationLeases.get(requestId);
+  if (timer) clearTimeout(timer);
+  preparationLeases.delete(requestId);
+}
+
+function buildPreparingNotice(plan: ControlledRestartPlan, participant: ControlledRestartParticipant): string {
+  return [
+    `Controlled restart ${plan.requestId} is about to restart the shared MetaBot Bridge.`,
+    plan.reason ? `Reason: ${plan.reason}` : '',
+    participant.wasActive
+      ? plan.resume
+        ? 'This bot has active work. Its task state has been checkpointed and a continuation will be queued after the Bridge is healthy.'
+        : 'This bot has active work. Its task state has been checkpointed, but automatic continuation was disabled for this restart.'
+      : 'This chat requested the restart and will receive the completion result after the Bridge is healthy.',
+    'New work is briefly paused until the restart finishes.',
+  ].filter(Boolean).join('\n');
+}
+
+function buildCompletionNotice(
+  plan: ControlledRestartPlan,
+  participant: ControlledRestartParticipant,
+  outcome: ControlledRestartParticipant['continuationOutcome'],
+): string {
+  return [
+    `Controlled restart ${plan.requestId} completed and the Bridge is online.`,
+    outcome === 'scheduled'
+      ? 'A continuation turn was queued for the interrupted work.'
+      : outcome === 'failed'
+        ? 'The interrupted work could not be queued automatically; inspect the Bridge logs before retrying.'
+        : participant.wasActive && !plan.resume
+          ? 'Automatic continuation was disabled for this restart.'
+        : participant.wasActive
+          ? 'This task is owned by an internal runtime and was not replayed as a user chat.'
+          : 'No in-flight turn was recorded in this chat, so no continuation was needed.',
+  ].join('\n');
+}
+
+function buildRecoveredCard(
+  participant: ControlledRestartParticipant,
+  continuationQueued: boolean,
+  now: number,
+): CardState {
+  const previous = participant.cardState;
+  const restartText = continuationQueued
+    ? 'MetaBot restarted successfully. A continuation turn was queued for the interrupted work.'
+    : 'MetaBot restarted, but no continuation turn was queued for this task.';
+  return {
+    ...previous,
+    status: continuationQueued ? 'complete' : 'error',
+    userPrompt: previous?.userPrompt || participant.userPrompt,
+    responseText: [previous?.responseText, restartText].filter(Boolean).join('\n\n'),
+    toolCalls: previous?.toolCalls || [],
+    durationMs: Math.max(previous?.durationMs || 0, now - participant.startedAt),
+    pendingQuestion: undefined,
+    errorMessage: continuationQueued ? undefined : 'Task interrupted by service restart',
+  };
+}
+
+function buildContinuationPrompt(plan: ControlledRestartPlan, participant: ControlledRestartParticipant): string {
+  const previous = participant.userPrompt.length > 2000
+    ? `${participant.userPrompt.slice(0, 1997)}...`
+    : participant.userPrompt;
+  return [
+    '<system-reminder>',
+    `Controlled MetaBot restart ${plan.requestId} completed successfully.`,
+    'The Bridge process and this engine turn were interrupted by that restart.',
+    'Continue the interrupted task from the existing chat/session context.',
+    'Verify the post-restart state, finish only the remaining work, and do not restart or update again merely to satisfy the interrupted request.',
+    '',
+    'Interrupted user prompt:',
+    previous,
+    ...(participant.queuedPrompts?.length
+      ? [
+        '',
+        'Messages that were queued behind the interrupted turn, in order:',
+        ...participant.queuedPrompts.map((prompt, index) => `${index + 1}. ${prompt.slice(0, 1000)}`),
+      ]
+      : []),
+    '</system-reminder>',
+  ].join('\n');
+}
+
+function continuationKey(requestId: string, participant: ControlledRestartParticipant): string {
+  return `restart-resume:${requestId}:${participant.platform}:${participant.botName}:${participant.chatId}`;
+}
+
+function participantKey(participant: Pick<ControlledRestartParticipant, 'platform' | 'botName' | 'chatId'>): string {
+  return `${participant.platform}\0${participant.botName}\0${participant.chatId}`;
+}
+
+function isInternalExecutionChat(chatId: string): boolean {
+  return chatId.startsWith('team:')
+    || chatId.startsWith('teaminst:')
+    || chatId.startsWith('worker:')
+    || chatId.startsWith('worker-')
+    || chatId.startsWith('arc:')
+    || chatId.startsWith('arc-');
+}
+
+function writeControlledRestartPlan(plan: ControlledRestartPlan): void {
+  const file = controlledRestartPlanPath();
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const temp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(temp, `${JSON.stringify(plan, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(temp, file);
+}
+
+function assertRequestId(requestId: string): void {
+  if (!REQUEST_ID_RE.test(requestId)) {
+    throw new RestartPreparationError('Invalid controlled restart request ID', 400);
+  }
+}
+
+function isControlledRestartPlan(value: unknown): value is ControlledRestartPlan {
+  const plan = value as ControlledRestartPlan;
+  return !!plan
+    && plan.version === 1
+    && typeof plan.requestId === 'string'
+    && REQUEST_ID_RE.test(plan.requestId)
+    && ['preparing', 'prepared', 'cancelled', 'completed'].includes(plan.status)
+    && typeof plan.resume === 'boolean'
+    && typeof plan.force === 'boolean'
+    && Array.isArray(plan.participants)
+    && typeof plan.createdAt === 'number'
+    && typeof plan.updatedAt === 'number';
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      timer.unref?.();
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}

--- a/src/bridge/restart-notice.ts
+++ b/src/bridge/restart-notice.ts
@@ -5,14 +5,14 @@ import * as path from 'node:path';
 /**
  * Restart breadcrumb + one-shot reminder.
  *
- * `pm2 restart` kills the whole node process — including every Claude session —
- * and respawns it. The agent that ran `metabot restart` therefore loses all
+ * `pm2 restart` kills the whole Bridge process — including every active engine
+ * turn — and respawns it. The agent that ran `metabot restart` therefore loses all
  * memory of having done so; when the next message arrives the session resumes
  * with "please restart" still in its history and the agent restarts again, in a
  * loop. To break it, `bin/metabot` writes a timestamp breadcrumb just before
- * `pm2 restart`; we read (and delete) it at boot, then inject a one-shot
- * `<system-reminder>` into the first turn of each chat telling the agent the
- * restart already happened and not to do it again.
+ * `pm2 restart`; we retain it at boot until coordinated recovery has queued
+ * every continuation. The legacy one-shot reminder remains as a compatibility
+ * fallback for breadcrumbs created by an older CLI.
  */
 
 const BREADCRUMB_FILENAME = 'last-restart.json';
@@ -30,27 +30,54 @@ function breadcrumbPath(): string {
 }
 
 /**
- * Read the restart breadcrumb at boot and stash the timestamp in memory, then
- * delete the file so a later cold start doesn't re-trigger. Call once during
- * bridge startup. Safe to call when no breadcrumb exists.
+ * Read the restart breadcrumb at boot and retain it until restart recovery has
+ * reached a durable decision. Call once during bridge startup. Safe to call
+ * when no breadcrumb exists.
  */
-export function loadRestartBreadcrumb(): void {
+export interface RestartBreadcrumb {
+  version?: number;
+  restartedAt: number;
+  requestId?: string;
+  botName?: string;
+  chatId?: string;
+  source?: string;
+  reason?: string;
+  resume?: boolean;
+}
+
+let restartBreadcrumb: RestartBreadcrumb | undefined;
+
+export function loadRestartBreadcrumb(): RestartBreadcrumb | undefined {
   const file = breadcrumbPath();
   try {
     const raw = fs.readFileSync(file, 'utf-8');
-    const parsed = JSON.parse(raw) as { restartedAt?: number };
+    const parsed = JSON.parse(raw) as Partial<RestartBreadcrumb>;
     if (typeof parsed.restartedAt === 'number') {
       restartedAtMs = parsed.restartedAt * 1000; // breadcrumb stores epoch seconds
+      restartBreadcrumb = {
+        ...parsed,
+        restartedAt: parsed.restartedAt,
+      };
     }
   } catch {
     /* missing/unreadable — nothing to do */
   }
-  // Delete regardless; the timestamp now lives in memory for this process.
+  return restartBreadcrumb;
+}
+
+export function getRestartBreadcrumb(): RestartBreadcrumb | undefined {
+  return restartBreadcrumb;
+}
+
+/** Delete a consumed breadcrumb after recovery/reporting is durably decided. */
+export function clearRestartBreadcrumb(requestId?: string): void {
+  if (requestId && restartBreadcrumb?.requestId && restartBreadcrumb.requestId !== requestId) return;
   try {
-    fs.unlinkSync(file);
+    fs.unlinkSync(breadcrumbPath());
   } catch {
     /* already gone */
   }
+  restartBreadcrumb = undefined;
 }
 
 /** True if we should inject the restart reminder for this chat's next turn. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as https from 'node:https';
 import * as path from 'node:path';
+import { once } from 'node:events';
 import * as lark from '@larksuiteoapi/node-sdk';
 import { loadAppConfig, type BotConfig } from './config.js';
 import { createLogger, type Logger } from './utils/logger.js';
@@ -10,6 +11,7 @@ import { FeishuSenderAdapter } from './feishu/feishu-sender-adapter.js';
 import { resolveFeishuWsRecoveryOptions } from './feishu/ws-recovery.js';
 import { MessageBridge } from './bridge/message-bridge.js';
 import { loadRestartBreadcrumb } from './bridge/restart-notice.js';
+import { recoverControlledRestartAfterStartup } from './bridge/restart-coordinator.js';
 import type { IMessageSender } from './bridge/message-sender.interface.js';
 import type { BotConfigBase } from './config.js';
 import { startTelegramBot } from './telegram/telegram-bot.js';
@@ -402,6 +404,12 @@ async function main() {
     sessionRegistry,
     agentTeams: appConfig.agentTeams,
   });
+
+  // Restart recovery must run in the new process, after every bot sender and
+  // the local health endpoint are ready. It resumes every affected chat, not
+  // only the chat that submitted the restart command.
+  if (!apiServer.listening) await once(apiServer, 'listening');
+  await recoverControlledRestartAfterStartup({ registry, scheduler, logger });
 
   // Graceful shutdown
   const shutdown = async () => {

--- a/src/scheduler/task-scheduler.ts
+++ b/src/scheduler/task-scheduler.ts
@@ -21,6 +21,8 @@ export interface ScheduledTask {
   status: 'pending' | 'executing' | 'completed' | 'failed' | 'cancelled';
   createdAt: number;
   retryCount: number;
+  /** Stable idempotency key for system-created tasks such as restart recovery. */
+  dedupeKey?: string;
   parentRecurringId?: string;  // set if spawned by a recurring task
 }
 
@@ -31,6 +33,7 @@ export interface ScheduleInput {
   delaySeconds: number;
   sendCards?: boolean;
   label?: string;
+  dedupeKey?: string;
 }
 
 export interface ScheduleUpdateInput {
@@ -126,6 +129,18 @@ export class TaskScheduler {
   // ===== One-time task methods (unchanged) =====
 
   scheduleTask(input: ScheduleInput): ScheduledTask {
+    if (input.dedupeKey) {
+      const existing = Array.from(this.tasks.values()).find(
+        (task) => task.dedupeKey === input.dedupeKey && task.status !== 'cancelled',
+      );
+      if (existing) {
+        this.logger.info(
+          { taskId: existing.id, dedupeKey: input.dedupeKey, status: existing.status },
+          'Scheduled task deduplicated',
+        );
+        return existing;
+      }
+    }
     const now = Date.now();
     const task: ScheduledTask = {
       id: crypto.randomUUID(),
@@ -135,6 +150,7 @@ export class TaskScheduler {
       executeAt: now + input.delaySeconds * 1000,
       sendCards: input.sendCards ?? true,
       label: input.label,
+      dedupeKey: input.dedupeKey,
       status: 'pending',
       createdAt: now,
       retryCount: 0,

--- a/tests/metabot-controlled-restart-cli.test.ts
+++ b/tests/metabot-controlled-restart-cli.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+let tempDir = '';
+let fakeBin = '';
+let callLog = '';
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metabot-restart-cli-'));
+  fakeBin = path.join(tempDir, 'bin');
+  callLog = path.join(tempDir, 'calls.log');
+  fs.mkdirSync(fakeBin, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeExecutable(name: string, body: string): void {
+  const file = path.join(fakeBin, name);
+  fs.writeFileSync(file, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`, { mode: 0o755 });
+}
+
+function installCurl(status = 200): void {
+  writeExecutable('curl', `
+printf 'curl %s\\n' "$*" >> "$CALL_LOG"
+out=""
+args=("$@")
+for ((i=0; i<\${#args[@]}; i++)); do
+  if [[ "\${args[$i]}" == "-o" ]]; then out="\${args[$((i+1))]}"; fi
+done
+if [[ -n "$out" ]]; then printf '{"status":"prepared"}' > "$out"; fi
+printf '${status}'
+`);
+}
+
+function runRestart(extraArgs: string[] = []) {
+  return spawnSync('bash', [path.join(repoRoot, 'bin/metabot'), 'restart', '--request-id', 'restart-cli-test', ...extraArgs], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      METABOT_HOME: repoRoot,
+      SESSION_STORE_DIR: path.join(tempDir, 'state'),
+      CALL_LOG: callLog,
+      NO_COLOR: '1',
+    },
+  });
+}
+
+describe('metabot controlled restart CLI', () => {
+  it('prepares the Bridge before writing the breadcrumb and invoking PM2', () => {
+    installCurl(200);
+    writeExecutable('pm2', 'printf \'pm2 %s\\n\' "$*" >> "$CALL_LOG"');
+
+    const result = runRestart(['--bot', 'admin', '--chat', 'oc_test', '--reason', 'test restart']);
+
+    expect(result.status).toBe(0);
+    const calls = fs.readFileSync(callLog, 'utf8');
+    expect(calls).toContain('/api/runtime/restart/prepare');
+    expect(calls).toContain('pm2 restart metabot');
+    const breadcrumb = JSON.parse(fs.readFileSync(path.join(tempDir, 'state', 'last-restart.json'), 'utf8'));
+    expect(breadcrumb).toMatchObject({
+      requestId: 'restart-cli-test',
+      botName: 'admin',
+      chatId: 'oc_test',
+      reason: 'test restart',
+      resume: true,
+    });
+  });
+
+  it('refuses to restart when prepare is rejected', () => {
+    installCurl(409);
+    writeExecutable('pm2', 'printf \'pm2 %s\\n\' "$*" >> "$CALL_LOG"');
+
+    const result = runRestart();
+
+    expect(result.status).not.toBe(0);
+    expect(fs.readFileSync(callLog, 'utf8')).not.toContain('pm2 restart');
+    expect(fs.existsSync(path.join(tempDir, 'state', 'last-restart.json'))).toBe(false);
+  });
+
+  it('cancels quiesce and removes the breadcrumb when PM2 rejects the restart', () => {
+    installCurl(200);
+    writeExecutable('pm2', 'printf \'pm2 %s\\n\' "$*" >> "$CALL_LOG"; exit 1');
+
+    const result = runRestart();
+
+    expect(result.status).not.toBe(0);
+    const calls = fs.readFileSync(callLog, 'utf8');
+    expect(calls).toContain('/api/runtime/restart/prepare');
+    expect(calls).toContain('/api/runtime/restart/cancel');
+    expect(fs.existsSync(path.join(tempDir, 'state', 'last-restart.json'))).toBe(false);
+  });
+});

--- a/tests/restart-coordinator.test.ts
+++ b/tests/restart-coordinator.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const originalSessionStoreDir = process.env.SESSION_STORE_DIR;
+let stateDir = '';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+} as any;
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metabot-controlled-restart-'));
+  process.env.SESSION_STORE_DIR = stateDir;
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  const notice = await import('../src/bridge/restart-notice.js');
+  notice.clearRestartBreadcrumb();
+  if (originalSessionStoreDir === undefined) delete process.env.SESSION_STORE_DIR;
+  else process.env.SESSION_STORE_DIR = originalSessionStoreDir;
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+function makeBot(name: string, chatId: string, startedAt: number, platform: 'feishu' | 'telegram' = 'feishu') {
+  const sender = {
+    sendTextNotice: vi.fn().mockResolvedValue(undefined),
+    updateCard: vi.fn().mockResolvedValue(true),
+  };
+  const bridge = {
+    beginRestartQuiesce: vi.fn(),
+    cancelRestartQuiesce: vi.fn(),
+    getRestartTaskSnapshots: vi.fn().mockReturnValue([{
+      botName: name,
+      chatId,
+      messageId: `msg-${name}`,
+      userPrompt: `work for ${name}`,
+      startedAt,
+      source: 'chat',
+      sendCards: true,
+      cardState: {
+        status: 'running',
+        userPrompt: `work for ${name}`,
+        responseText: `partial ${name}`,
+        toolCalls: [],
+      },
+    }]),
+  };
+  return { name, platform, sender, bridge, config: {} } as any;
+}
+
+function makeRegistry(bots: any[]) {
+  return {
+    listRegistered: vi.fn().mockReturnValue(bots),
+    getByPlatform: vi.fn((name: string, platform: string) => bots.find((bot) => bot.name === name && bot.platform === platform)),
+    get: vi.fn((name: string) => bots.find((bot) => bot.name === name)),
+  } as any;
+}
+
+describe('controlled restart coordination', () => {
+  it('quiesces every bot, checkpoints all active chats, and uses each bot sender for prepare notices', async () => {
+    const admin = makeBot('admin', 'chat-admin', 200);
+    const pm = makeBot('pm-codex', 'chat-pm', 100);
+    const registry = makeRegistry([admin, pm]);
+    const { prepareControlledRestart, readControlledRestartPlan } = await import('../src/bridge/restart-coordinator.js');
+
+    const plan = await prepareControlledRestart({
+      registry,
+      logger,
+      request: {
+        requestId: 'restart-multi-bot-1',
+        requesterBot: 'admin',
+        requesterChat: 'chat-admin',
+        reason: 'upgrade runtime',
+        resume: true,
+      },
+      now: 1_000,
+    });
+
+    expect(plan.status).toBe('prepared');
+    expect(plan.participants.map((participant) => participant.botName)).toEqual(['pm-codex', 'admin']);
+    expect(admin.bridge.beginRestartQuiesce).toHaveBeenCalledWith('restart-multi-bot-1');
+    expect(pm.bridge.beginRestartQuiesce).toHaveBeenCalledWith('restart-multi-bot-1');
+    expect(admin.sender.sendTextNotice).toHaveBeenCalledWith(
+      'chat-admin', 'MetaBot Restart Preparing', expect.stringContaining('upgrade runtime'), 'orange',
+    );
+    expect(pm.sender.sendTextNotice).toHaveBeenCalledWith(
+      'chat-pm', 'MetaBot Restart Preparing', expect.stringContaining('continuation'), 'orange',
+    );
+    expect(readControlledRestartPlan()).toMatchObject({
+      requestId: 'restart-multi-bot-1',
+      status: 'prepared',
+      participants: [{ botName: 'pm-codex' }, { botName: 'admin' }],
+    });
+  });
+
+  it('cancels prepare and releases every bot when one affected chat cannot be notified', async () => {
+    const admin = makeBot('admin', 'chat-admin', 100);
+    const pm = makeBot('pm-codex', 'chat-pm', 200);
+    pm.sender.sendTextNotice.mockRejectedValueOnce(new Error('send failed'));
+    const registry = makeRegistry([admin, pm]);
+    const { prepareControlledRestart, readControlledRestartPlan } = await import('../src/bridge/restart-coordinator.js');
+
+    await expect(prepareControlledRestart({
+      registry,
+      logger,
+      request: { requestId: 'restart-notice-fail' },
+    })).rejects.toThrow(/could not notify 1 affected chat/);
+
+    expect(readControlledRestartPlan()?.status).toBe('cancelled');
+    expect(admin.bridge.cancelRestartQuiesce).toHaveBeenCalledWith('restart-notice-fail');
+    expect(pm.bridge.cancelRestartQuiesce).toHaveBeenCalledWith('restart-notice-fail');
+  });
+
+  it('does not replay work that finishes while prepare notices are being delivered', async () => {
+    const admin = makeBot('admin', 'chat-admin', 100);
+    admin.sender.sendTextNotice.mockImplementationOnce(async () => {
+      admin.bridge.getRestartTaskSnapshots.mockReturnValue([]);
+    });
+    const registry = makeRegistry([admin]);
+    const coordinator = await import('../src/bridge/restart-coordinator.js');
+    const notice = await import('../src/bridge/restart-notice.js');
+
+    const plan = await coordinator.prepareControlledRestart({
+      registry,
+      logger,
+      request: { requestId: 'restart-finished-during-prepare' },
+    });
+
+    expect(plan.participants[0]).toMatchObject({
+      botName: 'admin',
+      prepareNotice: 'delivered',
+      wasActive: false,
+    });
+    fs.writeFileSync(path.join(stateDir, 'last-restart.json'), JSON.stringify({
+      restartedAt: Math.floor(Date.now() / 1000),
+      requestId: plan.requestId,
+    }));
+    notice.loadRestartBreadcrumb();
+    const scheduleTask = vi.fn();
+    await coordinator.recoverControlledRestartAfterStartup({
+      registry,
+      scheduler: { scheduleTask } as any,
+      logger,
+    });
+
+    expect(scheduleTask).not.toHaveBeenCalled();
+    expect(admin.sender.updateCard).not.toHaveBeenCalled();
+    expect(admin.sender.sendTextNotice).toHaveBeenLastCalledWith(
+      'chat-admin',
+      'MetaBot Restart Complete',
+      expect.stringContaining('No in-flight turn was recorded'),
+      'green',
+    );
+  });
+
+  it('sends completion from every bot and queues one durable continuation per interrupted chat', async () => {
+    const admin = makeBot('admin', 'chat-admin', 100);
+    const pm = makeBot('pm-codex', 'chat-pm', 200);
+    const registry = makeRegistry([admin, pm]);
+    const coordinator = await import('../src/bridge/restart-coordinator.js');
+    const notice = await import('../src/bridge/restart-notice.js');
+
+    await coordinator.prepareControlledRestart({
+      registry,
+      logger,
+      request: { requestId: 'restart-recover-all', requesterBot: 'admin', requesterChat: 'chat-admin' },
+    });
+    fs.writeFileSync(path.join(stateDir, 'last-restart.json'), JSON.stringify({
+      version: 1,
+      restartedAt: Math.floor(Date.now() / 1000),
+      requestId: 'restart-recover-all',
+      resume: true,
+    }));
+    notice.loadRestartBreadcrumb();
+
+    const scheduleTask = vi.fn((input: any) => ({ ...input, id: `task-${input.botName}` }));
+    const recovered = await coordinator.recoverControlledRestartAfterStartup({
+      registry,
+      scheduler: { scheduleTask } as any,
+      logger,
+      now: 5_000,
+    });
+
+    expect(scheduleTask).toHaveBeenCalledTimes(2);
+    expect(scheduleTask).toHaveBeenCalledWith(expect.objectContaining({
+      botName: 'admin',
+      chatId: 'chat-admin',
+      dedupeKey: expect.stringContaining('restart-recover-all'),
+      prompt: expect.stringContaining('work for admin'),
+    }));
+    expect(scheduleTask).toHaveBeenCalledWith(expect.objectContaining({ botName: 'pm-codex', chatId: 'chat-pm' }));
+    expect(admin.sender.updateCard).toHaveBeenCalledWith('msg-admin', expect.objectContaining({
+      status: 'complete', responseText: expect.stringContaining('partial admin'),
+    }));
+    expect(pm.sender.updateCard).toHaveBeenCalledWith('msg-pm-codex', expect.objectContaining({ status: 'complete' }));
+    expect(admin.sender.sendTextNotice).toHaveBeenLastCalledWith(
+      'chat-admin', 'MetaBot Restart Complete', expect.stringContaining('continuation turn was queued'), 'green',
+    );
+    expect(pm.sender.sendTextNotice).toHaveBeenLastCalledWith(
+      'chat-pm', 'MetaBot Restart Complete', expect.stringContaining('continuation turn was queued'), 'green',
+    );
+    expect(recovered?.status).toBe('completed');
+    expect(recovered?.participants.every((participant) => participant.continuationOutcome === 'scheduled')).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, 'last-restart.json'))).toBe(false);
+  });
+
+  it('reports an idle requester without scheduling a continuation', async () => {
+    const admin = makeBot('admin', 'unrelated-active-chat', 100);
+    admin.bridge.getRestartTaskSnapshots.mockReturnValue([]);
+    const registry = makeRegistry([admin]);
+    const coordinator = await import('../src/bridge/restart-coordinator.js');
+    const notice = await import('../src/bridge/restart-notice.js');
+
+    await coordinator.prepareControlledRestart({
+      registry,
+      logger,
+      request: {
+        requestId: 'restart-idle-requester',
+        requesterBot: 'admin',
+        requesterChat: 'chat-requester',
+      },
+    });
+    fs.writeFileSync(path.join(stateDir, 'last-restart.json'), JSON.stringify({
+      restartedAt: Math.floor(Date.now() / 1000),
+      requestId: 'restart-idle-requester',
+    }));
+    notice.loadRestartBreadcrumb();
+    const scheduleTask = vi.fn();
+
+    await coordinator.recoverControlledRestartAfterStartup({
+      registry,
+      scheduler: { scheduleTask } as any,
+      logger,
+    });
+
+    expect(scheduleTask).not.toHaveBeenCalled();
+    expect(admin.sender.sendTextNotice).toHaveBeenLastCalledWith(
+      'chat-requester',
+      'MetaBot Restart Complete',
+      expect.stringContaining('no continuation was needed'),
+      'green',
+    );
+  });
+
+  it('resumes non-card API work without sending notices to synthetic chat IDs', async () => {
+    const admin = makeBot('admin', 'agent-bus:request-1', 100);
+    admin.bridge.getRestartTaskSnapshots.mockReturnValue([{
+      botName: 'admin',
+      chatId: 'agent-bus:request-1',
+      userPrompt: 'delegate this task',
+      startedAt: 100,
+      source: 'api',
+      sendCards: false,
+      queuedPrompts: ['then report the result'],
+    }]);
+    const registry = makeRegistry([admin]);
+    const coordinator = await import('../src/bridge/restart-coordinator.js');
+
+    const prepared = await coordinator.prepareControlledRestart({
+      registry,
+      logger,
+      request: { requestId: 'restart-api-no-cards' },
+    });
+    expect(prepared.participants[0]?.prepareNotice).toBe('skipped');
+    expect(admin.sender.sendTextNotice).not.toHaveBeenCalled();
+
+    const scheduleTask = vi.fn((input: any) => ({ ...input, id: 'task-agent-bus' }));
+
+    // A fresh prepared plan is recoverable even if the CLI/process dies in the
+    // narrow window before it can persist last-restart.json.
+    const recovered = await coordinator.recoverControlledRestartAfterStartup({
+      registry,
+      scheduler: { scheduleTask } as any,
+      logger,
+    });
+
+    expect(scheduleTask).toHaveBeenCalledWith(expect.objectContaining({
+      botName: 'admin',
+      chatId: 'agent-bus:request-1',
+      sendCards: false,
+      prompt: expect.stringContaining('then report the result'),
+    }));
+    expect(admin.sender.sendTextNotice).not.toHaveBeenCalled();
+    expect(admin.sender.updateCard).not.toHaveBeenCalled();
+    expect(recovered?.participants[0]).toMatchObject({
+      completionNotice: 'skipped',
+      continuationOutcome: 'scheduled',
+    });
+  });
+
+  it('retains the durable handoff when continuation scheduling fails', async () => {
+    const admin = makeBot('admin', 'chat-admin', 100);
+    const registry = makeRegistry([admin]);
+    const coordinator = await import('../src/bridge/restart-coordinator.js');
+
+    await coordinator.prepareControlledRestart({
+      registry,
+      logger,
+      request: { requestId: 'restart-retry-schedule' },
+    });
+    const scheduleTaskDurably = vi.fn(() => {
+      throw new Error('durable scheduler unavailable');
+    });
+
+    const recovered = await coordinator.recoverControlledRestartAfterStartup({
+      registry,
+      scheduler: { scheduleTask: vi.fn(), scheduleTaskDurably } as any,
+      logger,
+    });
+
+    expect(scheduleTaskDurably).toHaveBeenCalledOnce();
+    expect(recovered).toMatchObject({
+      status: 'prepared',
+      participants: [{
+        continuationOutcome: 'failed',
+        completionNotice: 'delivered',
+      }],
+    });
+    expect(recovered?.participants[0]?.recoveredAt).toBeUndefined();
+    expect(coordinator.readControlledRestartPlan()?.status).toBe('prepared');
+  });
+});

--- a/tests/task-scheduler-one-time.test.ts
+++ b/tests/task-scheduler-one-time.test.ts
@@ -139,6 +139,25 @@ describe('TaskScheduler one-time tasks — creation', () => {
     expect(scheduler.taskCount()).toBe(2);
     scheduler.destroy();
   });
+
+  it('deduplicates system-created tasks by dedupeKey', () => {
+    const firstScheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const first = firstScheduler.scheduleTask({
+      botName: 'b', chatId: 'c', prompt: 'resume once', delaySeconds: 60, dedupeKey: 'restart:one',
+    });
+    firstScheduler.destroy();
+
+    // Simulate another process booting after a crash between scheduling the
+    // continuation and marking its restart participant recovered.
+    const recoveredScheduler = new TaskScheduler(createMockRegistry(), createMockLogger());
+    const duplicate = recoveredScheduler.scheduleTask({
+      botName: 'b', chatId: 'c', prompt: 'resume twice', delaySeconds: 120, dedupeKey: 'restart:one',
+    });
+    expect(duplicate.id).toBe(first.id);
+    expect(recoveredScheduler.listTasks()).toHaveLength(1);
+    expect(recoveredScheduler.listTasks()[0]?.prompt).toBe('resume once');
+    recoveredScheduler.destroy();
+  });
 });
 
 // =====================================================================


### PR DESCRIPTION
## Summary

- quiesce every registered bot before a shared Bridge restart
- checkpoint each affected active chat and queued prompt into an atomic durable handoff
- notify affected chats through their own bot before and after restart
- resume interrupted work with stable deduplication and retry incomplete recovery on a later startup
- cancel preparation on notification or PM2 failure, with a bounded preparation lease
- preserve non-card API recovery while avoiding generic replay of Agent Team, Worker, and ARC internal chats

## Validation

- Node 22.19.0
- full repository test suite: 1169 passed
- focused controlled-restart tests: 10 passed
- TypeScript no-emit check passed
- production build passed
- shell syntax and diff checks passed
- ESLint: 0 errors; 8 pre-existing warnings

## Operational notes

This change adds an authenticated prepare/cancel API and an atomic 0600 controlled-restart.json handoff. It does not change the sessions database schema or require a data migration.