### PR TITLE
fix(codex): avoid Windows spawn EINVAL

### DIFF
--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -20,10 +20,67 @@ import {
 const isWindows = process.platform === 'win32';
 const FALLBACK_CODEX_CONTEXT_WINDOW = 272000;
 
+function findWindowsCodexBinary(npmPrefix: string | undefined): string | undefined {
+  if (!npmPrefix) return undefined;
+
+  const target = process.arch === 'arm64'
+    ? { packageName: 'codex-win32-arm64', triple: 'aarch64-pc-windows-msvc' }
+    : { packageName: 'codex-win32-x64', triple: 'x86_64-pc-windows-msvc' };
+  const candidate = path.join(
+    npmPrefix,
+    'node_modules',
+    '@openai',
+    'codex',
+    'node_modules',
+    '@openai',
+    target.packageName,
+    'vendor',
+    target.triple,
+    'bin',
+    'codex.exe',
+  );
+  return existsSync(candidate) ? candidate : undefined;
+}
+
+export function buildCodexSpawnCommand(
+  executable: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
+  if (platform !== 'win32') return { command: executable, args };
+
+  if (path.basename(executable).toLowerCase() === 'codex.cmd') {
+    const codexScript = path.join(
+      path.dirname(executable),
+      'node_modules',
+      '@openai',
+      'codex',
+      'bin',
+      'codex.js',
+    );
+    if (existsSync(codexScript)) {
+      return { command: process.execPath, args: [codexScript, ...args] };
+    }
+    throw new Error(`Unable to resolve Codex npm entrypoint for ${executable}`);
+  }
+
+  if (/\.(?:cmd|bat)$/i.test(executable)) {
+    throw new Error(`Codex executable must be a native executable on Windows: ${executable}`);
+  }
+  return { command: executable, args };
+}
+
 function resolveCodexPath(): string {
   if (process.env.CODEX_EXECUTABLE_PATH) return process.env.CODEX_EXECUTABLE_PATH;
+
+  if (isWindows) {
+    const npmPrefix = process.env.APPDATA ? path.join(process.env.APPDATA, 'npm') : undefined;
+    const nativeBinary = findWindowsCodexBinary(npmPrefix);
+    if (nativeBinary) return nativeBinary;
+  }
+
   try {
-    const cmd = isWindows ? 'where codex' : 'which codex';
+    const cmd = isWindows ? 'where codex.cmd' : 'which codex';
     return execSync(cmd, { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
   } catch {
     if (!isWindows) {
@@ -224,10 +281,13 @@ export class CodexExecutor {
     };
 
     try {
-      child = spawn(codexConfig.executable || CODEX_EXECUTABLE, args, {
+      const executable = codexConfig.executable || CODEX_EXECUTABLE;
+      const spawnCommand = buildCodexSpawnCommand(executable, args);
+      child = spawn(spawnCommand.command, spawnCommand.args, {
         cwd,
         env: { ...process.env, ...(codexConfig.env ?? {}) },
         stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
       });
     } catch (err: any) {
       finishWithError(err?.message || String(err));

--- a/tests/codex-build-args.test.ts
+++ b/tests/codex-build-args.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { buildCodexArgs, resolveCodexModelMetadata } from '../src/engines/codex/executor.js';
+import {
+  buildCodexArgs,
+  buildCodexSpawnCommand,
+  resolveCodexModelMetadata,
+} from '../src/engines/codex/executor.js';
 import type { CodexBotConfig } from '../src/config.js';
 
 describe('buildCodexArgs', () => {
@@ -96,5 +100,53 @@ describe('buildCodexArgs', () => {
       else process.env.CODEX_HOME = priorCodexHome;
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('buildCodexSpawnCommand', () => {
+  const args = ['exec', '--json', 'prompt with spaces & "quotes"'];
+
+  it('runs the npm Codex wrapper through Node when codex.js exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'metabot-codex-wrapper-'));
+    try {
+      const codexScript = join(dir, 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+      mkdirSync(join(dir, 'node_modules', '@openai', 'codex', 'bin'), { recursive: true });
+      writeFileSync(codexScript, '');
+
+      expect(buildCodexSpawnCommand(join(dir, 'codex.cmd'), args, 'win32')).toEqual({
+        command: process.execPath,
+        args: [codexScript, ...args],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects other Windows command wrappers', () => {
+    expect(() => buildCodexSpawnCommand(
+      'C:\\tools\\custom-codex.cmd',
+      args,
+      'win32',
+    )).toThrow('Codex executable must be a native executable on Windows');
+  });
+
+  it('runs Windows native executables directly', () => {
+    expect(buildCodexSpawnCommand('C:\\tools\\codex.exe', args, 'win32')).toEqual({
+      command: 'C:\\tools\\codex.exe',
+      args,
+    });
+  });
+
+  it('leaves non-Windows commands unchanged', () => {
+    expect(buildCodexSpawnCommand('/usr/local/bin/codex', args, 'linux')).toEqual({
+      command: '/usr/local/bin/codex',
+      args,
+    });
+  });
+
+  it('rejects a Codex wrapper when its npm entrypoint is missing', () => {
+    expect(() => buildCodexSpawnCommand('codex.cmd', args, 'win32')).toThrow(
+      'Unable to resolve Codex npm entrypoint',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- resolve the native Windows Codex binary from the npm installation before falling back to `codex.cmd`
- execute the standard npm wrapper through Node instead of spawning a `.cmd` file directly
- reject unsupported Windows command wrappers with a diagnostic error
- add regression coverage for Windows and non-Windows spawn command construction

## Verification
- `npm test -- tests/codex-build-args.test.ts` (14 passed)
- `npx tsc --noEmit`
- `npx eslint src/engines/codex/executor.ts tests/codex-build-args.test.ts`
- real Windows `codex.cmd --version` smoke test: `codex-cli 0.147.0`, exit 0
- full `npm test`: 313 passed; 8 existing Windows SQLite cleanup failures (`EBUSY` in `skill-hub-store.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
