### PR TITLE
fix(pty): match claude's projects-dir escaping — every non-alphanumeric char becomes '-'

### DIFF
--- a/src/engines/claude/pty/pty-session.ts
+++ b/src/engines/claude/pty/pty-session.ts
@@ -16,6 +16,7 @@ import xterm from '@xterm/headless';
 const { Terminal } = xterm;
 type XtermTerminal = InstanceType<typeof Terminal>;
 import type { Logger } from '../../../utils/logger.js';
+import { claudeProjectsDir } from '../session-lister.js';
 import type {
   PtyClaudeSession as IPtyClaudeSession,
   PtyClaudeSessionOptions,
@@ -57,22 +58,15 @@ class PtyClaudeSessionImpl implements IPtyClaudeSession {
     // Session id: adopt resume id or self-generate.
     this.sessionId = opts.resume ?? randomUUID();
 
-    // Compute jsonl path: ~/.claude/projects/<escaped-cwd>/<sessionId>.jsonl
-    // Escaped cwd: every '/' replaced by '-' (leading slash → leading dash).
-    // cwd MUST be absolute here — a relative cwd (e.g. ".") escapes to "." and
-    // the tail points at the wrong dir, so the scanner reads nothing and the
-    // Feishu card renders blank. Config should already absolutize this
-    // (expandUserPath), but resolve defensively so the path derivation matches
-    // exactly what claude itself does (it derives its jsonl dir from its cwd).
-    const resolvedCwd = path.resolve(opts.cwd);
-    const escaped = resolvedCwd.replace(/\//g, '-');
-    this.jsonlPath = path.join(
-      os.homedir(),
-      '.claude',
-      'projects',
-      escaped,
-      `${this.sessionId}.jsonl`,
-    );
+    // Compute jsonl path via the shared claudeProjectsDir() (single source of
+    // truth with session-lister): claude replaces EVERY non-alphanumeric char
+    // with '-' — not just '/'. Underscores/dots/spaces all become '-' (verified
+    // against live ~/.claude/projects: /u/openclaw_workspace →
+    // -u-openclaw-workspace, ~/.openclaw → --openclaw). Replacing only '/'
+    // points the scanner at a nonexistent file whenever the cwd contains '_'
+    // (e.g. openclaw_workspace) — the scanner then waits forever and every
+    // reply comes back empty.
+    this.jsonlPath = path.join(claudeProjectsDir(opts.cwd), `${this.sessionId}.jsonl`);
 
     this.spawn();
   }

--- a/src/engines/claude/session-lister.ts
+++ b/src/engines/claude/session-lister.ts
@@ -27,12 +27,14 @@ export interface SessionSummary {
 /**
  * Directory where `claude` stores this cwd's session transcripts.
  *
- * MUST match `pty-session.ts` exactly: every '/' in the absolute cwd becomes
- * '-' (leading slash → leading dash). Exported so tests share one source of
- * truth with the path derivation under test.
+ * MUST match what claude itself does: EVERY non-alphanumeric char (not just
+ * '/', but also '_', '.', spaces, CJK brackets…) becomes '-'. Verified against
+ * live ~/.claude/projects: /u/openclaw_workspace → -u-openclaw-workspace,
+ * ~/.openclaw → --openclaw. Replacing only '/' breaks any cwd containing '_'.
+ * Exported so tests share one source of truth with the path derivation under test.
  */
 export function claudeProjectsDir(cwd: string, homeDir: string = os.homedir()): string {
-  const escaped = path.resolve(cwd).replace(/\//g, '-');
+  const escaped = path.resolve(cwd).replace(/[^a-zA-Z0-9-]/g, '-');
   return path.join(homeDir, '.claude', 'projects', escaped);
 }
 

--- a/tests/session-lister.test.ts
+++ b/tests/session-lister.test.ts
@@ -52,6 +52,17 @@ describe('claudeProjectsDir', () => {
     const dir = claudeProjectsDir('/a/b/c', '/home/u');
     expect(dir).toBe(path.join('/home/u', '.claude', 'projects', '-a-b-c'));
   });
+  it('escapes underscores and dots to dashes (matches claude itself)', () => {
+    // Verified against live ~/.claude/projects (Claude Code 2.1.x):
+    // /Users/garfield/openclaw_workspace → -Users-garfield-openclaw-workspace
+    expect(claudeProjectsDir('/u/openclaw_workspace', '/home/u')).toBe(
+      path.join('/home/u', '.claude', 'projects', '-u-openclaw-workspace'),
+    );
+    // /Users/garfield/.openclaw → -Users-garfield--openclaw
+    expect(claudeProjectsDir('/Users/garfield/.openclaw', '/home/u')).toBe(
+      path.join('/home/u', '.claude', 'projects', '-Users-garfield--openclaw'),
+    );
+  });
   it('resolves relative cwd before escaping', () => {
     const dir = claudeProjectsDir('.', '/home/u');
     expect(dir.startsWith(path.join('/home/u', '.claude', 'projects', '-'))).toBe(true);


### PR DESCRIPTION
Closes #373

## Problem

In `CLAUDE_BACKEND=pty` mode, bots whose working directory contains `_` (or `.`, spaces, CJK chars…) return **empty replies** — Telegram shows "thinking" → "done" with no message, while Claude actually answered.

The pty backend derives the transcript path `~/.claude/projects/<escaped-cwd>/<sessionId>.jsonl` by replacing only `/` → `-`, but Claude Code replaces **every non-alphanumeric character** with `-`. The jsonl scanner then tails a path that never exists, no assistant records reach the stream processor, and `responseText` stays `""`.

Live evidence (Claude Code 2.1.226):

| cwd | actual projects dir |
|---|---|
| `/Users/garfield/openclaw_workspace` | `-Users-garfield-openclaw-workspace` |
| `/Users/garfield/.openclaw` | `-Users-garfield--openclaw` |
| `/Users/garfield/app/apps/www.junniufund.cn` | `-Users-garfield-app-apps-www-junniufund-cn` |

## Fix

- `session-lister.ts` `claudeProjectsDir()`: escape `[^a-zA-Z0-9-]` → `-` (matches claude's rule)
- `pty-session.ts`: derive `jsonlPath` via the shared `claudeProjectsDir()` — single source of truth, as the existing comment already demands ("MUST match `pty-session.ts` exactly")
- `tests/session-lister.test.ts`: +2 cases covering underscore and dotted-directory escaping

## Verification

- `tsc --noEmit` clean
- `tests/session-lister.test.ts`: 12/12 pass (10 existing + 2 new)
- Reproduced end-to-end before the fix (injected turn → `responseText: ""`, scanner waiting on nonexistent `openclaw_workspace` path) and confirmed after (same turn → `responseText: "好"`, scanner reading the correct `openclaw-workspace` transcript)
