### PR TITLE
fix(feishu): keep tool summary on empty completion cards

### DIFF
--- a/src/feishu/card-builder-v2.ts
+++ b/src/feishu/card-builder-v2.ts
@@ -163,10 +163,13 @@ export function buildCardV2(state: CardState): string {
   // errored. Web UI keeps its own collapsible per-tool view (see
   // packages/web-ui/src/routes/chat.tsx); this only affects the
   // Feishu surface.
+  // Keep the summary on an empty successful turn. Hiding it on every
+  // completed card assumes a final response body exists; tool-only turns
+  // would otherwise render as a blank "Complete" card with only the footer.
   if (
     state.toolCalls.length > 0 &&
-    state.status !== 'complete' &&
-    state.status !== 'error'
+    state.status !== 'error' &&
+    (state.status !== 'complete' || !state.responseText.trim())
   ) {
     const last  = state.toolCalls[state.toolCalls.length - 1];
     const icon  = last.status === 'running' ? '⏳' : '✅';

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -75,10 +75,13 @@ export function buildCard(state: CardState): string {
   // for the rationale (users only care about the final answer; the running
   // tool list was noise). One line while in flight so a hung run is visibly
   // hung; section disappears entirely on complete/error.
+  // Keep the summary on an empty successful turn. Hiding it on every
+  // completed card assumes a final response body exists; tool-only turns
+  // would otherwise render as a blank "Complete" card with only the footer.
   if (
     state.toolCalls.length > 0 &&
-    state.status !== 'complete' &&
-    state.status !== 'error'
+    state.status !== 'error' &&
+    (state.status !== 'complete' || !state.responseText.trim())
   ) {
     const last  = state.toolCalls[state.toolCalls.length - 1];
     const icon  = last.status === 'running' ? '⏳' : '✅';

--- a/tests/card-builder-v2.test.ts
+++ b/tests/card-builder-v2.test.ts
@@ -193,6 +193,25 @@ describe('buildCardV2', () => {
     expect(toolEl).toBeUndefined();
   });
 
+  it('keeps a tool summary when a complete turn has no response text', () => {
+    const state: CardState = {
+      status:       'complete',
+      userPrompt:   'run the task',
+      responseText: '',
+      toolCalls: [
+        { name: 'Read', detail: '`src/index.ts`', status: 'done' },
+        { name: 'Edit', detail: '`src/index.ts`', status: 'done' },
+      ],
+    };
+    const elements = findElements(JSON.parse(buildCardV2(state)));
+    const toolEl = elements.find(
+      (e) => e.tag === 'markdown' && typeof e.content === 'string'
+        && /\*\*Edit\*\* · 2 tools/.test(e.content),
+    );
+    expect(toolEl).toBeDefined();
+    expect(toolEl.content).toContain('✅');
+  });
+
   it('renders background events with status icon + last event', () => {
     const state: CardState = {
       status:       'running',

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -57,6 +57,24 @@ describe('buildCard', () => {
     expect(toolEl).toBeUndefined();
   });
 
+  it('keeps a tool summary when a complete turn has no response text', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'run the task',
+      responseText: '',
+      toolCalls: [
+        { name: 'Read', detail: '`src/index.ts`', status: 'done' },
+        { name: 'Edit', detail: '`src/index.ts`', status: 'done' },
+      ],
+    };
+    const json = JSON.parse(buildCard(state));
+    const toolEl = json.elements.find(
+      (e: any) => e.tag === 'markdown' && /\*\*Edit\*\* · 2 tools/.test(e.content),
+    );
+    expect(toolEl).toBeDefined();
+    expect(toolEl.content).toContain('✅');
+  });
+
   it('builds complete card with stats', () => {
     const state: CardState = {
       status: 'complete',


### PR DESCRIPTION
Fixes #378.

### Problem

When a Claude Code turn completes without a user-facing response body but has tool calls, both Feishu card builders hide the tool indicator on `complete` cards. The resulting card contains only the green `Complete` header and stats footer, which renders as an empty bubble.

### Fix

- Keep the existing compact tool summary when a completed card has no response text.
- Preserve the current behavior for completed cards that contain a response body.
- Apply the same behavior to Card Schema 1.0 and 2.0 builders.
- Add regression coverage for empty successful turns in both builders.

This keeps the change at the rendering boundary and does not alter engine turn semantics or the existing streaming lifecycle.

### Verification

- `npm run test:bridge -- --run tests/stream-processor.test.ts tests/card-builder-v2.test.ts tests/card-builder.test.ts`
- `npm run build:bridge`
- Targeted ESLint passed.

The full bridge suite currently has unrelated baseline failures in the Windows session-lister tests, installer prerequisite test, Codex terminal-result test, and native `better-sqlite3`/Node ABI setup.