### PR TITLE
fix(skills): transfer complete Skill bundles

### DIFF
--- a/packages/skill-hub/src/commands.ts
+++ b/packages/skill-hub/src/commands.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as zlib from 'node:zlib';
 import { request } from './client.js';
 import type { Config } from './config.js';
 import { print } from '@xvirobotics/cli-core/print';
@@ -38,6 +39,20 @@ interface SkillRecordSnippet {
   name?: string;
   version?: number;
   skillMd?: string;
+  hasReferences?: boolean;
+}
+
+interface SkillBundleFile {
+  path: string;
+  content: string;
+  encoding?: 'base64' | 'utf8';
+  mode?: number;
+}
+
+interface SkillReferencesResponse {
+  name?: string;
+  version?: number;
+  files?: unknown;
 }
 
 const DEFAULT_SKILL_INSTALL_ROOT = path.join('.metabot', 'skills');
@@ -45,6 +60,144 @@ const ENGINE_SKILL_DIRS = new Set(['.claude/skills', '.codex/skills', '.agents/s
 
 function flagEnabled(value: string | true | undefined): boolean {
   return value === true || value === '1' || value === 'true' || value === 'yes';
+}
+
+const SKIPPED_BUNDLE_DIRS = new Set(['.git', 'node_modules']);
+
+function collectBundleFiles(root: string): SkillBundleFile[] {
+  const files: SkillBundleFile[] = [];
+
+  function visit(dir: string): void {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory() && SKIPPED_BUNDLE_DIRS.has(entry.name)) continue;
+      const absolutePath = path.join(dir, entry.name);
+      const relativePath = path.relative(root, absolutePath).split(path.sep).join('/');
+      if (relativePath === 'SKILL.md') continue;
+      if (entry.isSymbolicLink()) {
+        throw new Error(`publish: symbolic links are not supported in skill bundles (${relativePath})`);
+      }
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        throw new Error(`publish: unsupported bundle entry (${relativePath})`);
+      }
+      const stat = fs.statSync(absolutePath);
+      files.push({
+        path: relativePath,
+        content: fs.readFileSync(absolutePath).toString('base64'),
+        encoding: 'base64',
+        mode: stat.mode & 0o111 ? 0o755 : 0o644,
+      });
+    }
+  }
+
+  visit(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function packBundleFiles(files: SkillBundleFile[]): string | null {
+  if (files.length === 0) return null;
+  const payload = Buffer.from(JSON.stringify({ files }), 'utf8');
+  return zlib.gzipSync(payload).toString('base64');
+}
+
+function validateBundlePath(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
+    throw new Error('install: bundle contains an invalid file path');
+  }
+  const portable = value.replace(/\\/g, '/');
+  if (portable.startsWith('/') || /^[A-Za-z]:\//.test(portable)) {
+    throw new Error(`install: bundle contains an absolute file path (${value})`);
+  }
+  const normalized = path.posix.normalize(portable);
+  if (normalized === '.' || normalized === '..' || normalized.startsWith('../') || normalized !== portable) {
+    throw new Error(`install: bundle contains an unsafe file path (${value})`);
+  }
+  if (normalized === 'SKILL.md') {
+    throw new Error('install: bundle references must not replace SKILL.md');
+  }
+  return normalized;
+}
+
+function parseBundleFiles(value: unknown): Array<{ path: string; content: Buffer; mode: number }> {
+  if (!Array.isArray(value)) throw new Error('install: references response contains no file list');
+  const files: Array<{ path: string; content: Buffer; mode: number }> = [];
+  const seen = new Set<string>();
+
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') throw new Error('install: bundle contains an invalid file entry');
+    const entry = raw as Partial<SkillBundleFile>;
+    const relativePath = validateBundlePath(entry.path);
+    const portableKey = relativePath.toLocaleLowerCase('en-US');
+    if (seen.has(portableKey)) throw new Error(`install: bundle contains a duplicate file path (${relativePath})`);
+    seen.add(portableKey);
+    if (typeof entry.content !== 'string') {
+      throw new Error(`install: bundle file has invalid content (${relativePath})`);
+    }
+    let content: Buffer;
+    if (entry.encoding === undefined || entry.encoding === 'utf8') {
+      content = Buffer.from(entry.content, 'utf8');
+    } else if (entry.encoding === 'base64') {
+      content = Buffer.from(entry.content, 'base64');
+    } else {
+      throw new Error(`install: bundle file has unsupported encoding (${relativePath})`);
+    }
+    const mode = entry.mode === 0o755 ? 0o755 : 0o644;
+    files.push({ path: relativePath, content, mode });
+  }
+
+  const filePaths = new Set(files.map((file) => file.path));
+  for (const file of files) {
+    let parent = path.posix.dirname(file.path);
+    while (parent !== '.') {
+      if (filePaths.has(parent)) {
+        throw new Error(`install: bundle path is both a file and a directory (${parent})`);
+      }
+      parent = path.posix.dirname(parent);
+    }
+  }
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function installBundleAtomically(
+  targetDir: string,
+  skillMd: string,
+  files: Array<{ path: string; content: Buffer; mode: number }>,
+): void {
+  const target = path.resolve(targetDir);
+  if (target === path.parse(target).root) throw new Error('install: refusing to replace a filesystem root');
+  const parent = path.dirname(target);
+  fs.mkdirSync(parent, { recursive: true });
+  const stage = fs.mkdtempSync(path.join(parent, `.${path.basename(target)}.install-`));
+  let backup: string | undefined;
+
+  try {
+    fs.writeFileSync(path.join(stage, 'SKILL.md'), skillMd, { mode: 0o644 });
+    for (const file of files) {
+      const destination = path.join(stage, ...file.path.split('/'));
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(destination, file.content, { mode: file.mode });
+    }
+
+    if (fs.existsSync(target)) {
+      if (fs.lstatSync(target).isSymbolicLink()) {
+        throw new Error(`install: refusing to replace symbolic link target (${targetDir})`);
+      }
+      backup = `${target}.previous-${process.pid}-${Date.now()}`;
+      fs.renameSync(target, backup);
+    }
+    try {
+      fs.renameSync(stage, target);
+    } catch (error) {
+      if (backup && fs.existsSync(backup) && !fs.existsSync(target)) fs.renameSync(backup, target);
+      throw error;
+    }
+    if (backup) fs.rmSync(backup, { recursive: true, force: true });
+  } finally {
+    fs.rmSync(stage, { recursive: true, force: true });
+  }
 }
 
 export function defaultInstallDir(name: string): string {
@@ -68,12 +221,14 @@ export async function cmdPublish(cfg: Config, args: ParsedArgs): Promise<void> {
   const mdFlag = typeof args.flags.md === 'string' ? args.flags.md : undefined;
 
   let skillMd: string;
+  let referencesTar: string | null | undefined;
   if (mdFlag) {
     skillMd = fs.readFileSync(mdFlag, 'utf8');
   } else if (from) {
     const p = path.join(from, 'SKILL.md');
     if (!fs.existsSync(p)) throw new Error(`publish: ${p} not found (--from <dir> must contain SKILL.md)`);
     skillMd = fs.readFileSync(p, 'utf8');
+    referencesTar = packBundleFiles(collectBundleFiles(from));
   } else if (!process.stdin.isTTY) {
     const chunks: Buffer[] = [];
     skillMd = await new Promise<string>((resolve, reject) => {
@@ -91,7 +246,7 @@ export async function cmdPublish(cfg: Config, args: ParsedArgs): Promise<void> {
   const body = await request<SkillRecordSnippet>(cfg, {
     method: 'POST',
     path: `/api/skills/${encodeURIComponent(name)}/publish`,
-    body: { skillMd, visibility },
+    body: { skillMd, visibility, ...(from ? { referencesTar } : {}) },
   });
   print(body);
 }
@@ -114,10 +269,22 @@ export async function cmdInstall(cfg: Config, args: ParsedArgs): Promise<void> {
   if (!record.skillMd) {
     throw new Error(`install: ${name} returned no skillMd content`);
   }
-  fs.mkdirSync(to, { recursive: true });
+  let files: Array<{ path: string; content: Buffer; mode: number }> = [];
+  if (record.hasReferences) {
+    const references = await request<SkillReferencesResponse>(cfg, {
+      path: `/api/skills/${encodeURIComponent(name)}/references`,
+    });
+    files = parseBundleFiles(references.files);
+  }
+  installBundleAtomically(to, record.skillMd, files);
   const dst = path.join(to, 'SKILL.md');
-  fs.writeFileSync(dst, record.skillMd);
-  print({ name, installedTo: dst, version: record.version, trusted: targetsEngineAutoloadDir(to) });
+  print({
+    name,
+    installedTo: dst,
+    version: record.version,
+    filesInstalled: files.length + 1,
+    trusted: targetsEngineAutoloadDir(to),
+  });
 }
 
 export async function cmdRemove(cfg: Config, args: ParsedArgs): Promise<void> {
@@ -146,11 +313,11 @@ Commands:
   search <query>                    FTS search over published skills
   get <name>                        Get one skill (includes SKILL.md)
   publish <name>                    Publish a skill. Source order:
-                                      --from <dir>   reads <dir>/SKILL.md
+                                      --from <dir>   uploads the complete bundle
                                       --md <file>    reads file
                                       else           reads stdin
                                     Optional: --visibility published|private|shared
-  install <name>                    Download SKILL.md to a local review dir
+  install <name>                    Download the complete bundle to a local review dir
                                       [--to <dir>]   default: .metabot/skills/<name>
                                       [--trust]      required when --to points at .claude/.codex/.agents skills
   remove <name>                     Unpublish a skill

--- a/packages/skill-hub/tests/cli.test.ts
+++ b/packages/skill-hub/tests/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as zlib from 'node:zlib';
 import { loadConfig, DEFAULT_URL } from '../src/config.js';
 import { request } from '../src/client.js';
 import {
@@ -144,6 +145,72 @@ describe('cmdInstall', () => {
       globalThis.fetch = origFetch;
     }
   });
+
+  it('restores the complete bundle and replaces stale files', async () => {
+    const skillMd = '---\nname: foo\n---\n# hi\n';
+    const binary = Buffer.from([0, 1, 2, 255]);
+    const cfg = { url: 'http://ex', token: 't' };
+    const to = path.join(tmp, 'foo');
+    fs.mkdirSync(to);
+    fs.writeFileSync(path.join(to, 'stale.txt'), 'old');
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url.endsWith('/references')) {
+        return new Response(JSON.stringify({
+          name: 'foo',
+          version: 2,
+          files: [
+            { path: 'assets/blob.bin', content: binary.toString('base64'), encoding: 'base64', mode: 0o644 },
+            { path: 'scripts/run.sh', content: '#!/bin/sh\necho ok\n', mode: 0o755 },
+          ],
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ name: 'foo', version: 2, skillMd, hasReferences: true }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+    try {
+      const origWrite = process.stdout.write.bind(process.stdout);
+      (process.stdout as { write: (s: string) => boolean }).write = () => true;
+      try {
+        await cmdInstall(cfg, { positional: ['foo'], flags: { to } });
+      } finally {
+        process.stdout.write = origWrite;
+      }
+      expect(fs.readFileSync(path.join(to, 'SKILL.md'), 'utf8')).toBe(skillMd);
+      expect(fs.readFileSync(path.join(to, 'assets', 'blob.bin'))).toEqual(binary);
+      expect(fs.readFileSync(path.join(to, 'scripts', 'run.sh'), 'utf8')).toBe('#!/bin/sh\necho ok\n');
+      expect(fs.statSync(path.join(to, 'scripts', 'run.sh')).mode & 0o777).toBe(0o755);
+      expect(fs.existsSync(path.join(to, 'stale.txt'))).toBe(false);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('rejects unsafe bundle paths before changing the destination', async () => {
+    const cfg = { url: 'http://ex', token: 't' };
+    const to = path.join(tmp, 'foo');
+    fs.mkdirSync(to);
+    fs.writeFileSync(path.join(to, 'keep.txt'), 'keep');
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url.endsWith('/references')) {
+        return new Response(JSON.stringify({
+          files: [{ path: '../escape.txt', content: 'bad' }],
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        name: 'foo', version: 1, skillMd: '---\nname: foo\n---\n', hasReferences: true,
+      }), { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      await expect(cmdInstall(cfg, { positional: ['foo'], flags: { to } })).rejects.toThrow('unsafe file path');
+      expect(fs.readFileSync(path.join(to, 'keep.txt'), 'utf8')).toBe('keep');
+      expect(fs.existsSync(path.join(tmp, 'escape.txt'))).toBe(false);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
 });
 
 describe('cmdPublish', () => {
@@ -155,8 +222,12 @@ describe('cmdPublish', () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it('reads SKILL.md from --from <dir>', async () => {
+  it('packs the complete bundle from --from <dir>', async () => {
     fs.writeFileSync(path.join(tmp, 'SKILL.md'), '# hello\n');
+    fs.mkdirSync(path.join(tmp, 'scripts'));
+    fs.writeFileSync(path.join(tmp, 'scripts', 'run.sh'), '#!/bin/sh\necho ok\n', { mode: 0o755 });
+    fs.mkdirSync(path.join(tmp, 'assets'));
+    fs.writeFileSync(path.join(tmp, 'assets', 'blob.bin'), Buffer.from([0, 255, 1]));
     let captured: { body?: string } = {};
     const cfg = { url: 'http://ex', token: 't' };
     const origFetch = globalThis.fetch;
@@ -180,6 +251,44 @@ describe('cmdPublish', () => {
       }
       const parsed = JSON.parse(captured.body!);
       expect(parsed.skillMd).toBe('# hello\n');
+      const packed = JSON.parse(zlib.gunzipSync(Buffer.from(parsed.referencesTar, 'base64')).toString('utf8'));
+      expect(packed.files).toEqual([
+        {
+          path: 'assets/blob.bin',
+          content: Buffer.from([0, 255, 1]).toString('base64'),
+          encoding: 'base64',
+          mode: 0o644,
+        },
+        {
+          path: 'scripts/run.sh',
+          content: Buffer.from('#!/bin/sh\necho ok\n').toString('base64'),
+          encoding: 'base64',
+          mode: 0o755,
+        },
+      ]);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('clears an earlier bundle when --from contains only SKILL.md', async () => {
+    fs.writeFileSync(path.join(tmp, 'SKILL.md'), '# hello\n');
+    let captured: { body?: string } = {};
+    const cfg = { url: 'http://ex', token: 't' };
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (_u: string, init: RequestInit) => {
+      captured.body = init.body as string;
+      return new Response(JSON.stringify({ name: 'x', version: 2, published: true }), { status: 201 });
+    }) as unknown as typeof fetch;
+    try {
+      const origWrite = process.stdout.write.bind(process.stdout);
+      (process.stdout as { write: (s: string) => boolean }).write = () => true;
+      try {
+        await cmdPublish(cfg, { positional: ['x'], flags: { from: tmp } });
+      } finally {
+        process.stdout.write = origWrite;
+      }
+      expect(JSON.parse(captured.body!).referencesTar).toBeNull();
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/packages/skills/metabot/references/skills.md
+++ b/packages/skills/metabot/references/skills.md
@@ -10,8 +10,9 @@ metabot skills remove <name>
 ```
 
 A Skill bundle contains `SKILL.md` and may contain `references/`, `scripts/`,
-and `assets/`. Install the complete bundle. Project and global destinations are
-different discovery scopes.
+`assets/`, and `agents/`. `publish --from` uploads the complete bundle and
+`install` restores it, including binary files and executable script modes.
+Project and global destinations are different discovery scopes.
 
 `metabot skills install` defaults to `.metabot/skills/<name>` so you can review
 downloaded instructions before an engine auto-loads them. Passing `--to` with an


### PR DESCRIPTION
## Summary
- publish every file in a Skill bundle from `--from`, including binary content and executable modes
- install complete bundles through the existing references endpoint with path validation and atomic replacement
- document the complete-bundle contract and add traversal, binary, mode, stale-file, and clear-bundle coverage

## Validation
- Node 22.23.2
- `npm run build`
- `npm test` (1201 tests passed)
- `npm run lint` (0 errors; 7 pre-existing warnings)
- `git diff --check`