### PR TITLE
fix(execution): expose explicit API task cancellation

### DIFF
--- a/src/api/routes/core-chat-routes.ts
+++ b/src/api/routes/core-chat-routes.ts
@@ -679,6 +679,7 @@ export function acceptCoreChatRun(ctx: RouteContext, request: CoreChatRunRequest
 function apiTaskResultPayload(result: ApiTaskResult): Record<string, unknown> {
   return {
     success: result.success,
+    cancelled: result.cancelled,
     responseText: result.responseText,
     sessionId: result.sessionId,
     costUsd: result.costUsd,

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -98,6 +98,7 @@ export function resolvePersistentExecutorEnvDefault(envVal: string | undefined):
 
 interface RunningTask {
   abortController: AbortController;
+  cancelled: boolean;
   startTime: number;
   executionHandle: ExecutionHandle;
   pendingQuestion: PendingQuestion | null;
@@ -160,6 +161,8 @@ export interface ApiTaskOptions {
 
 export interface ApiTaskResult {
   success: boolean;
+  /** True when an explicit stop/reset cancelled the API task. */
+  cancelled?: boolean;
   responseText: string;
   sessionId?: string;
   costUsd?: number;
@@ -630,6 +633,7 @@ export class MessageBridge {
       task.questionCardMessageId = undefined;
     }
     task.executionHandle.finish();
+    task.cancelled = true;
     task.abortController.abort();
     // Clear the busy flag immediately so a follow-up after /stop or /reset can
     // start a fresh turn while the old stream winds down. executeQuery's
@@ -2280,6 +2284,7 @@ export class MessageBridge {
     const startTime = Date.now();
     runningTask = {
       abortController,
+      cancelled: false,
       startTime,
       executionHandle,
       pendingQuestion: null,
@@ -2761,7 +2766,7 @@ export class MessageBridge {
     if (!this.isChatBusy(options.chatId)) {
       try { this.outputsManager.cleanup(outputsDir); } catch { /* ignore */ }
     }
-    return { success: false, responseText: '', error: state.errorMessage };
+    return { success: false, cancelled: true, responseText: '', error: state.errorMessage };
   }
 
   private async executeReservedApiTask(
@@ -2871,6 +2876,7 @@ export class MessageBridge {
     const startTime = Date.now();
     runningTask = {
       abortController,
+      cancelled: false,
       startTime,
       executionHandle,
       pendingQuestion: null,
@@ -3069,6 +3075,7 @@ export class MessageBridge {
 
       return {
         success: lastState.status === 'complete',
+        ...(runningTask.cancelled ? { cancelled: true } : {}),
         responseText: lastState.responseText,
         sessionId: processor.getSessionId(),
         costUsd: lastState.costUsd,
@@ -3127,6 +3134,7 @@ export class MessageBridge {
 
           return {
             success: lastState.status === 'complete',
+            ...(runningTask.cancelled ? { cancelled: true } : {}),
             responseText: lastState.responseText,
             sessionId: processor.getSessionId(),
             costUsd: lastState.costUsd,
@@ -3167,6 +3175,7 @@ export class MessageBridge {
 
       return {
         success: false,
+        ...(runningTask.cancelled ? { cancelled: true } : {}),
         responseText: lastState.responseText,
         error: err.message || 'Unknown error',
       };

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -474,7 +474,12 @@ describe('MessageBridge between-turn questions', () => {
     await vi.waitFor(() => expect(bridge.runningTasks.has('chat-1')).toBe(true));
 
     releases[0]();
-    await first;
+    const firstResult = await first;
+    expect(firstResult).toMatchObject({
+      success: false,
+      cancelled: true,
+      error: 'Task was stopped',
+    });
     expect(bridge.isBusy('chat-1')).toBe(true);
 
     releases[1]();


### PR DESCRIPTION
## Summary

- add an optional `cancelled` discriminator to `ApiTaskResult`
- set it only when an explicit `/stop` or reset cancels an API task
- propagate the signal through Core Chat result payloads
- keep timeouts and other execution failures classified as ordinary failures

## Why

`executeApiTask()` currently collapses an explicit user cancellation into the same result shape as a real execution failure. Callers therefore cannot safely acknowledge user intent without also suppressing retries for genuine failures.

The optional field is backward-compatible and lets API consumers distinguish those cases without depending on error-message text.

## Testing

- `npm run build`
- `npx vitest run tests/message-bridge.test.ts` — 46 passed
- full repository suite on this commit — 1564 passed, 1 explicitly skipped
- `git diff --check`