### PR TITLE
feat(oss): add durable Agent Bus send path

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ Skills、T5T、Teams 和 CLI Access 共用同一 Token 与同一套导航。
 | `@Bot /group-reply mention\|all\|status`       | 控制一个飞书 Bot 在一个群里的回复模式            |
 | `metabot update`                               | 将 Package 管理的个人版升级到最新 GitHub Release |
 | `metabot update --package --version 1.3.0`     | 精确安装不可变的 v1.3.0 Release 包               |
+| `metabot send <agentId> "消息"`                | 通过 Personal Core 发送持久化 Agent Bus 消息       |
+
+Agent Bus 消息可绑定稳定会话并安全重试：使用 `--session <sessionId>` 指定会话，
+`--idempotency-key <key>` 去重重试，`--implicit` 隐藏运行卡片。Core 默认地址为
+`http://localhost:9200`，通过 `METABOT_CORE_URL` 和 `METABOT_CORE_TOKEN` 配置远端
+Personal Core；不会依赖托管服务或内部身份系统。
 
 完整命令详见[聊天命令](docs/usage/chat-commands.zh.md)、[CLI 参考](docs/reference/cli-metabot.zh.md)和 [REST API](docs/reference/api.zh.md)。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -197,6 +197,13 @@ Each bot has its own channel credentials, engine, workspace, and sessions. Bots 
 | `@Bot /group-reply mention\|all\|status`       | Control one Feishu bot's reply mode in one group                       |
 | `metabot update`                               | Update a package-managed personal edition to the latest GitHub Release |
 | `metabot update --package --version 1.3.0`     | Install exactly the immutable v1.3.0 Release package                   |
+| `metabot send <agentId> "message"`             | Send a durable Agent Bus message through Personal Core                  |
+
+Agent Bus messages can target a stable session and be retried safely: use
+`--session <sessionId>` for an exact session, `--idempotency-key <key>` to
+deduplicate retries, and `--implicit` to hide run presentation. Personal Core
+defaults to `http://localhost:9200`; configure a remote self-hosted Core with
+`METABOT_CORE_URL` and `METABOT_CORE_TOKEN`.
 
 See [Chat Commands](docs/usage/chat-commands.md), the [CLI Reference](docs/reference/cli-metabot.md), and the [REST API](docs/reference/api.md) for the complete surfaces.
 

--- a/docs/reference/cli-metabot.md
+++ b/docs/reference/cli-metabot.md
@@ -86,14 +86,39 @@ metabot bot <name>                  # get bot details
 
 ### Agent talk
 
+For durable point-to-point delivery through Personal Core, prefer the minimal
+Agent Bus command:
+
+```bash
+metabot send <agentId> "prompt"
+metabot send <agentId> "prompt" --session <sessionId> --idempotency-key <key>
+metabot send <agentId> "background task" --implicit
+```
+
+Core persists the message and logical run, resolves a usable target session,
+and returns `messageId`, `sessionId`, and `runId`. Set
+`--origin-chat <oc_...> --origin-bot <name>` when a Feishu-origin bridge should
+receive progress; use `--child-direct` to keep presentation in the target chat.
+
 ```bash
 metabot talk <bot> <chatId> <prompt>      # talk to a bot (bridge /api/talk)
 metabot talk alice/bot <chatId> <prompt>  # talk to a specific peer's bot
 ```
 
 The bot name supports [qualified names](../features/peers.md#qualified-names)
-(`peerName/botName`) for cross-instance routing. This is the bridge-local talk
-path; `metabot agents talk` is the separate central-registry P2P variant.
+(`peerName/botName`) for bridge-local routing. For durable cross-agent
+communication through Personal Core, use:
+
+```bash
+metabot send <agentId> "prompt"
+metabot send <agentId> "prompt" --session <sessionId> --idempotency-key <key>
+metabot send <agentId> "background task" --implicit
+```
+
+Core persists the message and logical run, resolves a usable target session,
+and returns `messageId`, `sessionId`, and `runId`. In a Feishu-origin context,
+`--origin-chat <oc_...> --origin-bot <name>` projects run events back to the
+origin bot; `--child-direct` keeps presentation in the target agent chat.
 
 ### Peers
 

--- a/docs/reference/cli-metabot.zh.md
+++ b/docs/reference/cli-metabot.zh.md
@@ -86,8 +86,17 @@ metabot talk alice/bot <chatId> <prompt>  # 指定 peer 的 Bot 对话
 ```
 
 Bot 名称支持[限定名](../features/peers.md#qualified-names)（`peerName/botName`）实现跨实例
-路由。这是 bridge 本地的对话路径；`metabot agents talk` 是基于中心注册表的 P2P
-变体。
+路由。这是 bridge 本地的对话路径。需要通过 Personal Core 持久化发送 Agent Bus 消息时，使用：
+
+```bash
+metabot send <agentId> "prompt"
+metabot send <agentId> "prompt" --session <sessionId> --idempotency-key <key>
+metabot send <agentId> "后台任务" --implicit
+```
+
+Core 会持久化消息和逻辑运行、解析目标会话，并返回 `messageId`、`sessionId`、`runId`。
+在飞书来源会话中，可用 `--origin-chat <oc_...> --origin-bot <name>` 将运行事件投影回来源
+Bot；`--child-direct` 则让结果显示在目标 Agent 会话。
 
 ### Peers
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,8 @@
 # @xvirobotics/cli
 
-`metabot` — unified CLI that dispatches to the metabot-core subcommand
-families. Thin wrapper over the existing per-family CLIs; no logic of
-its own beyond subcommand routing.
+`metabot` — unified CLI for Personal Core, including the durable Agent Bus
+send path. The binary keeps user-selected Core URLs and tokens configurable;
+no hosted or private service is required.
 
 ## Subcommands
 
@@ -10,12 +10,14 @@ its own beyond subcommand routing.
 |----------------------|----------------------------|--------------------------------|
 | `metabot memory`     | `@xvirobotics/metamemory`  | alias of `mm`                  |
 | `metabot skills`     | `@xvirobotics/skill-hub`   | alias of `mh`                  |
-| `metabot agents`     | (pending MR5)              | prints placeholder string      |
+| `metabot agents`     | Personal Core agent registry | list, search, register, visibility, sessions |
+| `metabot send`       | Personal Core Agent Bus      | durable point-to-point message with optional session/idempotency |
 | `metabot t5t`        | (pending Phase 3 — trunks) | prints placeholder string      |
 | `metabot help`       |                            | also `--help`, `-h`, no args   |
 
-The existing `mm` and `mh` binaries keep working unchanged — this is
-additive.
+The existing `mm` and `mh` binaries keep working unchanged. Use
+`metabot send <agentId> "message"` for Agent Bus communication; Core resolves
+the target session and returns message, session, and run IDs.
 
 ## Install
 

--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -2,18 +2,15 @@
  * `metabot agents` subcommands.
  *
  *   metabot agents list [--include-hidden]
- *   metabot agents register --url <url> [--bot-name <name>] [--hidden]
+ *   metabot agents register --url <url> [--bot-name <name>] [--description <text>] [--hidden]
  *   metabot agents heartbeat [--bot-name <name>]
  *   metabot agents whoami
  *   metabot agents visible <botName>
  *   metabot agents hide    <botName>
- *   metabot agents talk <peer>[/<bot>] <chatId> "<message>"
+ *   metabot agents remove  <botName>
  *
- * Wire shapes match `packages/server/src/agents/agent-routes.ts`. Cross-agent
- * talk from the CLI always enqueues through metabot-core's inbox relay. Resident
- * bridges still route same-bridge local bots directly before peer lookup; the
- * CLI has no local bridge registry, so it should not attempt direct P2P based on
- * registry URLs.
+ * Wire shapes match `packages/server/src/agents/agent-routes.ts`. Use the
+ * top-level `metabot send` command for Agent Bus communication.
  */
 
 import * as fs from 'node:fs';
@@ -21,9 +18,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { parseArgs, print, loadConfig } from '@xvirobotics/cli-core';
-import { deriveProjectChatId } from './project-id.js';
 
-// Personal edition default: local metabot-core. Override with METABOT_CORE_URL.
+// Personal Edition stays self-hostable: point at a local Core by default and
+// let METABOT_CORE_URL opt into a user's own hosted Core.
 const DEFAULT_BUS_URL = 'http://localhost:9200';
 
 interface BusConfig {
@@ -94,6 +91,7 @@ async function busRequest<T = unknown>(
 interface AgentRow {
   botName: string;
   url: string;
+  description?: string;
   visible: boolean;
   visibleToOwners?: string[];
   lastSeenAt: string;
@@ -106,9 +104,14 @@ interface ListResponse {
 function usage(): string {
   return `metabot agents — central agent registry (the "address book" for peer bots)
 
+Use metabot send <agentId> "<message>" for Agent Bus communication.
+
 Subcommands:
   list [--include-hidden]               List visible agents (admin: --include-hidden shows all)
-  register --url <url> [--bot-name <name>] [--hidden]
+  search "<keyword>" [--limit 20 --offset 0]
+  search --user <username> [--limit 20 --offset 0]
+                                        Search agents with bounded pagination.
+  register --url <url> [--bot-name <name>] [--description <text>] [--hidden]
                                         Register a bot in the registry; --bot-name
                                         lets one credential own many bots (anti-squat
                                         is enforced server-side by ownerCredentialId).
@@ -116,25 +119,21 @@ Subcommands:
                                         caller's credential botName (legacy 1:1 mode).
   whoami                                Show the credential identity behind this token
                                         (botName, role, authSource).
+  show    <agentId> --sessions          List up to 20 sessions for an agent
   visible <botName>                     Mark <botName> visible (must own or be admin)
   hide    <botName>                     Mark <botName> hidden  (must own or be admin)
+  remove  <botName>                     Delete a registry row (must own or be admin)
+  delete  <botName>                     Alias for remove
   share   <botName> <ownerName>         Add <ownerName> to <botName>'s per-user allowlist.
                                         Only takes effect when the bot is hidden.
   unshare <botName> <ownerName>         Remove <ownerName> from the allowlist.
   shared  <botName>                     Print <botName>'s current allowlist.
-  talk <peer>[/<bot>] [<chatId>] "<msg>"
-                                        Send a message to a peer's bot. When <chatId>
-                                        is omitted, defaults to the cwd-derived
-                                        project chatId.
-                                        Routes through metabot-core's central inbox
-                                        relay; resident bridges poll and execute
-                                        their own local bots, while CLI agents use
-                                        \`metabot inbox poll\` on the receiving end.
 
 Env:
   METABOT_CORE_URL              memory + agents URL (default ${DEFAULT_BUS_URL})
   METABOT_CORE_AGENT_BUS_URL    override agents-only base URL (falls back to METABOT_CORE_URL)
   METABOT_CORE_TOKEN            bearer token (or ~/.metabot-core/token)
+
 `;
 }
 
@@ -147,6 +146,40 @@ async function cmdList(args: string[]): Promise<void> {
   print(resp);
 }
 
+async function cmdSearch(args: string[]): Promise<void> {
+  const { positional, flags } = parseArgs(args);
+  const term = positional[0] || (typeof flags.q === 'string' ? flags.q : '');
+  const user = typeof flags.user === 'string' ? flags.user : '';
+  if (!term && !user) throw new Error('metabot agents search: "<keyword>" or --user <username> required');
+  const limit = typeof flags.limit === 'string' ? flags.limit : '20';
+  const offset = typeof flags.offset === 'string' ? flags.offset : '0';
+  const params = new URLSearchParams({ limit, offset });
+  if (term) params.set('q', term);
+  if (user) params.set('user', user);
+  const cfg = loadBusConfig();
+  print(await busRequest(cfg, 'GET', `/api/agents/search?${params.toString()}`));
+}
+
+async function cmdShow(args: string[]): Promise<void> {
+  const { positional, flags } = parseArgs(args);
+  const ref = positional[0];
+  if (!ref) throw new Error('metabot agents show: <agentId> required');
+  if (flags.sessions === true || flags.sessions === 'true') {
+    const cfg = loadBusConfig();
+    const limit = typeof flags.limit === 'string' ? flags.limit : '20';
+    const offset = typeof flags.offset === 'string' ? flags.offset : '0';
+    print(
+      await busRequest(
+        cfg,
+        'GET',
+        `/api/agents/${encodeURIComponent(ref)}/sessions?limit=${encodeURIComponent(limit)}&offset=${encodeURIComponent(offset)}`,
+      ),
+    );
+    return;
+  }
+  return cmdSetVisibility(args, true);
+}
+
 async function cmdRegister(args: string[]): Promise<void> {
   const { flags } = parseArgs(args);
   const url = typeof flags.url === 'string' ? flags.url : '';
@@ -154,6 +187,8 @@ async function cmdRegister(args: string[]): Promise<void> {
   const body: Record<string, unknown> = { url };
   const botName = typeof flags['bot-name'] === 'string' ? flags['bot-name'].trim() : '';
   if (botName) body.botName = botName;
+  const description = typeof flags.description === 'string' ? flags.description.trim() : '';
+  if (description) body.description = description;
   body.visible = flags.hidden === true ? false : true;
   const cfg = loadBusConfig();
   const resp = await busRequest(cfg, 'POST', '/api/agents', body);
@@ -182,12 +217,16 @@ async function cmdSetVisibility(args: string[], visible: boolean): Promise<void>
     throw new Error(`metabot agents ${visible ? 'visible' : 'hide'}: <botName> required`);
   }
   const cfg = loadBusConfig();
-  const resp = await busRequest(
-    cfg,
-    'PATCH',
-    `/api/agents/${encodeURIComponent(botName)}/visibility`,
-    { visible },
-  );
+  const resp = await busRequest(cfg, 'PATCH', `/api/agents/${encodeURIComponent(botName)}/visibility`, { visible });
+  print(resp);
+}
+
+async function cmdRemove(args: string[]): Promise<void> {
+  const { positional } = parseArgs(args);
+  const botName = positional[0];
+  if (!botName) throw new Error('metabot agents remove: <botName> required');
+  const cfg = loadBusConfig();
+  const resp = await busRequest(cfg, 'DELETE', `/api/agents/${encodeURIComponent(botName)}`);
   print(resp);
 }
 
@@ -214,9 +253,9 @@ async function cmdShare(args: string[]): Promise<void> {
     return;
   }
   const next = [...current, ownerName];
-  const resp = await busRequest(
-    cfg, 'PATCH', `/api/agents/${encodeURIComponent(botName)}/visible-to-owners`, { owners: next },
-  );
+  const resp = await busRequest(cfg, 'PATCH', `/api/agents/${encodeURIComponent(botName)}/visible-to-owners`, {
+    owners: next,
+  });
   print(resp);
 }
 
@@ -234,9 +273,9 @@ async function cmdUnshare(args: string[]): Promise<void> {
     return;
   }
   const next = current.filter((o) => o !== ownerName);
-  const resp = await busRequest(
-    cfg, 'PATCH', `/api/agents/${encodeURIComponent(botName)}/visible-to-owners`, { owners: next },
-  );
+  const resp = await busRequest(cfg, 'PATCH', `/api/agents/${encodeURIComponent(botName)}/visible-to-owners`, {
+    owners: next,
+  });
   print(resp);
 }
 
@@ -249,58 +288,6 @@ async function cmdShared(args: string[]): Promise<void> {
   print({ botName, visibleToOwners: current });
 }
 
-async function cmdTalk(args: string[]): Promise<void> {
-  const { positional } = parseArgs(args);
-  const target = positional[0];
-  // Allow omitting <chatId>: the cwd-derived chatId is the default so CC/Codex
-  // users don't have to invent one. When omitted, positional[1] is the content.
-  let chatId: string;
-  let content: string | undefined;
-  let chatIdSource: 'positional' | 'project' = 'positional';
-  if (positional.length >= 3) {
-    chatId = positional[1]!;
-    content = positional[2];
-  } else if (positional.length === 2) {
-    chatId = deriveProjectChatId();
-    content = positional[1];
-    chatIdSource = 'project';
-  } else {
-    throw new Error('metabot agents talk: <peer>[/<bot>] [<chatId>] "<message>" required');
-  }
-  if (!target || content === undefined) {
-    throw new Error('metabot agents talk: <peer>[/<bot>] [<chatId>] "<message>" required');
-  }
-  const slash = target.indexOf('/');
-  const peerName = slash >= 0 ? target.slice(0, slash) : target;
-  const botName = slash >= 0 ? target.slice(slash + 1) : target;
-  if (!peerName) throw new Error('metabot agents talk: <peer> empty');
-  if (!botName) throw new Error('metabot agents talk: <bot> empty after slash');
-
-  const cfg = loadBusConfig();
-  const list = await busRequest<ListResponse>(cfg, 'GET', '/api/agents');
-  const peer = (list.agents || []).find((a) => a.botName === peerName);
-  if (!peer) {
-    throw new Error(
-      `metabot agents talk: peer '${peerName}' not in registry — run \`metabot agents list\` to see who's online`,
-    );
-  }
-  if (!peer.url) throw new Error(`metabot agents talk: peer '${peerName}' has no url in registry`);
-
-  if (chatIdSource === 'project') {
-    process.stderr.write(`→ using project-derived chatId: ${chatId}\n`);
-  }
-
-  const resp = await busRequest(
-    cfg, 'POST', `/api/inbox/${encodeURIComponent(botName)}`, { chatId, content },
-  );
-  process.stdout.write(`→ ${peerName}/${botName} @ ${chatId} (relay)\n`);
-  if (typeof resp === 'object' && resp !== null) {
-    // Surface the message id so the sender can correlate with audit logs.
-    const id = (resp as { message?: { id?: unknown } }).message?.id;
-    if (typeof id === 'string') process.stderr.write(`  id=${id}\n`);
-  }
-}
-
 export async function run(args: string[]): Promise<void> {
   const sub = args[0];
   const rest = args.slice(1);
@@ -308,9 +295,31 @@ export async function run(args: string[]): Promise<void> {
     process.stdout.write(usage());
     return;
   }
+  if (
+    (rest.includes('--help') || rest.includes('-h')) &&
+    [
+      'list',
+      'register',
+      'heartbeat',
+      'whoami',
+      'visible',
+      'show',
+      'hide',
+      'remove',
+      'delete',
+      'share',
+      'unshare',
+      'shared',
+    ].includes(sub)
+  ) {
+    process.stdout.write(usage());
+    return;
+  }
   switch (sub) {
     case 'list':
       return cmdList(rest);
+    case 'search':
+      return cmdSearch(rest);
     case 'register':
       return cmdRegister(rest);
     case 'heartbeat':
@@ -319,17 +328,18 @@ export async function run(args: string[]): Promise<void> {
       return cmdWhoami();
     case 'visible':
     case 'show':
-      return cmdSetVisibility(rest, true);
+      return cmdShow(rest);
     case 'hide':
       return cmdSetVisibility(rest, false);
+    case 'remove':
+    case 'delete':
+      return cmdRemove(rest);
     case 'share':
       return cmdShare(rest);
     case 'unshare':
       return cmdUnshare(rest);
     case 'shared':
       return cmdShared(rest);
-    case 'talk':
-      return cmdTalk(rest);
     default:
       process.stderr.write(`metabot agents: unknown subcommand '${sub}'\n\n`);
       process.stdout.write(usage());

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -4,27 +4,28 @@ export function print(): void {
 
 Usage: metabot <subcommand> [args]
 
-Subcommands:
+Primary subcommands:
   memory <cmd> [args]   shared knowledge / notes
                         e.g. metabot memory search "auth" | metabot memory health
   skills <cmd> [args]   skill registry (alias: skill)
                         e.g. metabot skills list | metabot skills install <name>
-  agents <cmd> [args]   agent registry (address book for peer bots)
-                        e.g. metabot agents list | metabot agents talk <peer>/<bot> <chatId> "<msg>"
-  inbox <cmd> [args]    central inbox for CLI agents (no resident bridge needed)
-                        e.g. metabot inbox register | metabot inbox poll --loop
-  teams <cmd> [args]    MetaBot Agent Teams (local bridge)
-                        e.g. metabot teams dispatch demo worker "review PR" | metabot teams next demo worker
+  send <agentId> "message"  minimal point-to-point Agent Bus send
+                             in Feishu context, proxy progress to origin chat
+                             optional: --session <sessionId> | --implicit
+                                       --origin-chat <oc_...> --origin-bot <name>
+                                       --child-direct
   t5t <cmd> [args]      daily team status portal (board / projects / entries)
                         e.g. metabot t5t board | metabot t5t push <slug> <date> "<item>"
   help                  this message (also --help, -h, or bare invocation)
 
+Use metabot send for all point-to-point Agent Bus communication. The old
+chat/inbox/agents-talk CLI surfaces are no longer shipped; server fallback
+routes remain internal compatibility plumbing only.
+
 Each subcommand has its own help; pass --help through to see it:
   metabot memory --help
   metabot skills --help
-  metabot agents --help
-  metabot inbox --help
-  metabot teams --help
+  metabot send --help
   metabot t5t --help
 
 Env:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@
  *   metabot memory <…>   → @xvirobotics/metamemory  (former `mm`)
  *   metabot skills <…>   → @xvirobotics/skill-hub   (former `mh`)
  *   metabot agents <…>   → in-tree (./agents.js)
- *   metabot inbox <…>    → in-tree (./inbox.js); wraps /api/inbox/*
+ *   metabot send <…>     → in-tree (./send.js); wraps /api/messages/*
  *   metabot teams <…>    → in-tree (./teams.js); wraps local bridge /api/agent-teams/*
  *   metabot t5t <…>      → in-tree (./t5t.js); wraps /api/t5t/cli/*
  *   metabot help         → top-level help (also: bare invocation, --help, -h)
@@ -41,8 +41,8 @@ export async function main(argv: string[]): Promise<void> {
       await m.run(rest);
       return;
     }
-    case 'inbox': {
-      const m = await import('./inbox.js');
+    case 'send': {
+      const m = await import('./send.js');
       await m.run(rest);
       return;
     }
@@ -57,9 +57,7 @@ export async function main(argv: string[]): Promise<void> {
       return;
     }
     default: {
-      process.stderr.write(`metabot: unknown subcommand '${sub}'\n\n`);
-      const { print } = await import('./help.js');
-      print();
+      process.stderr.write(`metabot: unknown subcommand '${sub}'. Run 'metabot --help' for usage.\n`);
       process.exit(2);
     }
   }

--- a/packages/cli/src/send.ts
+++ b/packages/cli/src/send.ts
@@ -1,0 +1,111 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { loadConfig, parseArgs, print } from '@xvirobotics/cli-core';
+
+// Personal Edition default: local Core. Set METABOT_CORE_URL for a hosted
+// Core chosen by the operator.
+const DEFAULT_CORE_URL = 'http://localhost:9200';
+
+interface CoreConfig {
+  url: string;
+  token: string;
+}
+
+function readTokenFile(): string {
+  try {
+    const raw = fs.readFileSync(path.join(os.homedir(), '.metabot-core', 'token'), 'utf8');
+    return raw.split(/\r?\n/)[0]?.trim() || '';
+  } catch {
+    return '';
+  }
+}
+
+function loadCoreConfig(): CoreConfig {
+  const envUrl = (process.env.METABOT_CORE_URL || process.env.METABOT_CORE_AGENT_BUS_URL || '').trim();
+  const envToken = (process.env.METABOT_CORE_TOKEN || '').trim();
+  if (envUrl || envToken) {
+    const token = envToken || readTokenFile();
+    if (!token) {
+      throw new Error(
+        'no token configured - set METABOT_CORE_TOKEN env var, or write the token to ~/.metabot-core/token',
+      );
+    }
+    return { url: (envUrl || DEFAULT_CORE_URL).replace(/\/+$/, ''), token };
+  }
+  const cfg = loadConfig();
+  return { url: cfg.url, token: cfg.token };
+}
+
+async function coreRequest<T = unknown>(cfg: CoreConfig, body: unknown): Promise<T> {
+  const res = await fetch(`${cfg.url}/api/messages`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${cfg.token}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let parsed: unknown = text;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      /* keep raw */
+    }
+  }
+  if (!res.ok) {
+    const errMsg =
+      typeof parsed === 'object' && parsed && 'error' in parsed
+        ? String((parsed as { error: unknown }).error)
+        : String(parsed);
+    throw new Error(`metabot-core POST /api/messages -> ${res.status}: ${errMsg}`);
+  }
+  return parsed as T;
+}
+
+export function usage(): string {
+  return `metabot send - minimal durable Agent Bus message\n\nUsage:\n  metabot send <agentId> "<message>" [options]\n\nOptions:\n  --session <sessionId>                  Target an exact Agent Bus session.\n  --implicit                             Do not present the run in a chat.\n  --origin-chat <oc_...> --origin-bot <name>\n                                         Project progress to the origin chat.\n  --child-direct                         Present the run in the target Agent chat.\n  --reply-to <messageId>                 Attach an optional reply reference.\n  --sender-session <sessionId>            Identify the sender session.\n  --idempotency-key <key>                Deduplicate retries.\n\nThe target Agent and session are resolved by Core.\n`;
+}
+
+export async function run(args: string[]): Promise<void> {
+  if (!args.length || args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(usage());
+    return;
+  }
+  const { positional, flags } = parseArgs(args);
+  const agentId = positional[0];
+  const message = positional[1];
+  if (!agentId || !message) throw new Error('metabot send: <agentId> "<message>" required');
+
+  const body: Record<string, unknown> = { agentId, message };
+  const implicit = flags.implicit === true;
+  const childDirect = flags['child-direct'] === true || flags.direct === true;
+  const originChatId =
+    typeof flags['origin-chat'] === 'string'
+      ? flags['origin-chat'].trim()
+      : (process.env.METABOT_ORIGIN_CHAT || '').trim();
+  const originBotName =
+    typeof flags['origin-bot'] === 'string'
+      ? flags['origin-bot'].trim()
+      : (process.env.METABOT_ORIGIN_BOT || '').trim();
+  if (implicit) {
+    body.presentationMode = 'implicit';
+  } else if (!childDirect && originChatId && originBotName) {
+    body.presentationMode = 'origin-proxy';
+    body.originChatId = originChatId;
+    body.originBotName = originBotName;
+  }
+  for (const [flag, field] of [
+    ['session', 'sessionId'],
+    ['reply-to', 'replyTo'],
+    ['sender-session', 'senderSessionId'],
+    ['idempotency-key', 'idempotencyKey'],
+  ] as const) {
+    if (typeof flags[flag] === 'string' && flags[flag].trim()) body[field] = flags[flag].trim();
+  }
+  print(await coreRequest(loadCoreConfig(), body));
+}

--- a/packages/cli/tests/agents.test.ts
+++ b/packages/cli/tests/agents.test.ts
@@ -18,45 +18,43 @@ async function importFresh(): Promise<typeof import('../src/agents.js')> {
   return await import('../src/agents.js');
 }
 
-describe('metabot agents talk', () => {
-  it('routes registry peers through the core inbox relay instead of direct /api/talk', async () => {
+describe('metabot agents registry', () => {
+  it('prints registry help without exposing Agent Bus delivery commands or reading config', async () => {
+    process.env.METABOT_CORE_TOKEN = '';
+    process.env.METABOT_CORE_URL = '';
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    const mod = await importFresh();
+    await mod.run(['--help']);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const output = stdout.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('metabot send <agentId>');
+    expect(output).toContain('remove  <botName>');
+    expect(output).not.toContain('talk <peer>');
+  });
+
+  it('removes an owned registry row through the core delete route', async () => {
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === 'https://example.test/core/api/agents') {
-        return new Response(JSON.stringify({
-          agents: [
-            { botName: 'alice', url: 'http://alice:9100', visible: true, lastSeenAt: 'now' },
-          ],
-        }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        });
-      }
-      if (url === 'https://example.test/core/api/inbox/worker') {
-        return new Response(JSON.stringify({ message: { id: 'msg_1' } }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        });
-      }
-      return new Response(JSON.stringify({ error: 'unexpected', url, init }), { status: 500 });
+      expect(url).toBe('https://example.test/core/api/agents/bus-live-receiver-1');
+      expect(init?.method).toBe('DELETE');
+      return new Response(JSON.stringify({ botName: 'bus-live-receiver-1', removed: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
     }) as unknown as typeof fetch;
     vi.stubGlobal('fetch', fetchMock);
     const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
-    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
 
     const mod = await importFresh();
-    await mod.run(['talk', 'alice/worker', 'chat1', 'hello']);
+    await mod.run(['remove', 'bus-live-receiver-1']);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const relayCall = (fetchMock as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[1]!;
-    expect(relayCall[0]).toBe('https://example.test/core/api/inbox/worker');
-    expect(relayCall[1].method).toBe('POST');
-    expect(JSON.parse(String(relayCall[1].body))).toEqual({ chatId: 'chat1', content: 'hello' });
-    expect(
-      (fetchMock as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls.some(
-        ([url]) => url === 'http://alice:9100/api/talk',
-      ),
-    ).toBe(false);
-    expect(stdout.mock.calls.map((c) => String(c[0])).join('')).toContain('(relay)');
-    expect(stderr.mock.calls.map((c) => String(c[0])).join('')).toContain('id=msg_1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(stdout.mock.calls.map((c) => String(c[0])).join(''))).toEqual({
+      botName: 'bus-live-receiver-1',
+      removed: true,
+    });
   });
 });

--- a/packages/cli/tests/help.test.ts
+++ b/packages/cli/tests/help.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('metabot top-level help', () => {
+  it('keeps minimal send as the primary communication surface and hides compatibility wrappers', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const mod = await import('../src/help.js');
+
+    mod.print();
+
+    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
+    expect(output).toContain('Primary subcommands:');
+    expect(output).toContain('send <agentId> "message"  minimal point-to-point Agent Bus send');
+    expect(output).toContain('Use metabot send for all point-to-point Agent Bus communication.');
+    expect(output).not.toContain('Compatibility / local orchestration:');
+    expect(output).not.toContain('agents <cmd> [args]');
+    expect(output).not.toContain('inbox <cmd> [args]');
+    expect(output).not.toContain('teams <cmd> [args]');
+    expect(output).not.toContain('metabot agents --help');
+    expect(output).not.toContain('metabot inbox --help');
+    expect(output).not.toContain('metabot teams --help');
+    expect(output).toContain('chat/inbox/agents-talk CLI surfaces are no longer shipped');
+    expect(output).not.toContain('metabot chat');
+  });
+});

--- a/packages/cli/tests/send.test.ts
+++ b/packages/cli/tests/send.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.METABOT_CORE_TOKEN = 'mt_test_tok';
+  process.env.METABOT_CORE_URL = 'https://example.test/core';
+  process.env.HOME = '/tmp/metabot-cli-test-home-does-not-exist';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env = { ...ORIG_ENV };
+});
+
+async function importFresh(): Promise<typeof import('../src/send.js')> {
+  vi.resetModules();
+  return await import('../src/send.js');
+}
+
+describe('metabot send', () => {
+  it('prints help without reading config or making requests', async () => {
+    process.env.METABOT_CORE_TOKEN = '';
+    process.env.METABOT_CORE_URL = '';
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    const mod = await importFresh();
+    await mod.run(['--help']);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain(
+      'metabot send - minimal durable Agent Bus message',
+    );
+  });
+
+  it('posts a minimal message with an exact session', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe('https://example.test/core/api/messages');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(String(init?.body))).toEqual({
+        agentId: 'superagent',
+        message: 'hello',
+        sessionId: 'session_1',
+      });
+      return new Response(JSON.stringify({ ok: true, messageId: 'msg_1', sessionId: 'session_1', runId: 'run_1' }), {
+        status: 202,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    const mod = await importFresh();
+    await mod.run(['superagent', 'hello', '--session', 'session_1']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain('"runId": "run_1"');
+  });
+
+  it('supports implicit and origin-proxy presentation modes', async () => {
+    const bodies: unknown[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return new Response(JSON.stringify({ ok: true, runId: `run_${bodies.length}` }), {
+        status: 202,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('METABOT_ORIGIN_CHAT', 'oc_origin_chat');
+    vi.stubEnv('METABOT_ORIGIN_BOT', 'metabot');
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    const mod = await importFresh();
+    await mod.run(['superagent', 'background only', '--implicit']);
+    await mod.run(['superagent', 'run this']);
+    await mod.run(['superagent', 'direct', '--child-direct']);
+
+    expect(bodies).toEqual([
+      { agentId: 'superagent', message: 'background only', presentationMode: 'implicit' },
+      {
+        agentId: 'superagent',
+        message: 'run this',
+        presentationMode: 'origin-proxy',
+        originChatId: 'oc_origin_chat',
+        originBotName: 'metabot',
+      },
+      { agentId: 'superagent', message: 'direct' },
+    ]);
+  });
+});

--- a/packages/server/src/agents/agent-routes.ts
+++ b/packages/server/src/agents/agent-routes.ts
@@ -1,14 +1,64 @@
 import type { Credential } from '../auth/credentials.js';
-import {
-  AgentNotFoundError,
-  AgentStore,
-  NameSquatError,
-  type AgentRecord,
-} from './agent-store.js';
+import { AgentNotFoundError, AgentStore, NameSquatError, type AgentRecord } from './agent-store.js';
+import type { MessageStore } from '../bus/message-store.js';
 
 export interface RouteResult {
   status: number;
   body: unknown;
+}
+
+function canSeeAgent(agent: AgentRecord, cred: Credential): boolean {
+  return (
+    cred.role === 'admin' ||
+    agent.visible ||
+    (!!cred.ownerName && (agent.ownerName === cred.ownerName || agent.visibleToOwners.includes(cred.ownerName)))
+  );
+}
+
+export function searchAgents(store: AgentStore, query: URLSearchParams, cred: Credential): RouteResult {
+  const limit = Math.max(1, Math.min(100, Number(query.get('limit') || 20) || 20));
+  const offset = Math.max(0, Number(query.get('offset') || 0) || 0);
+  const term = query.get('q') || query.get('keyword') || undefined;
+  const username = query.get('user') || query.get('username') || undefined;
+  const all = store.search(term, username).filter((a) => canSeeAgent(a, cred));
+  const page = all.slice(offset, offset + limit);
+  return {
+    status: 200,
+    body: {
+      agents: page.map(publicShape),
+      total: all.length,
+      limit,
+      offset,
+      hasMore: offset + page.length < all.length,
+      nextOffset: offset + page.length < all.length ? offset + page.length : null,
+    },
+  };
+}
+
+export function listAgentSessions(
+  store: AgentStore,
+  messages: MessageStore,
+  agentRef: string,
+  query: URLSearchParams,
+  cred: Credential,
+): RouteResult {
+  const agent = store.getByName(agentRef) || store.getById(agentRef);
+  if (!agent || !canSeeAgent(agent, cred)) return err(404, 'agent_not_found');
+  const limit = Math.max(1, Math.min(100, Number(query.get('limit') || 20) || 20));
+  const offset = Math.max(0, Number(query.get('offset') || 0) || 0);
+  const listed = messages.listSessions(agent.id, { limit, offset });
+  return {
+    status: 200,
+    body: {
+      agent: publicShape(agent),
+      sessions: listed.sessions,
+      total: listed.total,
+      limit,
+      offset,
+      hasMore: offset + listed.sessions.length < listed.total,
+      nextOffset: offset + listed.sessions.length < listed.total ? offset + listed.sessions.length : null,
+    },
+  };
 }
 
 function err(status: number, error: string): RouteResult {
@@ -20,6 +70,7 @@ function publicShape(rec: AgentRecord) {
     id: rec.id,
     botName: rec.botName,
     url: rec.url,
+    description: rec.description,
     visible: rec.visible,
     memoryPublic: rec.memoryPublic,
     visibleToOwners: rec.visibleToOwners,
@@ -41,22 +92,20 @@ function resolveBotName(body: Record<string, unknown>, cred: Credential): string
   return raw || cred.botName;
 }
 
-export function registerAgent(
-  store: AgentStore,
-  body: Record<string, unknown>,
-  cred: Credential,
-): RouteResult {
+export function registerAgent(store: AgentStore, body: Record<string, unknown>, cred: Credential): RouteResult {
   const url = typeof body.url === 'string' ? body.url : '';
   if (!url) return err(400, 'url_required');
   const botName = resolveBotName(body, cred);
   if (!botName) return err(400, 'bot_name_required');
   const visible = body.visible === undefined ? true : !!body.visible;
   const memoryPublic = body.memoryPublic === undefined ? undefined : !!body.memoryPublic;
+  const description = typeof body.description === 'string' ? body.description.trim() : '';
 
   try {
     const rec = store.register({
       botName,
       url,
+      description,
       visible,
       memoryPublic,
       ownerCredentialId: cred.id,
@@ -78,11 +127,7 @@ export function registerAgent(
  * Used by the bridge to register all visible bots from `bots.json` in one
  * RPC at boot.
  */
-export function registerAgentsBulk(
-  store: AgentStore,
-  body: Record<string, unknown>,
-  cred: Credential,
-): RouteResult {
+export function registerAgentsBulk(store: AgentStore, body: Record<string, unknown>, cred: Credential): RouteResult {
   const bots = Array.isArray(body.bots) ? (body.bots as Array<Record<string, unknown>>) : null;
   if (!bots) return err(400, 'bots_array_required');
 
@@ -101,9 +146,14 @@ export function registerAgentsBulk(
     }
     const visible = entry.visible === undefined ? true : !!entry.visible;
     const memoryPublic = entry.memoryPublic === undefined ? undefined : !!entry.memoryPublic;
+    const description = typeof entry.description === 'string' ? entry.description.trim() : '';
     try {
       store.register({
-        botName, url, visible, memoryPublic,
+        botName,
+        url,
+        description,
+        visible,
+        memoryPublic,
         ownerCredentialId: cred.id,
         ownerName: cred.ownerName,
       });
@@ -120,11 +170,7 @@ export function registerAgentsBulk(
   return { status: 200, body: { registered, results } };
 }
 
-export function heartbeat(
-  store: AgentStore,
-  body: Record<string, unknown>,
-  cred: Credential,
-): RouteResult {
+export function heartbeat(store: AgentStore, body: Record<string, unknown>, cred: Credential): RouteResult {
   // Batch form: { botNames: ["a", "b", ...] } — bumps every owned name.
   if (Array.isArray(body.botNames)) {
     const names = (body.botNames as unknown[]).filter((n): n is string => typeof n === 'string');
@@ -143,8 +189,8 @@ export function heartbeat(
 }
 
 // Derive the host the agent advertises itself on. The web UI groups agents
-// by this value, so callers see "all bots on host-a.example.com" vs "all bots
-// on localhost" rather than a flat list. Falls back to the raw url string when
+// by this value, so callers see "all bots on 172.31.32.2" vs "all bots on
+// localhost" rather than a flat list. Falls back to the raw url string when
 // parsing throws (malformed URL stored against expectation) so the list call
 // never 500s on a single bad row.
 function deriveHost(url: string): string {
@@ -155,12 +201,9 @@ function deriveHost(url: string): string {
   }
 }
 
-export function listAgents(
-  store: AgentStore,
-  query: URLSearchParams,
-  cred: Credential,
-): RouteResult {
+export function listAgents(store: AgentStore, query: URLSearchParams, cred: Credential): RouteResult {
   const includeHidden = query.get('includeHidden') === '1';
+  const includeStale = query.get('includeStale') === '1';
   if (includeHidden && cred.role !== 'admin') {
     return err(403, 'include_hidden_admin_only');
   }
@@ -168,7 +211,14 @@ export function listAgents(
   // hidden rows owned by `cred.ownerName` to come back even when the caller
   // is a member. The legacy `visible = 1` SQL pre-filter at the store level
   // would have hidden the caller's own bots from their other-machine cred.
-  const all = store.list({ includeHidden: true });
+  // Agent discovery keeps the historical three-minute freshness window by
+  // default. The Web Console opts into stale rows so its registry can render
+  // offline agents too (and so an isolated database snapshot does not appear
+  // empty once its copied heartbeats age out).
+  const all = store.list({
+    includeHidden: true,
+    ttlMs: includeStale ? Number.POSITIVE_INFINITY : undefined,
+  });
   const visibleToCaller = (a: { visible: boolean; ownerName: string; visibleToOwners: string[] }): boolean => {
     if (includeHidden) return true; // admin-only, already gated above
     if (cred.role === 'admin') return true;
@@ -186,6 +236,7 @@ export function listAgents(
       agents: agents.map((a) => ({
         botName: a.botName,
         url: a.url,
+        description: a.description,
         host: deriveHost(a.url),
         visible: a.visible,
         ownerName: a.ownerName,
@@ -273,11 +324,7 @@ export function setAgentMemoryPublic(
   return { status: 200, body: { botName: rec.botName, memoryPublic: rec.memoryPublic } };
 }
 
-export function removeAgent(
-  store: AgentStore,
-  botName: string,
-  cred: Credential,
-): RouteResult {
+export function removeAgent(store: AgentStore, botName: string, cred: Credential): RouteResult {
   const existing = store.getByName(botName);
   if (!existing) return err(404, 'agent_not_found');
   if (existing.ownerCredentialId !== cred.id && cred.role !== 'admin') {

--- a/packages/server/src/agents/agent-store.ts
+++ b/packages/server/src/agents/agent-store.ts
@@ -6,6 +6,7 @@ export interface AgentRecord {
   id: string;
   botName: string;
   url: string;
+  description: string;
   visible: boolean;
   /**
    * When true, the CLI defaults this bot's `metabot memory create/mkdir`
@@ -39,6 +40,7 @@ export interface AgentRecord {
 export interface RegisterInput {
   botName: string;
   url: string;
+  description?: string;
   visible?: boolean;
   memoryPublic?: boolean;
   ownerCredentialId: string;
@@ -121,9 +123,9 @@ export class AgentStore {
     // and stay locked to public-visibility-only behavior.
     if (!cols.some((c) => c.name === 'owner_name')) {
       this.db.exec(`ALTER TABLE agents ADD COLUMN owner_name TEXT NOT NULL DEFAULT ''`);
-      const hasCredentials = this.db.prepare(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='credentials'",
-      ).get();
+      const hasCredentials = this.db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='credentials'")
+        .get();
       if (hasCredentials) {
         this.db.exec(`
           UPDATE agents
@@ -142,68 +144,99 @@ export class AgentStore {
     if (!cols.some((c) => c.name === 'visible_to_owners')) {
       this.db.exec(`ALTER TABLE agents ADD COLUMN visible_to_owners TEXT NOT NULL DEFAULT '[]'`);
     }
+
+    // Idempotent migration for `description` (added 2026-07-07). This is a
+    // user-facing purpose string surfaced in the Agents UI and populated from
+    // bots.json or CLI registration. Empty string preserves legacy rows.
+    if (!cols.some((c) => c.name === 'description')) {
+      this.db.exec(`ALTER TABLE agents ADD COLUMN description TEXT NOT NULL DEFAULT ''`);
+    }
   }
 
   register(input: RegisterInput): AgentRecord {
     const now = new Date().toISOString();
     const visible = input.visible !== false;
 
-    const existing = this.db.prepare(
-      'SELECT id, owner_credential_id, memory_public FROM agents WHERE bot_name = ?',
-    ).get(input.botName) as
-      | { id: string; owner_credential_id: string; memory_public: 0 | 1 }
+    const existing = this.db
+      .prepare('SELECT id, owner_credential_id, owner_name, memory_public FROM agents WHERE bot_name = ?')
+      .get(input.botName) as
+      | { id: string; owner_credential_id: string; owner_name: string | null; memory_public: 0 | 1 }
       | undefined;
 
     if (existing) {
-      if (existing.owner_credential_id !== input.ownerCredentialId) {
+      const sameCredential = existing.owner_credential_id === input.ownerCredentialId;
+      const sameOwner = !!existing.owner_name && existing.owner_name === input.ownerName;
+      if (!sameCredential && !sameOwner) {
         throw new NameSquatError(input.botName);
       }
       // memoryPublic only changes if the caller passed it explicitly — this
       // lets a bot toggle it at runtime via `metabot memory visibility` and
       // not have the next bridge re-register clobber the choice (bots.json
       // doesn't carry it unless the user wants it baked in).
-      const memoryPublic = input.memoryPublic === undefined
-        ? existing.memory_public === 1
-        : input.memoryPublic === true;
+      const memoryPublic =
+        input.memoryPublic === undefined ? existing.memory_public === 1 : input.memoryPublic === true;
       // ownerName re-sync on every register so a credential rotation that
       // preserves ownerCredentialId but changes ownerName keeps the row
       // accurate. Owner-bypass reads owner_name directly.
-      this.db.prepare(`
+      this.db
+        .prepare(
+          `
         UPDATE agents SET
-          url = ?, visible = ?, memory_public = ?, owner_name = ?, last_seen_at = ?
+          url = ?, description = ?, visible = ?, memory_public = ?,
+          owner_credential_id = ?, owner_name = ?, last_seen_at = ?
         WHERE bot_name = ?
-      `).run(
-        input.url, visible ? 1 : 0, memoryPublic ? 1 : 0, input.ownerName ?? '', now, input.botName,
-      );
+      `,
+        )
+        .run(
+          input.url,
+          input.description ?? '',
+          visible ? 1 : 0,
+          memoryPublic ? 1 : 0,
+          input.ownerCredentialId,
+          input.ownerName ?? '',
+          now,
+          input.botName,
+        );
       this.logger.info({ botName: input.botName }, 'agent re-registered');
       return this.getByName(input.botName)!;
     }
 
     const id = crypto.randomUUID();
     const memoryPublic = input.memoryPublic !== false;
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT INTO agents (id, bot_name, url, talk_secret, visible, memory_public,
-        owner_credential_id, owner_name, registered_at, last_seen_at)
-      VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)
-    `).run(
-      id, input.botName, input.url, visible ? 1 : 0, memoryPublic ? 1 : 0,
-      input.ownerCredentialId, input.ownerName ?? '', now, now,
-    );
+        owner_credential_id, owner_name, description, registered_at, last_seen_at)
+      VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      )
+      .run(
+        id,
+        input.botName,
+        input.url,
+        visible ? 1 : 0,
+        memoryPublic ? 1 : 0,
+        input.ownerCredentialId,
+        input.ownerName ?? '',
+        input.description ?? '',
+        now,
+        now,
+      );
     this.logger.info({ botName: input.botName, id }, 'agent registered');
     return this.getByName(input.botName)!;
   }
 
   heartbeat(botName: string, ownerCredentialId: string): string {
-    const existing = this.db.prepare(
-      'SELECT owner_credential_id FROM agents WHERE bot_name = ?',
-    ).get(botName) as { owner_credential_id: string } | undefined;
+    const existing = this.db.prepare('SELECT owner_credential_id FROM agents WHERE bot_name = ?').get(botName) as
+      | { owner_credential_id: string }
+      | undefined;
     if (!existing) throw new AgentNotFoundError(botName);
     if (existing.owner_credential_id !== ownerCredentialId) {
       throw new NameSquatError(botName);
     }
     const now = new Date().toISOString();
-    this.db.prepare('UPDATE agents SET last_seen_at = ? WHERE bot_name = ?')
-      .run(now, botName);
+    this.db.prepare('UPDATE agents SET last_seen_at = ? WHERE bot_name = ?').run(now, botName);
     return now;
   }
 
@@ -217,10 +250,13 @@ export class AgentStore {
     if (!botNames.length) return {};
     const now = new Date().toISOString();
     const owned = new Set(
-      (this.db.prepare(
-        `SELECT bot_name FROM agents WHERE owner_credential_id = ? AND bot_name IN (${botNames.map(() => '?').join(',')})`,
-      ).all(ownerCredentialId, ...botNames) as Array<{ bot_name: string }>)
-        .map((r) => r.bot_name),
+      (
+        this.db
+          .prepare(
+            `SELECT bot_name FROM agents WHERE owner_credential_id = ? AND bot_name IN (${botNames.map(() => '?').join(',')})`,
+          )
+          .all(ownerCredentialId, ...botNames) as Array<{ bot_name: string }>
+      ).map((r) => r.bot_name),
     );
     if (!owned.size) return {};
     const update = this.db.prepare('UPDATE agents SET last_seen_at = ? WHERE bot_name = ?');
@@ -235,18 +271,34 @@ export class AgentStore {
 
   /** Returns all agent records owned by the given credential (any visibility). */
   listOwnedBy(ownerCredentialId: string): AgentRecord[] {
-    const rows = this.db.prepare(
-      'SELECT * FROM agents WHERE owner_credential_id = ?',
-    ).all(ownerCredentialId) as RawAgentRow[];
+    const rows = this.db
+      .prepare('SELECT * FROM agents WHERE owner_credential_id = ?')
+      .all(ownerCredentialId) as RawAgentRow[];
     return rows.map(rowToRecord);
   }
 
   getByName(botName: string): AgentRecord | undefined {
-    const row = this.db.prepare('SELECT * FROM agents WHERE bot_name = ?').get(botName) as
-      | RawAgentRow
-      | undefined;
+    const row = this.db.prepare('SELECT * FROM agents WHERE bot_name = ?').get(botName) as RawAgentRow | undefined;
     if (!row) return undefined;
     return rowToRecord(row);
+  }
+
+  getById(id: string): AgentRecord | undefined {
+    const row = this.db.prepare('SELECT * FROM agents WHERE id = ?').get(id) as RawAgentRow | undefined;
+    return row ? rowToRecord(row) : undefined;
+  }
+
+  search(term?: string, username?: string): AgentRecord[] {
+    const q = (term || '').trim().toLowerCase();
+    const user = (username || '').trim().toLowerCase();
+    const rows = this.db.prepare('SELECT * FROM agents ORDER BY last_seen_at DESC').all() as RawAgentRow[];
+    return rows.map(rowToRecord).filter((a) => {
+      const text = `${a.botName} ${a.description} ${a.ownerName}`.toLowerCase();
+      return (
+        (!q || text.includes(q)) &&
+        (!user || a.ownerName.toLowerCase() === user || a.ownerName.toLowerCase().includes(user))
+      );
+    });
   }
 
   list(options: ListOptions = {}): AgentRecord[] {
@@ -254,9 +306,7 @@ export class AgentStore {
     const now = options.now ?? Date.now();
     const includeHidden = options.includeHidden === true;
 
-    const baseSql = includeHidden
-      ? 'SELECT * FROM agents'
-      : 'SELECT * FROM agents WHERE visible = 1';
+    const baseSql = includeHidden ? 'SELECT * FROM agents' : 'SELECT * FROM agents WHERE visible = 1';
     const rows = this.db.prepare(`${baseSql} ORDER BY last_seen_at DESC`).all() as RawAgentRow[];
 
     const fresh: AgentRecord[] = [];
@@ -269,14 +319,14 @@ export class AgentStore {
   }
 
   setVisibility(botName: string, visible: boolean): AgentRecord {
-    const result = this.db.prepare('UPDATE agents SET visible = ? WHERE bot_name = ?')
-      .run(visible ? 1 : 0, botName);
+    const result = this.db.prepare('UPDATE agents SET visible = ? WHERE bot_name = ?').run(visible ? 1 : 0, botName);
     if (result.changes === 0) throw new AgentNotFoundError(botName);
     return this.getByName(botName)!;
   }
 
   setMemoryPublic(botName: string, memoryPublic: boolean): AgentRecord {
-    const result = this.db.prepare('UPDATE agents SET memory_public = ? WHERE bot_name = ?')
+    const result = this.db
+      .prepare('UPDATE agents SET memory_public = ? WHERE bot_name = ?')
       .run(memoryPublic ? 1 : 0, botName);
     if (result.changes === 0) throw new AgentNotFoundError(botName);
     return this.getByName(botName)!;
@@ -288,7 +338,8 @@ export class AgentStore {
    * verbatim. Returns the post-update record.
    */
   setVisibleToOwners(botName: string, owners: string[]): AgentRecord {
-    const result = this.db.prepare('UPDATE agents SET visible_to_owners = ? WHERE bot_name = ?')
+    const result = this.db
+      .prepare('UPDATE agents SET visible_to_owners = ? WHERE bot_name = ?')
       .run(JSON.stringify(owners), botName);
     if (result.changes === 0) throw new AgentNotFoundError(botName);
     return this.getByName(botName)!;
@@ -317,6 +368,7 @@ interface RawAgentRow {
   id: string;
   bot_name: string;
   url: string;
+  description: string | null;
   talk_secret: string | null;
   visible: 0 | 1;
   memory_public: 0 | 1;
@@ -332,6 +384,7 @@ function rowToRecord(row: RawAgentRow): AgentRecord {
     id: row.id,
     botName: row.bot_name,
     url: row.url,
+    description: row.description || '',
     visible: row.visible === 1,
     memoryPublic: row.memory_public === 1,
     ownerCredentialId: row.owner_credential_id,

--- a/packages/server/src/bus/event-hub.ts
+++ b/packages/server/src/bus/event-hub.ts
@@ -1,0 +1,40 @@
+import type * as http from 'node:http';
+
+export interface BusEvent {
+  type: string;
+  roomId?: string;
+  agentRef?: string;
+  messageId?: string;
+  runId?: string;
+  correlationId?: string;
+  payload?: Record<string, unknown>;
+}
+
+type Listener = (event: BusEvent) => void;
+
+/** In-process event fan-out used by the personal Core server. */
+export class BusEventHub {
+  private readonly listeners = new Set<Listener>();
+
+  publish(event: BusEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        /* listeners must not break writes */
+      }
+    }
+  }
+
+  subscribe(req: http.IncomingMessage, res: http.ServerResponse, filter: (event: BusEvent) => boolean): void {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' });
+    res.write(': connected\n\n');
+    const listener = (event: BusEvent) => {
+      if (filter(event)) res.write(`data: ${JSON.stringify(event)}\n\n`);
+    };
+    this.listeners.add(listener);
+    const close = () => this.listeners.delete(listener);
+    req.on('close', close);
+    res.on('close', close);
+  }
+}

--- a/packages/server/src/bus/message-routes.ts
+++ b/packages/server/src/bus/message-routes.ts
@@ -1,0 +1,363 @@
+import type * as http from 'node:http';
+import type { Credential } from '../auth/credentials.js';
+import type { AgentStore, AgentRecord } from '../agents/agent-store.js';
+import type { ChatStore } from '../chat/chat-store.js';
+import type { ChatRunPresentation } from '../chat/chat-types.js';
+import type { BusEventHub } from './event-hub.js';
+import { MessageStore, type MessageSession } from './message-store.js';
+
+export interface MessageRouteDeps {
+  agents: AgentStore;
+  messages: MessageStore;
+  chat: ChatStore;
+  events: BusEventHub;
+  deliverRun?: (run: {
+    id: string;
+    conversationId: string;
+    triggerMessageId: string;
+    targetAgentRef: string;
+    prompt: string;
+    engine?: string | null;
+    model?: string | null;
+    presentation?: ChatRunPresentation | null;
+  }) => void;
+}
+export interface RouteResult {
+  status: number;
+  body: unknown;
+}
+const err = (status: number, error: string, extra: Record<string, unknown> = {}): RouteResult => ({
+  status,
+  body: { error, ...extra },
+});
+const senderRef = (cred: Credential) => (cred.ownerName || cred.botName).toLowerCase();
+
+function resolveAgent(store: AgentStore, ref: string, cred: Credential): AgentRecord | null {
+  const agent = store.getByName(ref) || store.getById(ref);
+  if (!agent) return null;
+  if (
+    cred.role === 'admin' ||
+    agent.visible ||
+    (!!cred.ownerName && (agent.ownerName === cred.ownerName || agent.visibleToOwners.includes(cred.ownerName)))
+  )
+    return agent;
+  return null;
+}
+
+function sessionShape(s: MessageSession): MessageSession {
+  return s;
+}
+
+function isFeishuChatId(value: string): boolean {
+  return /^oc_[A-Za-z0-9_-]{3,240}$/.test(value);
+}
+
+function originProxyPresentation(
+  body: Record<string, unknown>,
+  cred: Credential,
+  targetAgentRef: string,
+  agents: AgentStore,
+): ChatRunPresentation | undefined {
+  if (body.presentationMode !== 'origin-proxy') return undefined;
+  const chatId = typeof body.originChatId === 'string' ? body.originChatId.trim() : '';
+  const originBotName = typeof body.originBotName === 'string' ? body.originBotName.trim() : '';
+  const senderNames = new Set([cred.botName.trim().toLowerCase(), cred.ownerName.trim().toLowerCase()].filter(Boolean));
+  const adminSelectedRegisteredOrigin = cred.role === 'admin' && !!agents.getByName(originBotName);
+  if (
+    !isFeishuChatId(chatId) ||
+    !originBotName ||
+    (!senderNames.has(originBotName.toLowerCase()) && !adminSelectedRegisteredOrigin)
+  ) {
+    throw Object.assign(new Error('invalid_origin_proxy_presentation'), { statusCode: 400 });
+  }
+  return {
+    mode: 'origin-proxy',
+    chatId,
+    targetAgentRef,
+    requestedBy: cred.botName,
+    originBotName,
+    wakeLead: body.wakeLead !== false,
+  };
+}
+
+export function registerSession(deps: MessageRouteDeps, body: Record<string, unknown>, cred: Credential): RouteResult {
+  const ref = typeof body.agentId === 'string' ? body.agentId.trim() : '';
+  const agent = resolveAgent(deps.agents, ref || cred.botName, cred);
+  if (!agent) return err(404, 'agent_not_found');
+  if (cred.role !== 'admin' && agent.ownerCredentialId !== cred.id && agent.ownerName !== cred.ownerName)
+    return err(403, 'session_ownership_required');
+  const roomId = typeof body.roomId === 'string' ? body.roomId.trim() : '';
+  // Bind a provider session back to the central logical session that created
+  // this room. The Bridge's local SessionRegistry UUID is not a Bus address.
+  const roomSession = roomId ? deps.messages.findSessionByRoom(agent.id, roomId) : null;
+  const session = deps.messages.ensureSession({
+    agentId: agent.id,
+    agentName: agent.botName,
+    id: roomSession?.id ?? (typeof body.sessionId === 'string' ? body.sessionId : undefined),
+    provider: typeof body.provider === 'string' ? body.provider : undefined,
+    providerSessionId: typeof body.providerSessionId === 'string' ? body.providerSessionId : undefined,
+    status: typeof body.status === 'string' ? (body.status as MessageSession['status']) : 'online',
+    roomId: roomId || undefined,
+    transportChatId: typeof body.transportChatId === 'string' ? body.transportChatId.trim() : undefined,
+    transportPlatform: typeof body.transportPlatform === 'string' ? body.transportPlatform.trim() : undefined,
+    title: typeof body.title === 'string' ? body.title : undefined,
+  });
+  return { status: 201, body: { session: sessionShape(session) } };
+}
+
+export function listSessions(
+  deps: MessageRouteDeps,
+  agentRef: string,
+  query: URLSearchParams,
+  cred: Credential,
+): RouteResult {
+  const agent = resolveAgent(deps.agents, agentRef, cred);
+  if (!agent) return err(404, 'agent_not_found');
+  const limit = Math.max(1, Math.min(100, Number(query.get('limit') || 20) || 20));
+  const offset = Math.max(0, Number(query.get('offset') || 0) || 0);
+  const result = deps.messages.listSessions(agent.id, { limit, offset });
+  return {
+    status: 200,
+    body: {
+      agentId: agent.id,
+      agentName: agent.botName,
+      ...result,
+      limit,
+      offset,
+      hasMore: offset + result.sessions.length < result.total,
+      nextOffset: offset + result.sessions.length < result.total ? offset + result.sessions.length : null,
+    },
+  };
+}
+
+export function sendMessage(deps: MessageRouteDeps, body: Record<string, unknown>, cred: Credential): RouteResult {
+  const ref = typeof body.agentId === 'string' ? body.agentId.trim() : '';
+  if (!ref) return err(400, 'agent_id_required');
+  const text =
+    typeof body.message === 'string' ? body.message.trim() : typeof body.text === 'string' ? body.text.trim() : '';
+  if (!text) return err(400, 'message_required');
+  const agent = resolveAgent(deps.agents, ref, cred);
+  if (!agent) return err(404, 'agent_not_found');
+  const listed = deps.messages.listSessions(agent.id, { limit: 100, offset: 0 }).sessions;
+  const requested = typeof body.sessionId === 'string' ? body.sessionId.trim() : '';
+  let session = requested ? deps.messages.getSession(requested) : null;
+  if (requested && (!session || session.agentId !== agent.id)) return err(404, 'session_not_found');
+  if (!session) {
+    const usable = listed.filter((s) => s.status === 'online' || s.status === 'resumable');
+    if (usable.length > 1)
+      return err(409, 'session_required', { sessions: usable, agentId: agent.id, agentName: agent.botName });
+    if (usable.length === 1) session = usable[0]!;
+    else if (listed.length > 0 && listed.every((s) => s.status === 'offline'))
+      return err(409, 'session_offline', { sessions: listed, agentId: agent.id, agentName: agent.botName });
+    else if (listed.length === 1 && listed[0]!.status === 'provisioning') session = listed[0]!;
+    else if (listed.some((s) => s.status === 'provisioning'))
+      return err(409, 'session_provisioning', { sessions: listed, agentId: agent.id, agentName: agent.botName });
+  }
+  const from = senderRef(cred);
+  const idempotencyKey = typeof body.idempotencyKey === 'string' ? body.idempotencyKey.trim() : '';
+  if (!session) {
+    const room = deps.chat.createConversation({
+      kind: 'dm',
+      title: agent.botName,
+      createdBy: from,
+      participants: [{ kind: 'agent', ref: agent.botName, displayName: agent.botName }],
+    });
+    session = deps.messages.ensureSession({
+      agentId: agent.id,
+      agentName: agent.botName,
+      status: 'provisioning',
+      roomId: room.id,
+    });
+  } else if (!session.roomId) {
+    const room = deps.chat.createConversation({
+      kind: 'dm',
+      title: session.title || agent.botName,
+      createdBy: from,
+      participants: [{ kind: 'agent', ref: agent.botName, displayName: agent.botName }],
+    });
+    session = deps.messages.ensureSession({
+      agentId: agent.id,
+      agentName: agent.botName,
+      id: session.id,
+      roomId: room.id,
+    });
+  }
+  let presentation: ChatRunPresentation | undefined;
+  try {
+    presentation = originProxyPresentation(body, cred, agent.botName, deps.agents);
+  } catch (error) {
+    const statusCode = (error as { statusCode?: number }).statusCode;
+    return err(typeof statusCode === 'number' ? statusCode : 400, (error as Error).message || 'invalid_presentation');
+  }
+  if (
+    !presentation &&
+    body.presentationMode !== 'implicit' &&
+    session.transportPlatform === 'feishu' &&
+    typeof session.transportChatId === 'string' &&
+    isFeishuChatId(session.transportChatId)
+  ) {
+    presentation = {
+      mode: 'child-direct',
+      chatId: session.transportChatId,
+      targetAgentRef: agent.botName,
+      requestedBy: cred.botName,
+    };
+  }
+  if (idempotencyKey) {
+    const prior = deps.chat.getRunByIdempotency(from, idempotencyKey);
+    if (prior) {
+      if (prior.targetAgentRef !== agent.botName) return err(409, 'idempotency_key_target_mismatch');
+      if (prior.conversationId !== session.roomId) return err(409, 'idempotency_key_session_mismatch');
+      if (JSON.stringify(prior.presentation) !== JSON.stringify(presentation ?? null))
+        return err(409, 'idempotency_key_presentation_mismatch');
+      return {
+        status: 202,
+        body: {
+          ok: true,
+          idempotentReplay: true,
+          messageId: prior.triggerMessageId,
+          sessionId: session.id,
+          runId: prior.id,
+          correlationId: prior.id,
+          agentId: agent.id,
+          agentName: agent.botName,
+        },
+      };
+    }
+  }
+  const { message, run, idempotentReplay } = deps.chat.appendMessageAndCreateRun(
+    {
+      conversationId: session.roomId!,
+      kind: 'user',
+      senderKind: 'user',
+      senderRef: from,
+      senderDisplayName: from,
+      content: text,
+      mentionedAgentRefs: [],
+      replyTo: typeof body.replyTo === 'string' ? body.replyTo : undefined,
+      senderSessionId: typeof body.senderSessionId === 'string' ? body.senderSessionId : undefined,
+    },
+    {
+      conversationId: session.roomId!,
+      targetAgentRef: agent.botName,
+      idempotencyOwner: idempotencyKey ? from : undefined,
+      idempotencyKey: idempotencyKey || undefined,
+      presentation,
+    },
+  );
+  if (idempotentReplay) {
+    return {
+      status: 202,
+      body: {
+        ok: true,
+        idempotentReplay: true,
+        messageId: message.id,
+        sessionId: session.id,
+        runId: run.id,
+        correlationId: run.id,
+        agentId: agent.id,
+        agentName: agent.botName,
+      },
+    };
+  }
+  deps.events.publish({
+    type: 'message.created',
+    roomId: session.roomId,
+    agentRef: agent.botName,
+    messageId: message.id,
+    runId: run.id,
+    correlationId: run.id,
+    payload: { sessionId: session.id },
+  });
+  deps.events.publish({
+    type: 'run.available',
+    roomId: session.roomId,
+    agentRef: agent.botName,
+    messageId: message.id,
+    runId: run.id,
+    correlationId: run.id,
+    payload: { sessionId: session.id },
+  });
+  deps.deliverRun?.({
+    id: run.id,
+    conversationId: session.roomId!,
+    triggerMessageId: message.id,
+    targetAgentRef: agent.botName,
+    prompt: text,
+    engine: run.engine,
+    model: run.model,
+    presentation: run.presentation,
+  });
+  return {
+    status: 202,
+    body: {
+      ok: true,
+      messageId: message.id,
+      sessionId: session.id,
+      runId: run.id,
+      correlationId: run.id,
+      agentId: agent.id,
+      agentName: agent.botName,
+    },
+  };
+}
+
+export function ackMessage(deps: MessageRouteDeps, id: string, cred: Credential): RouteResult {
+  const canonical = deps.chat.getMessage(id);
+  if (canonical) {
+    const run = deps.chat.getRunByTriggerMessageId(id);
+    if (!run) return err(409, 'message_not_bus_run');
+    const agent = deps.agents.getByName(run.targetAgentRef);
+    if (!agent) return err(404, 'agent_not_found');
+    if (cred.role !== 'admin' && agent.ownerCredentialId !== cred.id && agent.ownerName !== cred.ownerName)
+      return err(403, 'message_ack_ownership_required');
+    const session = deps.messages.findSessionByRoom(agent.id, run.conversationId);
+    const deliveryStatus = run.status === 'queued' ? 'pending' : 'acked';
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        canonical: true,
+        message: {
+          id: canonical.id,
+          agentId: agent.id,
+          sessionId: session?.id,
+          senderAgentId: canonical.senderRef,
+          senderSessionId: canonical.senderSessionId,
+          text: canonical.content,
+          replyTo: canonical.replyTo,
+          createdAt: canonical.createdAt,
+          status: deliveryStatus,
+        },
+        runId: run.id,
+        deliveryStatus: run.status,
+      },
+    };
+  }
+  const legacy = deps.messages.getMessage(id);
+  if (!legacy) return err(404, 'message_not_found');
+  const agent = deps.agents.getById(legacy.agentId);
+  if (agent && cred.role !== 'admin' && agent.ownerCredentialId !== cred.id && agent.ownerName !== cred.ownerName)
+    return err(403, 'message_ack_ownership_required');
+  const updated = deps.messages.ackMessage(id)!;
+  return { status: 200, body: { ok: true, legacy: true, message: updated } };
+}
+
+export function streamMessages(
+  deps: MessageRouteDeps,
+  query: URLSearchParams,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  cred: Credential,
+): RouteResult | void {
+  const ref = query.get('agentId') || query.get('agent') || '';
+  const agent = resolveAgent(deps.agents, ref, cred);
+  if (!agent) return err(404, 'agent_not_found');
+  deps.events.subscribe(
+    req,
+    res,
+    (event) =>
+      event.agentRef === agent.botName &&
+      (!query.get('sessionId') || event.payload?.sessionId === query.get('sessionId')),
+  );
+}

--- a/packages/server/src/bus/message-store.ts
+++ b/packages/server/src/bus/message-store.ts
@@ -1,0 +1,295 @@
+import * as crypto from 'node:crypto';
+import type Database from 'better-sqlite3';
+import type { Logger } from 'pino';
+
+export type MessageSessionStatus = 'online' | 'resumable' | 'offline' | 'provisioning';
+
+export interface MessageSession {
+  id: string;
+  agentId: string;
+  agentName: string;
+  provider?: string;
+  providerSessionId?: string;
+  status: MessageSessionStatus;
+  roomId?: string;
+  transportChatId?: string;
+  transportPlatform?: string;
+  title?: string;
+  createdAt: string;
+  updatedAt: string;
+  lastSeenAt?: string;
+}
+
+export interface MessageRecord {
+  id: string;
+  agentId: string;
+  sessionId: string;
+  senderAgentId: string;
+  senderSessionId?: string;
+  text: string;
+  replyTo?: string;
+  createdAt: string;
+  status: 'pending' | 'acked';
+}
+
+export interface EnsureSessionInput {
+  agentId: string;
+  agentName: string;
+  id?: string;
+  provider?: string;
+  providerSessionId?: string;
+  status?: MessageSessionStatus;
+  roomId?: string;
+  transportChatId?: string;
+  transportPlatform?: string;
+  title?: string;
+}
+
+/** Small durable catalog for the simplified Agent Bus protocol. */
+export class MessageStore {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly logger: Logger,
+  ) {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS message_sessions (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        provider TEXT,
+        provider_session_id TEXT,
+        status TEXT NOT NULL DEFAULT 'provisioning',
+        room_id TEXT,
+        transport_chat_id TEXT,
+        transport_platform TEXT,
+        title TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        last_seen_at TEXT
+      );
+      CREATE INDEX IF NOT EXISTS message_sessions_agent_idx
+        ON message_sessions(agent_id, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS message_sessions_agent_status_idx
+        ON message_sessions(agent_id, status, updated_at DESC);
+      CREATE TABLE IF NOT EXISTS bus_messages (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        sender_agent_id TEXT NOT NULL,
+        sender_session_id TEXT,
+        text TEXT NOT NULL,
+        reply_to TEXT,
+        idempotency_key TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS bus_messages_session_idx
+        ON bus_messages(session_id, created_at);
+    `);
+    const columns = this.db.prepare('PRAGMA table_info(bus_messages)').all() as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === 'idempotency_key')) {
+      this.db.exec('ALTER TABLE bus_messages ADD COLUMN idempotency_key TEXT');
+    }
+    const sessionColumns = this.db.prepare('PRAGMA table_info(message_sessions)').all() as Array<{ name: string }>;
+    if (!sessionColumns.some((column) => column.name === 'transport_chat_id')) {
+      this.db.exec('ALTER TABLE message_sessions ADD COLUMN transport_chat_id TEXT');
+    }
+    if (!sessionColumns.some((column) => column.name === 'transport_platform')) {
+      this.db.exec('ALTER TABLE message_sessions ADD COLUMN transport_platform TEXT');
+    }
+    this.db.exec(
+      'CREATE UNIQUE INDEX IF NOT EXISTS bus_messages_idempotency_idx ON bus_messages(sender_agent_id, idempotency_key) WHERE idempotency_key IS NOT NULL',
+    );
+  }
+
+  getSession(id: string): MessageSession | null {
+    const row = this.db.prepare('SELECT * FROM message_sessions WHERE id = ?').get(id) as RawSession | undefined;
+    return row ? mapSession(row) : null;
+  }
+
+  findSessionByRoom(agentId: string, roomId: string): MessageSession | null {
+    const row = this.db
+      .prepare('SELECT * FROM message_sessions WHERE agent_id = ? AND room_id = ? ORDER BY created_at ASC LIMIT 1')
+      .get(agentId, roomId) as RawSession | undefined;
+    return row ? mapSession(row) : null;
+  }
+
+  listSessions(
+    agentId: string,
+    options: { limit?: number; offset?: number } = {},
+  ): { sessions: MessageSession[]; total: number } {
+    const limit = Math.max(1, Math.min(100, options.limit ?? 20));
+    const offset = Math.max(0, options.offset ?? 0);
+    const total = Number(
+      (this.db.prepare('SELECT COUNT(*) AS n FROM message_sessions WHERE agent_id = ?').get(agentId) as { n: number })
+        .n,
+    );
+    const rows = this.db
+      .prepare('SELECT * FROM message_sessions WHERE agent_id = ? ORDER BY updated_at DESC, id LIMIT ? OFFSET ?')
+      .all(agentId, limit, offset) as RawSession[];
+    return { sessions: rows.map(mapSession), total };
+  }
+
+  ensureSession(input: EnsureSessionInput): MessageSession {
+    const id = input.id?.trim() || crypto.randomUUID();
+    const now = new Date().toISOString();
+    const existing = this.getSession(id);
+    if (existing && existing.agentId !== input.agentId) throw new Error('session_agent_mismatch');
+    if (existing) {
+      this.db
+        .prepare(
+          `UPDATE message_sessions SET agent_name = ?, provider = COALESCE(?, provider),
+        provider_session_id = COALESCE(?, provider_session_id), status = COALESCE(?, status),
+        room_id = COALESCE(?, room_id), transport_chat_id = COALESCE(?, transport_chat_id),
+        transport_platform = COALESCE(?, transport_platform), title = COALESCE(?, title),
+        updated_at = ?, last_seen_at = ? WHERE id = ?`,
+        )
+        .run(
+          input.agentName,
+          input.provider ?? null,
+          input.providerSessionId ?? null,
+          input.status ?? null,
+          input.roomId ?? null,
+          input.transportChatId ?? null,
+          input.transportPlatform ?? null,
+          input.title ?? null,
+          now,
+          now,
+          id,
+        );
+      return this.getSession(id)!;
+    }
+    this.db
+      .prepare(
+        `INSERT INTO message_sessions
+      (id, agent_id, agent_name, provider, provider_session_id, status, room_id,
+       transport_chat_id, transport_platform, title, created_at, updated_at, last_seen_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.agentId,
+        input.agentName,
+        input.provider ?? null,
+        input.providerSessionId ?? null,
+        input.status ?? 'provisioning',
+        input.roomId ?? null,
+        input.transportChatId ?? null,
+        input.transportPlatform ?? null,
+        input.title ?? null,
+        now,
+        now,
+        now,
+      );
+    this.logger.info({ sessionId: id, agentId: input.agentId }, 'message session registered');
+    return this.getSession(id)!;
+  }
+
+  touchSession(id: string, status?: MessageSessionStatus, providerSessionId?: string): MessageSession | null {
+    const now = new Date().toISOString();
+    this.db
+      .prepare(
+        `UPDATE message_sessions SET status = COALESCE(?, status),
+      provider_session_id = COALESCE(?, provider_session_id), updated_at = ?, last_seen_at = ? WHERE id = ?`,
+      )
+      .run(status ?? null, providerSessionId ?? null, now, now, id);
+    return this.getSession(id);
+  }
+
+  addMessage(
+    input: Omit<MessageRecord, 'id' | 'createdAt' | 'status'> & { id?: string; idempotencyKey?: string },
+  ): MessageRecord {
+    const id = input.id?.trim() || crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO bus_messages
+      (id, agent_id, session_id, sender_agent_id, sender_session_id, text, reply_to, idempotency_key, status, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)`,
+      )
+      .run(
+        id,
+        input.agentId,
+        input.sessionId,
+        input.senderAgentId,
+        input.senderSessionId ?? null,
+        input.text,
+        input.replyTo ?? null,
+        input.idempotencyKey ?? null,
+        createdAt,
+      );
+    return this.getMessage(id)!;
+  }
+
+  getByIdempotency(senderAgentId: string, key: string): MessageRecord | null {
+    const row = this.db
+      .prepare('SELECT id FROM bus_messages WHERE sender_agent_id = ? AND idempotency_key = ?')
+      .get(senderAgentId, key) as { id: string } | undefined;
+    return row ? this.getMessage(row.id) : null;
+  }
+
+  getMessage(id: string): MessageRecord | null {
+    const row = this.db.prepare('SELECT * FROM bus_messages WHERE id = ?').get(id) as RawMessage | undefined;
+    if (!row) return null;
+    return {
+      id: row.id,
+      agentId: row.agent_id,
+      sessionId: row.session_id,
+      senderAgentId: row.sender_agent_id,
+      senderSessionId: row.sender_session_id || undefined,
+      text: row.text,
+      replyTo: row.reply_to || undefined,
+      createdAt: row.created_at,
+      status: row.status === 'acked' ? 'acked' : 'pending',
+    };
+  }
+
+  ackMessage(id: string): MessageRecord | null {
+    this.db.prepare("UPDATE bus_messages SET status = 'acked' WHERE id = ?").run(id);
+    return this.getMessage(id);
+  }
+}
+
+interface RawSession {
+  id: string;
+  agent_id: string;
+  agent_name: string;
+  provider: string | null;
+  provider_session_id: string | null;
+  status: MessageSessionStatus;
+  room_id: string | null;
+  transport_chat_id: string | null;
+  transport_platform: string | null;
+  title: string | null;
+  created_at: string;
+  updated_at: string;
+  last_seen_at: string | null;
+}
+interface RawMessage {
+  id: string;
+  agent_id: string;
+  session_id: string;
+  sender_agent_id: string;
+  sender_session_id: string | null;
+  text: string;
+  reply_to: string | null;
+  status: string;
+  created_at: string;
+}
+function mapSession(row: RawSession): MessageSession {
+  return {
+    id: row.id,
+    agentId: row.agent_id,
+    agentName: row.agent_name,
+    provider: row.provider || undefined,
+    providerSessionId: row.provider_session_id || undefined,
+    status: row.status,
+    roomId: row.room_id || undefined,
+    transportChatId: row.transport_chat_id || undefined,
+    transportPlatform: row.transport_platform || undefined,
+    title: row.title || undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastSeenAt: row.last_seen_at || undefined,
+  };
+}

--- a/packages/server/src/chat/chat-events.ts
+++ b/packages/server/src/chat/chat-events.ts
@@ -1,0 +1,29 @@
+import type * as http from 'node:http';
+import type { ChatLiveEvent } from './chat-types.js';
+
+/** Lightweight in-process SSE hub for personal chat clients. */
+export class ChatEventHub {
+  private readonly listeners = new Set<(event: ChatLiveEvent) => void>();
+
+  publish(event: ChatLiveEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        /* closed clients are harmless */
+      }
+    }
+  }
+
+  stream(req: http.IncomingMessage, res: http.ServerResponse, conversationId: string, _userRef: string): void {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' });
+    res.write(': connected\n\n');
+    const listener = (event: ChatLiveEvent) => {
+      if (event.conversationId === conversationId) res.write(`data: ${JSON.stringify(event)}\n\n`);
+    };
+    this.listeners.add(listener);
+    const close = () => this.listeners.delete(listener);
+    req.on('close', close);
+    res.on('close', close);
+  }
+}

--- a/packages/server/src/chat/chat-routes.ts
+++ b/packages/server/src/chat/chat-routes.ts
@@ -2,7 +2,13 @@ import type { Credential } from '../auth/credentials.js';
 import type { AgentRecord, AgentStore } from '../agents/agent-store.js';
 import type { ChatStore } from './chat-store.js';
 import { ChatForbiddenError, ChatNotFoundError } from './chat-store.js';
-import type { ChatParticipantCandidate, ChatParticipantKind, ChatRunEventKind } from './chat-types.js';
+import type {
+  ChatParticipantCandidate,
+  ChatParticipantKind,
+  ChatRun,
+  ChatRunEvent,
+  ChatRunEventKind,
+} from './chat-types.js';
 
 export interface RouteResult {
   status: number;
@@ -28,6 +34,7 @@ export interface ChatRouteDeps {
     toolUseId?: string;
     answer?: string;
   }) => void;
+  onRunEvent?: (run: ChatRun, event: ChatRunEvent) => void;
 }
 
 function err(status: number, error: string): RouteResult {
@@ -425,13 +432,15 @@ export function postRunEvent(
   const kind = parseEventKind(body.kind ?? body.type);
   if (!kind) return err(400, 'event_kind_required');
   const seq = typeof body.seq === 'number' ? body.seq : Number.parseInt(String(body.seq ?? ''), 10);
-  return withChatErrors(() => ({
-    status: 200,
-    body: deps.chat.appendRunEvent({
+  return withChatErrors(() => {
+    const event = deps.chat.appendRunEvent({
       runId,
       seq,
       kind,
       payload: asObject(body.payload),
-    }),
-  }));
+    });
+    const next = deps.chat.getRun(runId);
+    if (next) deps.onRunEvent?.(next, event);
+    return { status: 200, body: event };
+  });
 }

--- a/packages/server/src/chat/chat-store.ts
+++ b/packages/server/src/chat/chat-store.ts
@@ -16,6 +16,7 @@ import type {
   ChatRun,
   ChatRunEvent,
   ChatRunEventKind,
+  ChatRunPresentation,
   ChatRunStatus,
   ChatFile,
 } from './chat-types.js';
@@ -70,6 +71,8 @@ export interface AppendMessageInput {
   content: string;
   mentionedAgentRefs?: string[];
   runId?: string | null;
+  replyTo?: string | null;
+  senderSessionId?: string | null;
 }
 
 export interface CreateRunInput {
@@ -78,6 +81,9 @@ export interface CreateRunInput {
   targetAgentRef: string;
   engine?: string | null;
   model?: string | null;
+  idempotencyOwner?: string | null;
+  idempotencyKey?: string | null;
+  presentation?: ChatRunPresentation | null;
 }
 
 export interface AppendRunEventInput {
@@ -127,6 +133,8 @@ interface RawMessageRow {
   content: string;
   mentioned_agent_refs: string;
   run_id: string | null;
+  reply_to?: string | null;
+  sender_session_id?: string | null;
   created_at: string;
 }
 
@@ -150,6 +158,9 @@ interface RawRunRow {
   completed_at: string | null;
   error: string | null;
   final_message_id: string | null;
+  idempotency_owner?: string | null;
+  idempotency_key?: string | null;
+  presentation_json?: string | null;
 }
 
 interface RawRunEventRow {
@@ -215,8 +226,10 @@ export class ChatStore {
         sender_ref           TEXT NOT NULL,
         sender_display_name  TEXT NOT NULL,
         content              TEXT NOT NULL,
-        mentioned_agent_refs TEXT NOT NULL DEFAULT '[]',
-        run_id               TEXT,
+      mentioned_agent_refs TEXT NOT NULL DEFAULT '[]',
+      run_id               TEXT,
+        reply_to             TEXT,
+        sender_session_id    TEXT,
         created_at           TEXT NOT NULL,
         FOREIGN KEY (conversation_id) REFERENCES chat_conversations(id) ON DELETE CASCADE
       );
@@ -237,6 +250,9 @@ export class ChatStore {
         target_agent_ref   TEXT NOT NULL,
         engine             TEXT,
         model              TEXT,
+        idempotency_owner  TEXT,
+        idempotency_key    TEXT,
+        presentation_json  TEXT,
         status             TEXT NOT NULL CHECK (status IN ('queued', 'running', 'waiting_user', 'completed', 'failed', 'canceled')),
         created_at         TEXT NOT NULL,
         updated_at         TEXT NOT NULL,
@@ -292,6 +308,14 @@ export class ChatStore {
     `);
     this.ensureColumn('chat_runs', 'engine', 'TEXT');
     this.ensureColumn('chat_runs', 'model', 'TEXT');
+    this.ensureColumn('chat_runs', 'idempotency_owner', 'TEXT');
+    this.ensureColumn('chat_runs', 'idempotency_key', 'TEXT');
+    this.ensureColumn('chat_runs', 'presentation_json', 'TEXT');
+    this.ensureColumn('chat_messages', 'reply_to', 'TEXT');
+    this.ensureColumn('chat_messages', 'sender_session_id', 'TEXT');
+    this.db.exec(
+      'CREATE UNIQUE INDEX IF NOT EXISTS chat_runs_idempotency_idx ON chat_runs(idempotency_owner, idempotency_key) WHERE idempotency_key IS NOT NULL',
+    );
   }
 
   private ensureColumn(table: string, column: string, definition: string): void {
@@ -313,10 +337,14 @@ export class ChatStore {
     const title = normalizeTitle(input.title, input.kind, participants, input.createdBy);
 
     const insert = this.db.transaction(() => {
-      this.db.prepare(`
+      this.db
+        .prepare(
+          `
         INSERT INTO chat_conversations (id, kind, title, created_by, created_at, updated_at, last_message_at)
         VALUES (?, ?, ?, ?, ?, ?, NULL)
-      `).run(id, input.kind, title, input.createdBy, now, now);
+      `,
+        )
+        .run(id, input.kind, title, input.createdBy, now, now);
       const stmt = this.db.prepare(`
         INSERT INTO chat_participants (conversation_id, kind, ref, display_name, added_by, added_at)
         VALUES (?, ?, ?, ?, ?, ?)
@@ -332,7 +360,9 @@ export class ChatStore {
   }
 
   findAgentDm(userRef: string, agentRef: string): ChatConversationSummary | null {
-    const row = this.db.prepare(`
+    const row = this.db
+      .prepare(
+        `
       SELECT c.*
         FROM chat_conversations c
         JOIN chat_participants u
@@ -343,7 +373,9 @@ export class ChatStore {
          AND (SELECT COUNT(*) FROM chat_participants p WHERE p.conversation_id = c.id) = 2
        ORDER BY c.updated_at DESC
        LIMIT 1
-    `).get(userRef, agentRef) as RawConversationRow | undefined;
+    `,
+      )
+      .get(userRef, agentRef) as RawConversationRow | undefined;
     if (!row) return null;
     return this.summaryFromConversation(row, userRef);
   }
@@ -359,16 +391,16 @@ export class ChatStore {
       kind: 'dm',
       title: input.agentDisplayName || input.agentRef,
       createdBy: input.userRef,
-      participants: [
-        { kind: 'agent', ref: input.agentRef, displayName: input.agentDisplayName || input.agentRef },
-      ],
+      participants: [{ kind: 'agent', ref: input.agentRef, displayName: input.agentDisplayName || input.agentRef }],
     });
   }
 
   findUserDm(userRef: string, otherUserRef: string): ChatConversationSummary | null {
     const normalizedUser = normalizeRef('user', userRef);
     const normalizedOther = normalizeRef('user', otherUserRef);
-    const row = this.db.prepare(`
+    const row = this.db
+      .prepare(
+        `
       SELECT c.*
         FROM chat_conversations c
         JOIN chat_participants u
@@ -379,7 +411,9 @@ export class ChatStore {
          AND (SELECT COUNT(*) FROM chat_participants p WHERE p.conversation_id = c.id) = 2
        ORDER BY c.updated_at DESC
        LIMIT 1
-    `).get(normalizedUser, normalizedOther) as RawConversationRow | undefined;
+    `,
+      )
+      .get(normalizedUser, normalizedOther) as RawConversationRow | undefined;
     if (!row) return null;
     return this.summaryFromConversation(row, normalizedUser);
   }
@@ -400,9 +434,7 @@ export class ChatStore {
       kind: 'dm',
       title: input.otherDisplayName || otherUserRef,
       createdBy: userRef,
-      participants: [
-        { kind: 'user', ref: otherUserRef, displayName: input.otherDisplayName || otherUserRef },
-      ],
+      participants: [{ kind: 'user', ref: otherUserRef, displayName: input.otherDisplayName || otherUserRef }],
     });
   }
 
@@ -411,7 +443,9 @@ export class ChatStore {
     const capped = Math.min(Math.max(limit, 1), 50);
     if (!q) return [];
     const like = `%${q.replace(/[%_]/g, '\\$&')}%`;
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(
+        `
       SELECT ref, MAX(display_name) AS display_name
         FROM chat_participants
        WHERE kind = 'user'
@@ -419,7 +453,9 @@ export class ChatStore {
        GROUP BY ref
        ORDER BY ref ASC
        LIMIT ?
-    `).all(like, like, capped) as Array<{ ref: string; display_name: string | null }>;
+    `,
+      )
+      .all(like, like, capped) as Array<{ ref: string; display_name: string | null }>;
     return rows.map((row) => ({
       kind: 'user',
       ref: row.ref,
@@ -430,20 +466,25 @@ export class ChatStore {
 
   getConversationForUser(id: string, userRef: string): ChatConversationSummary {
     this.assertParticipant(id, 'user', userRef);
-    const row = this.db.prepare('SELECT * FROM chat_conversations WHERE id = ?')
-      .get(id) as RawConversationRow | undefined;
+    const row = this.db.prepare('SELECT * FROM chat_conversations WHERE id = ?').get(id) as
+      | RawConversationRow
+      | undefined;
     if (!row) throw new ChatNotFoundError(id);
     return this.summaryFromConversation(row, userRef);
   }
 
   listConversationsForUser(userRef: string): ChatConversationSummary[] {
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(
+        `
       SELECT c.*
         FROM chat_conversations c
         JOIN chat_participants p ON p.conversation_id = c.id
        WHERE p.kind = 'user' AND p.ref = ?
        ORDER BY COALESCE(c.last_message_at, c.updated_at) DESC, c.created_at DESC
-    `).all(userRef) as RawConversationRow[];
+    `,
+      )
+      .all(userRef) as RawConversationRow[];
     return rows.map((row) => this.summaryFromConversation(row, userRef));
   }
 
@@ -453,8 +494,9 @@ export class ChatStore {
     participant: { kind: ChatParticipantKind; ref: string; displayName?: string },
   ): ChatParticipant {
     this.assertParticipant(conversationId, 'user', actorUserRef);
-    const conv = this.db.prepare('SELECT kind, created_by FROM chat_conversations WHERE id = ?')
-      .get(conversationId) as { kind: ChatConversationKind; created_by: string } | undefined;
+    const conv = this.db.prepare('SELECT kind, created_by FROM chat_conversations WHERE id = ?').get(conversationId) as
+      | { kind: ChatConversationKind; created_by: string }
+      | undefined;
     if (!conv) throw new ChatNotFoundError(conversationId);
     if (conv.created_by !== actorUserRef) {
       throw Object.assign(new Error('chat_owner_required'), { statusCode: 403 });
@@ -463,17 +505,21 @@ export class ChatStore {
       throw Object.assign(new Error('dm_participants_immutable'), { statusCode: 409 });
     }
     const now = new Date().toISOString();
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT OR IGNORE INTO chat_participants (conversation_id, kind, ref, display_name, added_by, added_at)
       VALUES (?, ?, ?, ?, ?, ?)
-    `).run(
-      conversationId,
-      participant.kind,
-      normalizeRef(participant.kind, participant.ref),
-      participant.displayName || normalizeRef(participant.kind, participant.ref),
-      actorUserRef,
-      now,
-    );
+    `,
+      )
+      .run(
+        conversationId,
+        participant.kind,
+        normalizeRef(participant.kind, participant.ref),
+        participant.displayName || normalizeRef(participant.kind, participant.ref),
+        actorUserRef,
+        now,
+      );
     this.db.prepare('UPDATE chat_conversations SET updated_at = ? WHERE id = ?').run(now, conversationId);
     return this.getParticipant(conversationId, participant.kind, participant.ref)!;
   }
@@ -492,28 +538,38 @@ export class ChatStore {
     const now = new Date().toISOString();
     const id = crypto.randomUUID();
     const mentioned = dedupeStrings(input.mentionedAgentRefs || []);
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT INTO chat_messages (
         id, conversation_id, kind, sender_kind, sender_ref, sender_display_name,
-        content, mentioned_agent_refs, run_id, created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      id,
-      input.conversationId,
-      input.kind,
-      input.senderKind,
-      input.senderRef,
-      input.senderDisplayName || input.senderRef,
-      content,
-      JSON.stringify(mentioned),
-      input.runId || null,
-      now,
-    );
-    this.db.prepare(`
+        content, mentioned_agent_refs, run_id, reply_to, sender_session_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      )
+      .run(
+        id,
+        input.conversationId,
+        input.kind,
+        input.senderKind,
+        input.senderRef,
+        input.senderDisplayName || input.senderRef,
+        content,
+        JSON.stringify(mentioned),
+        input.runId || null,
+        input.replyTo || null,
+        input.senderSessionId || null,
+        now,
+      );
+    this.db
+      .prepare(
+        `
       UPDATE chat_conversations
          SET updated_at = ?, last_message_at = ?
        WHERE id = ?
-    `).run(now, now, input.conversationId);
+    `,
+      )
+      .run(now, now, input.conversationId);
     if (input.senderKind === 'user') {
       this.markReadUnchecked(input.conversationId, input.senderRef, id, now);
     }
@@ -529,29 +585,37 @@ export class ChatStore {
     const limit = Math.min(Math.max(options.limit ?? 50, 1), 200);
     const before = options.before;
     const rows = before
-      ? this.db.prepare(`
+      ? (this.db
+          .prepare(
+            `
           SELECT * FROM chat_messages
            WHERE conversation_id = ? AND rowid < (
              SELECT rowid FROM chat_messages WHERE id = ? AND conversation_id = ?
            )
            ORDER BY rowid DESC
            LIMIT ?
-        `).all(conversationId, before, conversationId, limit) as RawMessageRow[]
-      : this.db.prepare(`
+        `,
+          )
+          .all(conversationId, before, conversationId, limit) as RawMessageRow[])
+      : (this.db
+          .prepare(
+            `
           SELECT * FROM chat_messages
            WHERE conversation_id = ?
            ORDER BY rowid DESC
            LIMIT ?
-        `).all(conversationId, limit) as RawMessageRow[];
+        `,
+          )
+          .all(conversationId, limit) as RawMessageRow[]);
     return rows.map(rowToMessage).reverse();
   }
 
   markRead(conversationId: string, userRef: string, messageId: string | null): ChatReadState {
     this.assertParticipant(conversationId, 'user', userRef);
     if (messageId !== null) {
-      const row = this.db.prepare(
-        'SELECT id FROM chat_messages WHERE conversation_id = ? AND id = ?',
-      ).get(conversationId, messageId);
+      const row = this.db
+        .prepare('SELECT id FROM chat_messages WHERE conversation_id = ? AND id = ?')
+        .get(conversationId, messageId);
       if (!row) throw Object.assign(new Error('message_not_found'), { statusCode: 404 });
     }
     const now = new Date().toISOString();
@@ -567,21 +631,29 @@ export class ChatStore {
     }
     const now = new Date().toISOString();
     const id = crypto.randomUUID();
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT INTO chat_runs (
-        id, conversation_id, trigger_message_id, target_agent_ref, engine, model, status,
+        id, conversation_id, trigger_message_id, target_agent_ref, engine, model,
+        idempotency_owner, idempotency_key, presentation_json, status,
         created_at, updated_at, completed_at, error, final_message_id
-      ) VALUES (?, ?, ?, ?, ?, ?, 'queued', ?, ?, NULL, NULL, NULL)
-    `).run(
-      id,
-      input.conversationId,
-      input.triggerMessageId,
-      input.targetAgentRef,
-      cleanOptional(input.engine),
-      cleanOptional(input.model),
-      now,
-      now,
-    );
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, NULL, NULL, NULL)
+    `,
+      )
+      .run(
+        id,
+        input.conversationId,
+        input.triggerMessageId,
+        input.targetAgentRef,
+        cleanOptional(input.engine),
+        cleanOptional(input.model),
+        cleanOptional(input.idempotencyOwner),
+        cleanOptional(input.idempotencyKey),
+        input.presentation ? JSON.stringify(input.presentation) : null,
+        now,
+        now,
+      );
     return this.getRun(id)!;
   }
 
@@ -593,18 +665,59 @@ export class ChatStore {
   }
 
   getRun(runId: string): ChatRun | null {
-    const row = this.db.prepare('SELECT * FROM chat_runs WHERE id = ?')
-      .get(runId) as RawRunRow | undefined;
+    const row = this.db.prepare('SELECT * FROM chat_runs WHERE id = ?').get(runId) as RawRunRow | undefined;
     return row ? rowToRun(row) : null;
+  }
+
+  getRunByIdempotency(owner: string, key: string): ChatRun | null {
+    const row = this.db
+      .prepare('SELECT * FROM chat_runs WHERE idempotency_owner = ? AND idempotency_key = ?')
+      .get(owner, key) as RawRunRow | undefined;
+    return row ? rowToRun(row) : null;
+  }
+
+  getRunByTriggerMessageId(messageId: string): ChatRun | null {
+    const row = this.db.prepare('SELECT * FROM chat_runs WHERE trigger_message_id = ?').get(messageId) as
+      | RawRunRow
+      | undefined;
+    return row ? rowToRun(row) : null;
+  }
+
+  appendMessageAndCreateRun(
+    message: AppendMessageInput,
+    run: Omit<CreateRunInput, 'triggerMessageId'>,
+  ): { message: ChatMessage; run: ChatRun; idempotentReplay: boolean } {
+    if (run.idempotencyOwner && run.idempotencyKey) {
+      const prior = this.getRunByIdempotency(run.idempotencyOwner, run.idempotencyKey);
+      if (prior) return { message: this.getMessage(prior.triggerMessageId)!, run: prior, idempotentReplay: true };
+    }
+    const created = this.appendMessage(message);
+    try {
+      const createdRun = this.createRun({ ...run, triggerMessageId: created.id });
+      return { message: created, run: createdRun, idempotentReplay: false };
+    } catch (error) {
+      // A concurrent retry may win the unique idempotency index between the
+      // lookup above and INSERT. Return that canonical run instead of leaking
+      // a SQLite constraint error to the caller.
+      if (run.idempotencyOwner && run.idempotencyKey) {
+        const prior = this.getRunByIdempotency(run.idempotencyOwner, run.idempotencyKey);
+        if (prior) return { message: this.getMessage(prior.triggerMessageId)!, run: prior, idempotentReplay: true };
+      }
+      throw error;
+    }
   }
 
   listRuns(conversationId: string, userRef: string): ChatRun[] {
     this.assertParticipant(conversationId, 'user', userRef);
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(
+        `
       SELECT * FROM chat_runs
        WHERE conversation_id = ?
        ORDER BY created_at ASC, id ASC
-    `).all(conversationId) as RawRunRow[];
+    `,
+      )
+      .all(conversationId) as RawRunRow[];
     return rows.map(rowToRun);
   }
 
@@ -617,7 +730,8 @@ export class ChatStore {
 
     const tx = this.db.transaction(() => {
       const payloadJson = JSON.stringify(input.payload);
-      const existing = this.db.prepare('SELECT * FROM chat_run_events WHERE run_id = ? AND seq = ?')
+      const existing = this.db
+        .prepare('SELECT * FROM chat_run_events WHERE run_id = ? AND seq = ?')
         .get(input.runId, input.seq) as RawRunEventRow | undefined;
       if (existing) {
         if (existing.kind !== input.kind || existing.payload_json !== payloadJson) {
@@ -631,10 +745,14 @@ export class ChatStore {
 
       const now = new Date().toISOString();
       const id = crypto.randomUUID();
-      this.db.prepare(`
+      this.db
+        .prepare(
+          `
         INSERT INTO chat_run_events (id, run_id, seq, kind, payload_json, created_at)
         VALUES (?, ?, ?, ?, ?, ?)
-      `).run(id, input.runId, input.seq, input.kind, payloadJson, now);
+      `,
+        )
+        .run(id, input.runId, input.seq, input.kind, payloadJson, now);
 
       if (input.kind === 'state') {
         this.updateRunStatus(input.runId, payloadStatus(input.payload) || 'running', now);
@@ -654,8 +772,7 @@ export class ChatStore {
         this.updateRunStatus(input.runId, run.status === 'queued' ? 'running' : run.status, now);
       }
 
-      const row = this.db.prepare('SELECT * FROM chat_run_events WHERE id = ?')
-        .get(id) as RawRunEventRow;
+      const row = this.db.prepare('SELECT * FROM chat_run_events WHERE id = ?').get(id) as RawRunEventRow;
       return rowToRunEvent(row);
     });
     return tx();
@@ -663,11 +780,15 @@ export class ChatStore {
 
   listRunEventsForUser(runId: string, userRef: string): ChatRunEvent[] {
     const run = this.getRunForUser(runId, userRef);
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(
+        `
       SELECT * FROM chat_run_events
        WHERE run_id = ?
        ORDER BY seq ASC
-    `).all(run.id) as RawRunEventRow[];
+    `,
+      )
+      .all(run.id) as RawRunEventRow[];
     return rows.map(rowToRunEvent);
   }
 
@@ -678,25 +799,28 @@ export class ChatStore {
 
   listFiles(conversationId: string, userRef: string): ChatFile[] {
     this.assertParticipant(conversationId, 'user', userRef);
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(
+        `
       SELECT * FROM chat_files
        WHERE conversation_id = ?
        ORDER BY created_at ASC, id ASC
-    `).all(conversationId) as RawFileRow[];
+    `,
+      )
+      .all(conversationId) as RawFileRow[];
     return rows.map(rowToFile);
   }
 
-  private updateRunStatus(
-    runId: string,
-    status: ChatRunStatus,
-    updatedAt: string,
-    error?: string | null,
-  ): void {
-    this.db.prepare(`
+  private updateRunStatus(runId: string, status: ChatRunStatus, updatedAt: string, error?: string | null): void {
+    this.db
+      .prepare(
+        `
       UPDATE chat_runs
          SET status = ?, updated_at = ?, error = COALESCE(?, error)
        WHERE id = ? AND status NOT IN ('completed', 'failed', 'canceled')
-    `).run(status, updatedAt, error ?? null, runId);
+    `,
+      )
+      .run(status, updatedAt, error ?? null, runId);
   }
 
   private completeRun(run: ChatRun, payload: Record<string, unknown>, at: string): void {
@@ -705,30 +829,34 @@ export class ChatStore {
     const content = payloadContent(payload);
     if (!content) throw Object.assign(new Error('complete_content_required'), { statusCode: 400 });
     const messageId = crypto.randomUUID();
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT INTO chat_messages (
         id, conversation_id, kind, sender_kind, sender_ref, sender_display_name,
         content, mentioned_agent_refs, run_id, created_at
       ) VALUES (?, ?, 'assistant', 'agent', ?, ?, ?, '[]', ?, ?)
-    `).run(
-      messageId,
-      fresh.conversationId,
-      fresh.targetAgentRef,
-      fresh.targetAgentRef,
-      content,
-      fresh.id,
-      at,
-    );
-    this.db.prepare(`
+    `,
+      )
+      .run(messageId, fresh.conversationId, fresh.targetAgentRef, fresh.targetAgentRef, content, fresh.id, at);
+    this.db
+      .prepare(
+        `
       UPDATE chat_runs
          SET status = 'completed', updated_at = ?, completed_at = ?, final_message_id = ?
        WHERE id = ?
-    `).run(at, at, messageId, fresh.id);
-    this.db.prepare(`
+    `,
+      )
+      .run(at, at, messageId, fresh.id);
+    this.db
+      .prepare(
+        `
       UPDATE chat_conversations
          SET updated_at = ?, last_message_at = ?
        WHERE id = ?
-    `).run(at, at, fresh.conversationId);
+    `,
+      )
+      .run(at, at, fresh.conversationId);
   }
 
   private recordFilesFromPayload(run: ChatRun, payload: Record<string, unknown>, at: string): void {
@@ -738,111 +866,138 @@ export class ChatStore {
       const file = raw as Record<string, unknown>;
       const name = typeof file.name === 'string' ? file.name.trim() : '';
       if (!name) continue;
-      const mimeType = typeof file.mimeType === 'string'
-        ? file.mimeType
-        : typeof file.mime_type === 'string' ? file.mime_type : 'application/octet-stream';
-      const sizeBytes = typeof file.sizeBytes === 'number'
-        ? file.sizeBytes
-        : typeof file.size_bytes === 'number' ? file.size_bytes : null;
+      const mimeType =
+        typeof file.mimeType === 'string'
+          ? file.mimeType
+          : typeof file.mime_type === 'string'
+            ? file.mime_type
+            : 'application/octet-stream';
+      const sizeBytes =
+        typeof file.sizeBytes === 'number'
+          ? file.sizeBytes
+          : typeof file.size_bytes === 'number'
+            ? file.size_bytes
+            : null;
       const storageKey = typeof file.storageKey === 'string' ? file.storageKey : undefined;
-      this.createFileUnchecked({
-        conversationId: run.conversationId,
-        runId: run.id,
-        name,
-        mimeType,
-        sizeBytes,
-        storageKey,
-        createdBy: run.targetAgentRef,
-      }, at);
+      this.createFileUnchecked(
+        {
+          conversationId: run.conversationId,
+          runId: run.id,
+          name,
+          mimeType,
+          sizeBytes,
+          storageKey,
+          createdBy: run.targetAgentRef,
+        },
+        at,
+      );
     }
   }
 
   private createFileUnchecked(input: CreateFileInput, at: string): ChatFile {
     const storageKey = normalizeStorageKey(input.storageKey);
     const id = crypto.randomUUID();
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT INTO chat_files (
         id, conversation_id, message_id, run_id, name, mime_type,
         size_bytes, storage_key, created_by, created_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      id,
-      input.conversationId,
-      input.messageId || null,
-      input.runId || null,
-      input.name.trim(),
-      input.mimeType || 'application/octet-stream',
-      input.sizeBytes ?? null,
-      storageKey,
-      input.createdBy,
-      at,
-    );
+    `,
+      )
+      .run(
+        id,
+        input.conversationId,
+        input.messageId || null,
+        input.runId || null,
+        input.name.trim(),
+        input.mimeType || 'application/octet-stream',
+        input.sizeBytes ?? null,
+        storageKey,
+        input.createdBy,
+        at,
+      );
     const row = this.db.prepare('SELECT * FROM chat_files WHERE id = ?').get(id) as RawFileRow;
     return rowToFile(row);
   }
 
   private assertParticipant(conversationId: string, kind: ChatParticipantKind, ref: string): void {
-    const exists = this.db.prepare(`
+    const exists = this.db
+      .prepare(
+        `
       SELECT 1 FROM chat_participants
        WHERE conversation_id = ? AND kind = ? AND ref = ?
-    `).get(conversationId, kind, ref);
+    `,
+      )
+      .get(conversationId, kind, ref);
     if (exists) return;
     const conv = this.db.prepare('SELECT 1 FROM chat_conversations WHERE id = ?').get(conversationId);
     if (!conv) throw new ChatNotFoundError(conversationId);
     throw new ChatForbiddenError();
   }
 
-  private getParticipant(
-    conversationId: string,
-    kind: ChatParticipantKind,
-    ref: string,
-  ): ChatParticipant | null {
-    const row = this.db.prepare(`
+  private getParticipant(conversationId: string, kind: ChatParticipantKind, ref: string): ChatParticipant | null {
+    const row = this.db
+      .prepare(
+        `
       SELECT * FROM chat_participants WHERE conversation_id = ? AND kind = ? AND ref = ?
-    `).get(conversationId, kind, ref) as RawParticipantRow | undefined;
+    `,
+      )
+      .get(conversationId, kind, ref) as RawParticipantRow | undefined;
     return row ? rowToParticipant(row) : null;
   }
 
   private listParticipantsUnchecked(conversationId: string): ChatParticipant[] {
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(
+        `
       SELECT * FROM chat_participants WHERE conversation_id = ? ORDER BY kind DESC, added_at ASC
-    `).all(conversationId) as RawParticipantRow[];
+    `,
+      )
+      .all(conversationId) as RawParticipantRow[];
     return rows.map(rowToParticipant);
   }
 
-  private getMessage(id: string): ChatMessage | null {
-    const row = this.db.prepare('SELECT * FROM chat_messages WHERE id = ?')
-      .get(id) as RawMessageRow | undefined;
+  getMessage(id: string): ChatMessage | null {
+    const row = this.db.prepare('SELECT * FROM chat_messages WHERE id = ?').get(id) as RawMessageRow | undefined;
     return row ? rowToMessage(row) : null;
   }
 
   private getReadState(conversationId: string, userRef: string): ChatReadState | null {
-    const row = this.db.prepare(`
+    const row = this.db
+      .prepare(
+        `
       SELECT * FROM chat_read_state WHERE conversation_id = ? AND user_ref = ?
-    `).get(conversationId, userRef) as RawReadStateRow | undefined;
+    `,
+      )
+      .get(conversationId, userRef) as RawReadStateRow | undefined;
     return row ? rowToReadState(row) : null;
   }
 
-  private markReadUnchecked(
-    conversationId: string,
-    userRef: string,
-    messageId: string | null,
-    at: string,
-  ): void {
-    this.db.prepare(`
+  private markReadUnchecked(conversationId: string, userRef: string, messageId: string | null, at: string): void {
+    this.db
+      .prepare(
+        `
       INSERT INTO chat_read_state (conversation_id, user_ref, last_read_message_id, last_read_at)
       VALUES (?, ?, ?, ?)
       ON CONFLICT(conversation_id, user_ref) DO UPDATE SET
         last_read_message_id = excluded.last_read_message_id,
         last_read_at = excluded.last_read_at
-    `).run(conversationId, userRef, messageId, at);
+    `,
+      )
+      .run(conversationId, userRef, messageId, at);
   }
 
   private summaryFromConversation(row: RawConversationRow, userRef: string): ChatConversationSummary {
     const conversation = rowToConversation(row);
-    const lastRow = this.db.prepare(`
+    const lastRow = this.db
+      .prepare(
+        `
       SELECT * FROM chat_messages WHERE conversation_id = ? ORDER BY rowid DESC LIMIT 1
-    `).get(row.id) as RawMessageRow | undefined;
+    `,
+      )
+      .get(row.id) as RawMessageRow | undefined;
     const read = this.getReadState(row.id, userRef);
     const unreadCount = countUnread(this.db, row.id, read?.lastReadMessageId || null, userRef);
     return {
@@ -888,6 +1043,8 @@ function rowToMessage(row: RawMessageRow): ChatMessage {
     content: row.content,
     mentionedAgentRefs: parseStringArray(row.mentioned_agent_refs),
     runId: row.run_id,
+    ...(row.reply_to ? { replyTo: row.reply_to } : {}),
+    ...(row.sender_session_id ? { senderSessionId: row.sender_session_id } : {}),
     createdAt: row.created_at,
   };
 }
@@ -915,6 +1072,9 @@ function rowToRun(row: RawRunRow): ChatRun {
     completedAt: row.completed_at,
     error: row.error,
     finalMessageId: row.final_message_id,
+    idempotencyOwner: row.idempotency_owner || null,
+    idempotencyKey: row.idempotency_key || null,
+    presentation: row.presentation_json ? (parseObject(row.presentation_json) as unknown as ChatRunPresentation) : null,
   };
 }
 
@@ -1015,9 +1175,7 @@ function parseStringArray(raw: string): string[] {
 function parseObject(raw: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : {};
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
   } catch {
     return {};
   }
@@ -1026,13 +1184,14 @@ function parseObject(raw: string): Record<string, unknown> {
 function payloadStatus(payload: Record<string, unknown>): ChatRunStatus | null {
   const status = payload.status;
   if (
-    status === 'queued'
-    || status === 'running'
-    || status === 'waiting_user'
-    || status === 'completed'
-    || status === 'failed'
-    || status === 'canceled'
-  ) return status;
+    status === 'queued' ||
+    status === 'running' ||
+    status === 'waiting_user' ||
+    status === 'completed' ||
+    status === 'failed' ||
+    status === 'canceled'
+  )
+    return status;
   return null;
 }
 
@@ -1067,19 +1226,27 @@ function countUnread(
   userRef: string,
 ): number {
   if (!lastReadMessageId) {
-    const row = db.prepare(`
+    const row = db
+      .prepare(
+        `
       SELECT COUNT(*) AS count FROM chat_messages
        WHERE conversation_id = ? AND NOT (sender_kind = 'user' AND sender_ref = ?)
-    `).get(conversationId, userRef) as { count: number };
+    `,
+      )
+      .get(conversationId, userRef) as { count: number };
     return row.count;
   }
-  const row = db.prepare(`
+  const row = db
+    .prepare(
+      `
     SELECT COUNT(*) AS count FROM chat_messages
      WHERE conversation_id = ?
        AND rowid > COALESCE((
          SELECT rowid FROM chat_messages WHERE conversation_id = ? AND id = ?
        ), 0)
        AND NOT (sender_kind = 'user' AND sender_ref = ?)
-  `).get(conversationId, conversationId, lastReadMessageId, userRef) as { count: number };
+  `,
+    )
+    .get(conversationId, conversationId, lastReadMessageId, userRef) as { count: number };
   return row.count;
 }

--- a/packages/server/src/chat/chat-types.ts
+++ b/packages/server/src/chat/chat-types.ts
@@ -3,6 +3,15 @@ export type ChatParticipantKind = 'user' | 'agent';
 export type ChatMessageKind = 'user' | 'assistant' | 'system';
 export type ChatRunStatus = 'queued' | 'running' | 'waiting_user' | 'completed' | 'failed' | 'canceled';
 export type ChatRunEventKind = 'state' | 'complete' | 'question' | 'file' | 'log' | 'error';
+export interface ChatRunPresentation {
+  mode: 'child-direct' | 'origin-proxy';
+  chatId: string;
+  targetAgentRef: string;
+  requestedBy: string;
+  originBotName?: string;
+  wakeLead?: boolean;
+  teamName?: string;
+}
 
 export interface ChatConversation {
   id: string;
@@ -40,6 +49,8 @@ export interface ChatMessage {
   content: string;
   mentionedAgentRefs: string[];
   runId: string | null;
+  replyTo?: string;
+  senderSessionId?: string;
   createdAt: string;
 }
 
@@ -69,6 +80,9 @@ export interface ChatRun {
   completedAt: string | null;
   error: string | null;
   finalMessageId: string | null;
+  idempotencyOwner?: string | null;
+  idempotencyKey?: string | null;
+  presentation?: ChatRunPresentation | null;
 }
 
 export interface ChatRunEvent {
@@ -92,3 +106,9 @@ export interface ChatFile {
   createdBy: string;
   createdAt: string;
 }
+
+export type ChatLiveEvent =
+  | { type: 'message.created'; conversationId: string; message: ChatMessage }
+  | { type: 'run.updated'; conversationId: string; run: ChatRun }
+  | { type: 'run.event'; conversationId: string; runId: string; event: ChatRunEvent }
+  | { type: 'file.created'; conversationId: string; file: ChatFile };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,6 +11,11 @@ import { SkillStore } from './skills/skill-store.js';
 import { AgentStore } from './agents/agent-store.js';
 import { InboxStore } from './agents/inbox-store.js';
 import { ChatStore } from './chat/chat-store.js';
+import type { ChatRun, ChatRunEvent, ChatRunPresentation } from './chat/chat-types.js';
+import { ChatEventHub } from './chat/chat-events.js';
+import { BusEventHub } from './bus/event-hub.js';
+import * as messageRoutes from './bus/message-routes.js';
+import { MessageStore } from './bus/message-store.js';
 import { T5tStore } from './t5t/t5t-store.js';
 import { loadT5tFolderIds } from './t5t/folder-ids.js';
 import { AuditLog, createDefaultAuditLog, type AuditOp } from './observability/audit-log.js';
@@ -59,6 +64,7 @@ export interface ServerHandle {
   skillStore: SkillStore;
   agentStore: AgentStore;
   inboxStore: InboxStore;
+  messageStore: MessageStore;
   chatStore: ChatStore;
   t5tStore: T5tStore;
   auditLog: AuditLog;
@@ -94,7 +100,10 @@ function readBody(req: http.IncomingMessage): Promise<string> {
     req.on('data', (chunk: Buffer) => {
       if (tooLarge) return;
       total += chunk.length;
-      if (total > MAX_BODY_SIZE) { tooLarge = true; return; }
+      if (total > MAX_BODY_SIZE) {
+        tooLarge = true;
+        return;
+      }
       chunks.push(chunk);
     });
     req.on('end', () => {
@@ -113,7 +122,10 @@ function readRawBody(req: http.IncomingMessage): Promise<Buffer> {
     req.on('data', (chunk: Buffer) => {
       if (tooLarge) return;
       total += chunk.length;
-      if (total > MAX_BODY_SIZE) { tooLarge = true; return; }
+      if (total > MAX_BODY_SIZE) {
+        tooLarge = true;
+        return;
+      }
       chunks.push(chunk);
     });
     req.on('end', () => {
@@ -173,9 +185,7 @@ function serveStaticFile(
 
   const ext = path.extname(absPath).toLowerCase();
   const mime = STATIC_MIME[ext] || 'application/octet-stream';
-  const cacheControl = isImmutableAsset
-    ? 'public, max-age=31536000, immutable'
-    : 'no-cache';
+  const cacheControl = isImmutableAsset ? 'public, max-age=31536000, immutable' : 'no-cache';
   res.writeHead(200, {
     'Content-Type': mime,
     'Content-Length': stat.size,
@@ -196,10 +206,7 @@ function serveStaticFile(
  * should treat this as "no UI configured / not eligible" and continue with
  * normal API routing.
  */
-function tryServeStatic(
-  res: http.ServerResponse,
-  pathname: string,
-): boolean {
+function tryServeStatic(res: http.ServerResponse, pathname: string): boolean {
   if (hasTraversal(pathname)) {
     jsonResponse(res, 400, { error: 'bad_path' });
     return true;
@@ -222,8 +229,10 @@ function tryServeStatic(
   const cliRoot = path.join(STATIC_DIR, 'cli');
   const installRoot = path.join(STATIC_DIR, 'install');
   if (
-    resolved === cliRoot || resolved.startsWith(cliRoot + path.sep)
-    || resolved === installRoot || resolved.startsWith(installRoot + path.sep)
+    resolved === cliRoot ||
+    resolved.startsWith(cliRoot + path.sep) ||
+    resolved === installRoot ||
+    resolved.startsWith(installRoot + path.sep)
   ) {
     jsonResponse(res, 404, { error: 'not_found' });
     return true;
@@ -257,6 +266,7 @@ async function deliverChatRunToAgent(
     prompt: string;
     engine?: string | null;
     model?: string | null;
+    presentation?: ChatRunPresentation | null;
   },
 ): Promise<void> {
   const agent = agentStore.getByName(run.targetAgentRef);
@@ -275,6 +285,7 @@ async function deliverChatRunToAgent(
       model: run.model,
       eventCallbackUrl: `${corePublicBaseUrl()}/api/chat/runs/${encodeURIComponent(run.id)}/events`,
       userId: 'metabot-core-chat',
+      ...(run.presentation ? { presentation: run.presentation } : {}),
     };
     const message = inboxStore.enqueue({
       targetBot: run.targetAgentRef,
@@ -287,9 +298,41 @@ async function deliverChatRunToAgent(
         request,
       }),
     });
-    logger.info({ runId: run.id, targetAgentRef: run.targetAgentRef, inboxMessageId: message.id }, 'chat run enqueued for bridge relay');
+    logger.info(
+      { runId: run.id, targetAgentRef: run.targetAgentRef, inboxMessageId: message.id },
+      'chat run enqueued for bridge relay',
+    );
   } catch (err) {
     logger.warn({ err, runId: run.id, targetAgentRef: run.targetAgentRef }, 'chat run delivery failed');
+  }
+}
+
+function deliverChatRunProjectionToOrigin(
+  inboxStore: InboxStore,
+  logger: Logger,
+  run: ChatRun,
+  event: ChatRunEvent,
+): void {
+  const presentation = run.presentation;
+  if (presentation?.mode !== 'origin-proxy' || !presentation.originBotName || !presentation.chatId) return;
+  try {
+    inboxStore.enqueue({
+      targetBot: presentation.originBotName,
+      chatId: `core-chat-proxy:${run.id}`,
+      fromBot: run.targetAgentRef,
+      fromOwner: 'metabot-core',
+      fromCredentialId: 'metabot-core-system',
+      content: JSON.stringify({
+        type: 'core-chat-proxy',
+        runId: run.id,
+        targetAgentRef: run.targetAgentRef,
+        originChatId: presentation.chatId,
+        wakeLead: presentation.wakeLead !== false,
+        event,
+      }),
+    });
+  } catch (err) {
+    logger.warn({ err, runId: run.id }, 'core chat run projection enqueue failed');
   }
 }
 
@@ -314,7 +357,12 @@ function deliverChatControlToAgent(
       content: JSON.stringify({ type: 'core-chat-control', ...control }),
     });
     logger.info(
-      { runId: control.runId, action: control.action, targetAgentRef: control.targetAgentRef, inboxMessageId: message.id },
+      {
+        runId: control.runId,
+        action: control.action,
+        targetAgentRef: control.targetAgentRef,
+        inboxMessageId: message.id,
+      },
       'chat control enqueued for bridge relay',
     );
   } catch (err) {
@@ -372,11 +420,7 @@ function isWebWritableRoute(method: string, pathname: string): boolean {
   if (/^\/api\/chat\/runs\/[^/]+\/(answer|cancel)$/.test(pathname) && method === 'POST') return true;
   // Project kill (soft-kill via append-only doc) — owner-auth enforced at the
   // route layer. Matches the shape `POST /api/t5t/projects/:slug/kill`.
-  if (
-    method === 'POST'
-    && pathname.startsWith('/api/t5t/projects/')
-    && pathname.endsWith('/kill')
-  ) return true;
+  if (method === 'POST' && pathname.startsWith('/api/t5t/projects/') && pathname.endsWith('/kill')) return true;
   return false;
 }
 
@@ -450,6 +494,9 @@ function deriveOp(method: string, pathname: string): AuditOp | string {
   if (pathname === '/api/agents/heartbeat' && method === 'POST') return 'heartbeat';
   if (pathname === '/api/agents/bulk' && method === 'POST') return 'register';
   if (pathname === '/api/agents' && method === 'POST') return 'register';
+  if (pathname === '/api/agents/search' && method === 'GET') return 'search';
+  if (pathname === '/api/messages' && method === 'POST') return 'message';
+  if (pathname.startsWith('/api/messages/')) return method === 'GET' ? 'list' : 'message';
   if (pathname === '/api/whoami' && method === 'GET') return 'whoami';
   if (pathname.endsWith('/visibility') && method === 'PATCH') return 'visibility';
   // T5T-specific ops (must precede the generic POST/GET fallbacks).
@@ -465,11 +512,7 @@ function deriveOp(method: string, pathname: string): AuditOp | string {
   if (pathname === '/api/t5t/cli/kill' && method === 'POST') return 'kill';
   if (pathname === '/api/t5t/cli/reopen' && method === 'POST') return 'reopen';
   if (pathname === '/api/t5t/cli/delete' && method === 'POST') return 'delete';
-  if (
-    method === 'POST'
-    && pathname.startsWith('/api/t5t/projects/')
-    && pathname.endsWith('/kill')
-  ) return 'kill';
+  if (method === 'POST' && pathname.startsWith('/api/t5t/projects/') && pathname.endsWith('/kill')) return 'kill';
   if (pathname === '/api/t5t/board' && method === 'GET') return 'list';
   if (pathname.startsWith('/api/t5t/projects/') && method === 'GET') return 'get';
   if (pathname === '/api/web/issue-token' && method === 'POST') return 'issue';
@@ -490,10 +533,11 @@ function deriveOp(method: string, pathname: string): AuditOp | string {
   if (method === 'PATCH' || method === 'PUT') return 'update';
   if (method === 'DELETE') return 'delete';
   if (method === 'GET') {
-    const isCollection = pathname === '/api/memory/folders'
-      || pathname === '/api/memory/documents'
-      || pathname === '/api/skills'
-      || pathname === '/api/agents';
+    const isCollection =
+      pathname === '/api/memory/folders' ||
+      pathname === '/api/memory/documents' ||
+      pathname === '/api/skills' ||
+      pathname === '/api/agents';
     return isCollection ? 'list' : 'get';
   }
   return method.toLowerCase();
@@ -515,11 +559,10 @@ export function startServer(options: ServerOptions): ServerHandle {
   const agentStore = new AgentStore(db, logger.child({ module: 'agents' }));
   const inboxStore = new InboxStore(db, logger.child({ module: 'inbox' }));
   const chatStore = new ChatStore(db, logger.child({ module: 'chat' }));
-  const t5tFolderIds = loadT5tFolderIds(
-    process.env,
-    memoryStore,
-    logger.child({ module: 't5t-folders' }),
-  );
+  const messageStore = new MessageStore(db, logger.child({ module: 'messages' }));
+  const busEventHub = new BusEventHub();
+  const chatEventHub = new ChatEventHub();
+  const t5tFolderIds = loadT5tFolderIds(process.env, memoryStore, logger.child({ module: 't5t-folders' }));
   const t5tStore = new T5tStore(memoryStore, t5tFolderIds, logger.child({ module: 't5t' }));
   const auditLog = createDefaultAuditLog(dataDir, logger);
 
@@ -527,13 +570,18 @@ export function startServer(options: ServerOptions): ServerHandle {
   const tokenFile = path.join(dataDir, 'admin-bootstrap-token.txt');
   const bootstrapToken = credentialsStore.bootstrapAdmin(tokenFile);
   if (bootstrapToken) {
-    logger.warn({ tokenFile }, 'ADMIN TOKEN BOOTSTRAPPED — stored in the protected token file; token value is not logged');
+    logger.warn(
+      { tokenFile },
+      'ADMIN TOKEN BOOTSTRAPPED — stored in the protected token file; token value is not logged',
+    );
   }
 
   const startedAt = Date.now();
   const chatDeps = {
     chat: chatStore,
     agents: agentStore,
+    events: chatEventHub,
+    busEvents: busEventHub,
     deliverRun: (run: {
       id: string;
       conversationId: string;
@@ -542,6 +590,7 @@ export function startServer(options: ServerOptions): ServerHandle {
       prompt: string;
       engine?: string | null;
       model?: string | null;
+      presentation?: ChatRunPresentation | null;
     }) => {
       void deliverChatRunToAgent(agentStore, inboxStore, logger, run);
     },
@@ -552,6 +601,15 @@ export function startServer(options: ServerOptions): ServerHandle {
       toolUseId?: string;
       answer?: string;
     }) => deliverChatControlToAgent(inboxStore, logger, control),
+    onRunEvent: (run: ChatRun, event: ChatRunEvent) => deliverChatRunProjectionToOrigin(inboxStore, logger, run, event),
+  };
+  const messageDeps = {
+    agents: agentStore,
+    messages: messageStore,
+    chat: chatStore,
+    events: busEventHub,
+    deliverRun: chatDeps.deliverRun,
+    onRunEvent: chatDeps.onRunEvent,
   };
 
   const server = http.createServer(async (req, res) => {
@@ -580,7 +638,9 @@ export function startServer(options: ServerOptions): ServerHandle {
             latencyMs: Date.now() - auditStart,
             ...(authSource ? { authSource } : {}),
           });
-        } catch { /* audit must never break the request */ }
+        } catch {
+          /* audit must never break the request */
+        }
       });
     }
 
@@ -601,8 +661,7 @@ export function startServer(options: ServerOptions): ServerHandle {
     // when you intentionally self-distribute and have confirmed your build
     // embeds no secrets (see METABOT_PACKAGE_DEFAULT_ENV_FILE in pack scripts).
     const publicDistribution =
-      process.env.METABOT_PUBLIC_DISTRIBUTION === '1'
-      || process.env.METABOT_PUBLIC_DISTRIBUTION === 'true';
+      process.env.METABOT_PUBLIC_DISTRIBUTION === '1' || process.env.METABOT_PUBLIC_DISTRIBUTION === 'true';
     const distributionAuthorized = (): boolean =>
       publicDistribution || !isAuthFailure(authenticate(req, credentialsStore));
 
@@ -619,10 +678,7 @@ export function startServer(options: ServerOptions): ServerHandle {
     // The tarball + script are built by `packages/cli/scripts/pack.sh` into
     // `packages/server/static/cli/`. Tokens are user-supplied at install time,
     // not embedded.
-    if (
-      (method === 'GET' || method === 'HEAD')
-      && (distPath === '/cli/install.sh' || distPath === '/cli/latest.tgz')
-    ) {
+    if ((method === 'GET' || method === 'HEAD') && (distPath === '/cli/install.sh' || distPath === '/cli/latest.tgz')) {
       if (!distributionAuthorized()) {
         jsonResponse(res, 401, { error: 'unauthorized' });
         return;
@@ -650,8 +706,8 @@ export function startServer(options: ServerOptions): ServerHandle {
     // only does this when METABOT_PACKAGE_DEFAULT_ENV_FILE is explicitly set —
     // another reason these endpoints are not anonymous by default.
     if (
-      (method === 'GET' || method === 'HEAD')
-      && (distPath === '/install/install.sh' || distPath === '/install/latest.tgz')
+      (method === 'GET' || method === 'HEAD') &&
+      (distPath === '/install/install.sh' || distPath === '/install/latest.tgz')
     ) {
       if (!distributionAuthorized()) {
         jsonResponse(res, 401, { error: 'unauthorized' });
@@ -677,11 +733,11 @@ export function startServer(options: ServerOptions): ServerHandle {
     const isUiHost = !uiHost || reqHost === uiHost;
 
     if (
-      isUiHost
-      && method === 'GET'
-      && !pathname.startsWith('/api/')
-      && !pathname.startsWith('/admin/')
-      && pathname !== '/health'
+      isUiHost &&
+      method === 'GET' &&
+      !pathname.startsWith('/api/') &&
+      !pathname.startsWith('/admin/') &&
+      pathname !== '/health'
     ) {
       try {
         if (tryServeStatic(res, pathname)) return;
@@ -733,9 +789,10 @@ export function startServer(options: ServerOptions): ServerHandle {
       const allowedEmails = options.uiAllowedEmails || [];
       const hasBearer = extractBearer(req) !== null;
       const webIdentityEnabled = allowedEmails.length > 0;
-      const auth = (!hasBearer && webIdentityEnabled && req.headers['x-forwarded-email'])
-        ? authenticateWeb(req, allowedEmails)
-        : authenticate(req, credentialsStore);
+      const auth =
+        !hasBearer && webIdentityEnabled && req.headers['x-forwarded-email']
+          ? authenticateWeb(req, allowedEmails)
+          : authenticate(req, credentialsStore);
       if (isAuthFailure(auth)) {
         jsonResponse(res, auth.status, { error: auth.error });
         return;
@@ -752,11 +809,7 @@ export function startServer(options: ServerOptions): ServerHandle {
       // were reached, role='member' + empty writableNamespaces would still
       // reject Memory/Skills writes — T5T uses an internal admin cred via
       // T5tStore and gates ownership at the route layer.
-      if (
-        cred.authSource === 'web'
-        && !isWebReadableRoute(method, pathname)
-        && !isWebWritableRoute(method, pathname)
-      ) {
+      if (cred.authSource === 'web' && !isWebReadableRoute(method, pathname) && !isWebWritableRoute(method, pathname)) {
         jsonResponse(res, 404, { error: 'not_found' });
         return;
       }
@@ -902,6 +955,45 @@ export function startServer(options: ServerOptions): ServerHandle {
         return jsonResult(res, agentRoutes.removeAgent(agentStore, botName, cred));
       }
 
+      // ---- Minimal durable Agent Bus protocol ----
+      if (pathname === '/api/messages' && method === 'POST') {
+        const body = await parseJsonBody(req);
+        return jsonResult(res, messageRoutes.sendMessage(messageDeps, body, cred));
+      }
+      if (pathname === '/api/messages/sessions' && method === 'POST') {
+        const body = await parseJsonBody(req);
+        return jsonResult(res, messageRoutes.registerSession(messageDeps, body, cred));
+      }
+      if (pathname === '/api/messages/sessions' && method === 'GET') {
+        const ref = query.get('agentId') || query.get('agent') || '';
+        return jsonResult(res, messageRoutes.listSessions(messageDeps, ref, query, cred));
+      }
+      const messageAckMatch = pathname.match(/^\/api\/messages\/([^/]+)\/ack$/);
+      if (messageAckMatch && method === 'POST') {
+        return jsonResult(res, messageRoutes.ackMessage(messageDeps, decodeURIComponent(messageAckMatch[1]), cred));
+      }
+      if (pathname === '/api/messages/stream' && method === 'GET') {
+        const result = messageRoutes.streamMessages(messageDeps, query, req, res, cred);
+        if (result) return jsonResult(res, result);
+        return;
+      }
+      const agentSessionsMatch = pathname.match(/^\/api\/agents\/([^/]+)\/sessions$/);
+      if (agentSessionsMatch && method === 'GET') {
+        return jsonResult(
+          res,
+          agentRoutes.listAgentSessions(
+            agentStore,
+            messageStore,
+            decodeURIComponent(agentSessionsMatch[1]),
+            query,
+            cred,
+          ),
+        );
+      }
+      if (pathname === '/api/agents/search' && method === 'GET') {
+        return jsonResult(res, agentRoutes.searchAgents(agentStore, query, cred));
+      }
+
       // ---- Inbox routes (central agent-bus inbox for CLI users) ----
       // Match order: longer paths first so `/poll` doesn't hit the bare
       // `/api/inbox/:botName` enqueue match.
@@ -909,18 +1001,11 @@ export function startServer(options: ServerOptions): ServerHandle {
       if (inboxPollMatch && method === 'POST') {
         const botName = decodeURIComponent(inboxPollMatch[1]);
         // Long-poll: handler writes the response directly.
-        const body = await parseJsonBody(req).catch(() => ({} as Record<string, unknown>));
+        const body = await parseJsonBody(req).catch(() => ({}) as Record<string, unknown>);
         const chatIdQ = query.get('chatId');
-        const chatId = chatIdQ !== null
-          ? chatIdQ
-          : (typeof body.chatId === 'string' ? body.chatId : undefined);
-        const waitMs = inboxRoutes.parsePollWaitMs(
-          query.get('wait') ?? body.wait,
-        );
-        inboxRoutes.pollInbox(
-          { inbox: inboxStore, agents: agentStore },
-          { botName, chatId, waitMs, cred, req, res },
-        );
+        const chatId = chatIdQ !== null ? chatIdQ : typeof body.chatId === 'string' ? body.chatId : undefined;
+        const waitMs = inboxRoutes.parsePollWaitMs(query.get('wait') ?? body.wait);
+        inboxRoutes.pollInbox({ inbox: inboxStore, agents: agentStore }, { botName, chatId, waitMs, cred, req, res });
         return;
       }
       const inboxMatch = pathname.match(/^\/api\/inbox\/([^/]+)$/);
@@ -978,11 +1063,19 @@ export function startServer(options: ServerOptions): ServerHandle {
         const text = await voiceResp.text();
         let body: unknown = text;
         if (text) {
-          try { body = JSON.parse(text); } catch { /* keep raw */ }
+          try {
+            body = JSON.parse(text);
+          } catch {
+            /* keep raw */
+          }
         }
         if (!voiceResp.ok) {
           logger.warn({ status: voiceResp.status }, 'chat voice transcription proxy failed');
-          return jsonResponse(res, voiceResp.status, typeof body === 'object' && body ? body : { error: 'voice_transcribe_failed' });
+          return jsonResponse(
+            res,
+            voiceResp.status,
+            typeof body === 'object' && body ? body : { error: 'voice_transcribe_failed' },
+          );
         }
         return jsonResponse(res, 200, body);
       }
@@ -1161,6 +1254,7 @@ export function startServer(options: ServerOptions): ServerHandle {
     skillStore,
     agentStore,
     inboxStore,
+    messageStore,
     chatStore,
     t5tStore,
     auditLog,

--- a/packages/server/tests/message-routes.test.ts
+++ b/packages/server/tests/message-routes.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { call, startTestServer, type ServerKit } from './helpers.js';
+
+let kit: ServerKit | undefined;
+afterEach(async () => {
+  await kit?.cleanup();
+  kit = undefined;
+});
+
+async function issue(k: ServerKit, botName: string, ownerName = botName) {
+  const r = await call(k.baseUrl, 'POST', '/admin/credentials/issue', k.adminToken, {
+    botName,
+    ownerName,
+    role: 'member',
+  });
+  expect(r.status).toBe(201);
+  return { token: r.body.token as string, credentialId: r.body.credential.id as string };
+}
+
+describe('minimal message protocol', () => {
+  it('creates a logical session on first send and reuses it', async () => {
+    kit = await startTestServer('minimal-message');
+    const sender = await issue(kit, 'sender', 'sender@example.com');
+    const owner = await issue(kit, 'target-owner', 'target@example.com');
+    const rec = kit.handle.agentStore.register({
+      botName: 'target',
+      url: 'inbox:',
+      ownerCredentialId: owner.credentialId,
+      ownerName: 'target@example.com',
+    });
+    const first = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, { agentId: rec.id, message: 'hello' });
+    expect(first.status).toBe(202);
+    expect(first.body.sessionId).toEqual(expect.any(String));
+    const listed = await call(kit.baseUrl, 'GET', `/api/agents/${encodeURIComponent(rec.id)}/sessions`, sender.token);
+    expect(listed.status).toBe(200);
+    expect(listed.body.sessions).toHaveLength(1);
+    const logicalSession = listed.body.sessions[0] as { id: string; roomId: string };
+    const providerMirror = await call(kit.baseUrl, 'POST', '/api/messages/sessions', owner.token, {
+      agentId: rec.id,
+      sessionId: 'bridge-local-session-id',
+      roomId: logicalSession.roomId,
+      provider: 'codex',
+      providerSessionId: 'codex-thread-id',
+      status: 'resumable',
+      transportChatId: 'oc_target_chat',
+      transportPlatform: 'feishu',
+    });
+    expect(providerMirror.status).toBe(201);
+    expect(providerMirror.body.session).toMatchObject({
+      id: first.body.sessionId,
+      provider: 'codex',
+      providerSessionId: 'codex-thread-id',
+      status: 'resumable',
+      transportChatId: 'oc_target_chat',
+      transportPlatform: 'feishu',
+    });
+    expect(kit.handle.messageStore.listSessions(rec.id).total).toBe(1);
+    const second = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: 'target',
+      sessionId: first.body.sessionId,
+      message: 'again',
+    });
+    expect(second.status).toBe(202);
+    expect(second.body.sessionId).toBe(first.body.sessionId);
+    expect(kit.handle.chatStore.getRun(String(second.body.runId))?.presentation).toEqual({
+      mode: 'child-direct',
+      chatId: 'oc_target_chat',
+      targetAgentRef: 'target',
+      requestedBy: 'sender',
+    });
+
+    const implicit = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: 'target',
+      sessionId: first.body.sessionId,
+      message: 'background only',
+      presentationMode: 'implicit',
+    });
+    expect(implicit.status).toBe(202);
+    expect(kit.handle.chatStore.getRun(String(implicit.body.runId))?.presentation).toBeNull();
+  });
+
+  it('uses the ChatStore message as the canonical record', async () => {
+    kit = await startTestServer('minimal-message-canonical-record');
+    const sender = await issue(kit, 'sender', 'sender@example.com');
+    const owner = await issue(kit, 'target-owner', 'target@example.com');
+    const rec = kit.handle.agentStore.register({
+      botName: 'target',
+      url: 'inbox:',
+      ownerCredentialId: owner.credentialId,
+      ownerName: 'target@example.com',
+    });
+
+    const sent = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: rec.id,
+      message: 'canonical message',
+      replyTo: 'prior-message',
+      senderSessionId: 'sender-session',
+      idempotencyKey: 'canonical-key',
+    });
+    expect(sent.status).toBe(202);
+    const message = kit.handle.chatStore.getMessage(String(sent.body.messageId));
+    expect(message).toMatchObject({
+      id: sent.body.messageId,
+      content: 'canonical message',
+      replyTo: 'prior-message',
+      senderSessionId: 'sender-session',
+    });
+    expect((kit.handle.db.prepare('SELECT COUNT(*) AS count FROM bus_messages').get() as { count: number }).count).toBe(
+      0,
+    );
+
+    const replay = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: rec.id,
+      sessionId: sent.body.sessionId,
+      message: 'canonical message',
+      idempotencyKey: 'canonical-key',
+    });
+    expect(replay.status).toBe(202);
+    expect(replay.body).toMatchObject({
+      idempotentReplay: true,
+      messageId: sent.body.messageId,
+      runId: sent.body.runId,
+      sessionId: sent.body.sessionId,
+    });
+    expect((kit.handle.db.prepare('SELECT COUNT(*) AS count FROM chat_runs').get() as { count: number }).count).toBe(1);
+
+    const ack = await call(
+      kit.baseUrl,
+      'POST',
+      `/api/messages/${encodeURIComponent(String(sent.body.messageId))}/ack`,
+      owner.token,
+    );
+    expect(ack.status).toBe(200);
+    expect(ack.body).toMatchObject({ canonical: true, deliveryStatus: 'queued' });
+    expect(ack.body.message).toMatchObject({ status: 'pending', text: 'canonical message' });
+  });
+
+  it('reuses a provisioning session instead of creating a second context', async () => {
+    kit = await startTestServer('minimal-message-provisioning');
+    const sender = await issue(kit, 'sender', 'sender@example.com');
+    const owner = await issue(kit, 'target-owner', 'target@example.com');
+    const rec = kit.handle.agentStore.register({
+      botName: 'target',
+      url: 'inbox:',
+      ownerCredentialId: owner.credentialId,
+      ownerName: 'target@example.com',
+    });
+
+    const first = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: rec.id,
+      message: 'first',
+    });
+    const second = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: rec.id,
+      message: 'second',
+    });
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202);
+    expect(second.body.sessionId).toBe(first.body.sessionId);
+    expect(kit.handle.messageStore.listSessions(rec.id).total).toBe(1);
+  });
+
+  it('serializes concurrent idempotent sends into one run', async () => {
+    kit = await startTestServer('minimal-message-concurrent-idempotency');
+    const sender = await issue(kit, 'sender', 'sender@example.com');
+    const owner = await issue(kit, 'target-owner', 'target@example.com');
+    const rec = kit.handle.agentStore.register({
+      botName: 'target',
+      url: 'inbox:',
+      ownerCredentialId: owner.credentialId,
+      ownerName: 'target@example.com',
+    });
+
+    const results = await Promise.all(
+      [1, 2].map(() =>
+        call(kit!.baseUrl, 'POST', '/api/messages', sender.token, {
+          agentId: rec.id,
+          message: 'retry safely',
+          idempotencyKey: 'concurrent-key',
+        }),
+      ),
+    );
+    expect(results.every((result) => result.status === 202)).toBe(true);
+    expect(results[0]!.body.runId).toBe(results[1]!.body.runId);
+    expect((kit.handle.db.prepare('SELECT COUNT(*) AS count FROM chat_runs').get() as { count: number }).count).toBe(1);
+  });
+
+  it('forwards target-session presentation to the bridge relay payload', async () => {
+    kit = await startTestServer('minimal-message-relay-presentation');
+    const sender = await issue(kit, 'sender', 'sender@example.com');
+    const owner = await issue(kit, 'target-owner', 'target@example.com');
+    const rec = kit.handle.agentStore.register({
+      botName: 'target',
+      url: 'inbox:',
+      ownerCredentialId: owner.credentialId,
+      ownerName: 'target@example.com',
+    });
+    const seed = await call(kit.baseUrl, 'POST', '/api/messages/sessions', owner.token, {
+      agentId: rec.id,
+      sessionId: 'target-feishu-session',
+      provider: 'codex',
+      providerSessionId: 'codex-thread-id',
+      status: 'resumable',
+      transportChatId: 'oc_target_chat',
+      transportPlatform: 'feishu',
+    });
+    expect(seed.status).toBe(201);
+
+    const sent = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: rec.id,
+      sessionId: 'target-feishu-session',
+      message: 'hello target chat',
+    });
+    expect(sent.status).toBe(202);
+    const relay = kit.handle.inboxStore.peek('target', undefined, 1)[0];
+    expect(relay).toBeDefined();
+    const payload = JSON.parse(relay!.content) as { request: { presentation?: unknown } };
+    expect(payload.request.presentation).toEqual({
+      mode: 'child-direct',
+      chatId: 'oc_target_chat',
+      targetAgentRef: 'target',
+      requestedBy: 'sender',
+    });
+  });
+
+  it('stores origin-proxy presentation and relays run events back to the sender bridge', async () => {
+    kit = await startTestServer('minimal-message-origin-proxy');
+    const sender = await issue(kit, 'sender', 'sender@example.com');
+    const owner = await issue(kit, 'target-owner', 'target@example.com');
+    kit.handle.agentStore.register({
+      botName: 'target',
+      url: 'inbox:',
+      ownerCredentialId: owner.credentialId,
+      ownerName: 'target@example.com',
+    });
+
+    const sent = await call(kit.baseUrl, 'POST', '/api/messages', sender.token, {
+      agentId: 'target',
+      message: 'run remotely',
+      presentationMode: 'origin-proxy',
+      originChatId: 'oc_origin_chat',
+      originBotName: 'sender',
+    });
+    expect(sent.status).toBe(202);
+    expect(kit.handle.chatStore.getRun(String(sent.body.runId))?.presentation).toEqual({
+      mode: 'origin-proxy',
+      chatId: 'oc_origin_chat',
+      targetAgentRef: 'target',
+      requestedBy: 'sender',
+      originBotName: 'sender',
+      wakeLead: true,
+    });
+
+    const event = await call(kit.baseUrl, 'POST', `/api/chat/runs/${sent.body.runId}/events`, owner.token, {
+      seq: 1,
+      kind: 'complete',
+      payload: { content: 'remote result', state: { responseText: 'remote result', toolCalls: [] } },
+    });
+    expect(event.status).toBe(200);
+    const projection = kit.handle.inboxStore.peek('sender', `core-chat-proxy:${sent.body.runId}`, 1)[0];
+    expect(projection).toBeDefined();
+    expect(JSON.parse(projection!.content)).toMatchObject({
+      type: 'core-chat-proxy',
+      targetAgentRef: 'target',
+      originChatId: 'oc_origin_chat',
+      wakeLead: true,
+      event: { seq: 1, kind: 'complete' },
+    });
+  });
+
+  it('allows an admin to project through a registered origin bot', async () => {
+    kit = await startTestServer('minimal-message-admin-origin-proxy');
+    const target = await issue(kit, 'target-owner', 'target@example.com');
+    kit.handle.agentStore.register({
+      botName: 'target',
+      url: 'inbox:',
+      ownerCredentialId: target.credentialId,
+      ownerName: 'target@example.com',
+    });
+    const sent = await call(kit.baseUrl, 'POST', '/api/messages', kit.adminToken, {
+      agentId: 'target',
+      message: 'project from admin',
+      presentationMode: 'origin-proxy',
+      originChatId: 'oc_admin_origin_chat',
+      originBotName: 'target',
+    });
+    expect(sent.status).toBe(202);
+    expect(kit.handle.chatStore.getRun(String(sent.body.runId))?.presentation).toMatchObject({
+      mode: 'origin-proxy',
+      chatId: 'oc_admin_origin_chat',
+      originBotName: 'target',
+    });
+  });
+
+  it('searches by username with bounded pagination', async () => {
+    kit = await startTestServer('minimal-search');
+    const token = await issue(kit, 'searcher', 'alice@example.com');
+    kit.handle.agentStore.register({
+      botName: 'robot-a',
+      url: 'inbox:',
+      description: 'vision',
+      ownerCredentialId: 'owner-a',
+      ownerName: 'bob@example.com',
+    });
+    kit.handle.agentStore.register({
+      botName: 'robot-b',
+      url: 'inbox:',
+      description: 'planning',
+      ownerCredentialId: 'owner-b',
+      ownerName: 'alice@example.com',
+    });
+    const result = await call(kit.baseUrl, 'GET', '/api/agents/search?user=alice@example.com&limit=1', token.token);
+    expect(result.status).toBe(200);
+    expect(result.body.agents).toHaveLength(1);
+    expect(result.body.hasMore).toBe(false);
+  });
+});

--- a/packages/skills/metabot/SKILL.md
+++ b/packages/skills/metabot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metabot
-description: "Unified MetaBot CLI for personal Memory, Skill Hub, agent registry and inbox relay, Agent Teams, T5T, scheduling, and bridge runtime operations."
+description: "Unified MetaBot CLI for personal Memory, Skill Hub, durable Agent Bus messaging, agent registry, Agent Teams, T5T, scheduling, and bridge runtime operations."
 ---
 
 # MetaBot Personal CLI Router
@@ -15,7 +15,7 @@ semantics only; project execution policy belongs in the workspace `AGENTS.md`.
 | --- | --- |
 | Search, read, create, update, share, or delete Meta Memory | [`references/memory.md`](references/memory.md) |
 | Browse, install, or publish a Skill | [`references/skills.md`](references/skills.md) |
-| Inspect Agents or use the inbox relay | [`references/agents.md`](references/agents.md) |
+| Inspect Agents or send durable Agent Bus messages | [`references/agents.md`](references/agents.md) |
 | Coordinate an Agent Team | Use the separate `metabot-team` Skill |
 | Read or write T5T status | [`references/t5t.md`](references/t5t.md) |
 | Schedule work or inspect a runtime | [`references/runtime.md`](references/runtime.md) |
@@ -27,8 +27,7 @@ metabot memory search "query"
 metabot memory get <id|path>
 metabot skills list
 metabot agents list
-metabot agents talk <agent> "message"
-metabot inbox poll --loop
+metabot send <agentId> "message"
 metabot teams status <team> --summary
 metabot t5t push <project> <YYYY-MM-DD> "entry"
 metabot health
@@ -43,6 +42,9 @@ bridge-local command is available.
 - Override it with `METABOT_CORE_URL` for another user-configured Core.
 - Use `METABOT_CORE_TOKEN`, or the first line of `~/.metabot-core/token`.
 - `metabot agents whoami` shows the current Core identity.
+- `metabot send` returns durable `messageId`, `sessionId`, and `runId` values;
+  pass `--session` or `--idempotency-key` when a retry must target the same
+  logical run.
 - Project and global Skill destinations are distinct discovery scopes.
 - MetaBot's own `metabot` and `metabot-team` bundles are global-only; project
   mirrors are retired outside discovery roots so stale copies cannot shadow

--- a/packages/skills/metabot/references/agents.md
+++ b/packages/skills/metabot/references/agents.md
@@ -3,12 +3,14 @@
 ```bash
 metabot agents list
 metabot agents whoami
-metabot agents talk <peer>[/<bot>] [<chatId>] "message"
-metabot inbox register [--bot-name <name>]
-metabot inbox poll [--chat <id>] [--once|--loop]
-metabot inbox peek [--chat <id>]
+metabot agents search "keyword"
+metabot agents show <agentId> --sessions
+metabot send <agentId> "message" [--session <sessionId>]
 ```
 
-When `chatId` is omitted, the CLI may derive a project-scoped conversation ID.
-Use an explicit ID for a thread shared across hosts. Inbox polling is the relay
-surface for CLI-only Agents without a resident bridge.
+`metabot send` is the canonical durable point-to-point path. Core resolves a
+logical session (or creates one), persists the message and run, and returns
+correlation IDs. Use `--implicit` for background work, or pair
+`--origin-chat <oc_...> --origin-bot <name>` with a configured Feishu origin
+to project progress back to that chat. `--idempotency-key` makes safe retries
+return the original run instead of creating a duplicate.

--- a/src/api/routes/core-chat-routes.ts
+++ b/src/api/routes/core-chat-routes.ts
@@ -43,6 +43,14 @@ export interface CoreChatRunRequest {
   userId?: string;
   engine?: EngineName;
   model?: string;
+  presentation?: {
+    mode: 'child-direct' | 'origin-proxy';
+    chatId: string;
+    targetAgentRef: string;
+    requestedBy: string;
+    originBotName?: string;
+    wakeLead?: boolean;
+  };
   maxTurns?: number;
   allowedTools?: string[];
   voice?: {
@@ -147,6 +155,28 @@ export function parseCoreChatRunRequest(body: Record<string, unknown>): { reques
   const voice = typeof body.voice === 'object' && body.voice !== null
     ? body.voice as Record<string, unknown>
     : undefined;
+  const rawPresentation = typeof body.presentation === 'object' && body.presentation !== null
+    ? body.presentation as Record<string, unknown>
+    : undefined;
+  const presentationMode: 'child-direct' | 'origin-proxy' | undefined =
+    rawPresentation?.mode === 'child-direct' || rawPresentation?.mode === 'origin-proxy'
+      ? rawPresentation.mode
+      : undefined;
+  const presentationChatId = asString(rawPresentation?.chatId);
+  const presentationTarget = asString(rawPresentation?.targetAgentRef);
+  const presentationRequestedBy = asString(rawPresentation?.requestedBy);
+  const presentation =
+    (presentationMode === 'child-direct' || presentationMode === 'origin-proxy') &&
+    presentationChatId && presentationTarget && presentationRequestedBy
+      ? {
+          mode: presentationMode,
+          chatId: presentationChatId,
+          targetAgentRef: presentationTarget,
+          requestedBy: presentationRequestedBy,
+          originBotName: asString(rawPresentation?.originBotName),
+          wakeLead: rawPresentation?.wakeLead !== false,
+        }
+      : undefined;
 
   return {
     request: {
@@ -160,6 +190,7 @@ export function parseCoreChatRunRequest(body: Record<string, unknown>): { reques
       userId: asString(body.userId),
       engine: asEngineName(body.engine),
       model: asString(body.model),
+      presentation,
       maxTurns,
       allowedTools: asStringArray(body.allowedTools),
       voice: voice ? {
@@ -647,7 +678,10 @@ export function acceptCoreChatRun(ctx: RouteContext, request: CoreChatRunRequest
     return { status: 429, body: { error: budgetCheck.reason } };
   }
 
-  const executionChatId = request.executionChatId || defaultExecutionChatId(request.conversationId, request.targetBot);
+  const executionChatId =
+    request.presentation?.mode === 'child-direct'
+      ? request.presentation.chatId
+      : request.executionChatId || defaultExecutionChatId(request.conversationId, request.targetBot);
   if (activeCoreChatRuns.get(request.runId)?.status === 'running') {
     return { status: 409, body: { error: `Run already active: ${request.runId}` } };
   }


### PR DESCRIPTION
## Summary
- add self-hosted durable `/api/messages` Agent Bus protocol with sessions, idempotency, ack, SSE, and origin projection
- add `metabot send` CLI and agent search/session surfaces
- preserve Personal Edition Bearer auth and localhost Core defaults
- document the public send workflow and add server/CLI coverage

## Verification
- `npm test` (726 root tests; shell update env unset)
- `npm run test -w @xvirobotics/metabot-core-server` (389 tests)
- `npm run test -w @xvirobotics/cli` (41 tests)
- `npm run build` and `npm run build:bridge`
- `npm run lint` (0 errors)