### PR TITLE
feat(oss): paginate MetaMemory search results

### DIFF
--- a/docs/features/metamemory.md
+++ b/docs/features/metamemory.md
@@ -15,6 +15,7 @@ explicit per-document choice.
 
 ```bash
 metabot memory search "deployment guide"
+metabot memory search "deployment guide" --limit 20 --offset 20
 metabot memory list
 metabot memory get <document-id>
 metabot memory path /users/me/project/guide
@@ -30,6 +31,10 @@ metabot memory health
 `create` and `update` read content from standard input when the content argument
 is omitted. Use `--html` only for a complete HTML document; Markdown is the
 default.
+
+Search results are ranked and capped at 100 per request. Use `--offset` with
+`--limit` to retrieve later pages. The Core Console search page exposes the
+same paging through its **load more** control.
 
 ## Paths and sharing
 

--- a/packages/metamemory/src/commands.ts
+++ b/packages/metamemory/src/commands.ts
@@ -142,9 +142,10 @@ export async function cmdSearch(cfg: Config, args: ParsedArgs): Promise<void> {
   const q = args.positional[0];
   if (!q) throw new Error('search: <query> required');
   const limit = typeof args.flags.limit === 'string' ? args.flags.limit : '20';
+  const offset = typeof args.flags.offset === 'string' ? args.flags.offset : undefined;
   const body = await request(cfg, {
     path: '/api/memory/search',
-    query: { q, limit },
+    query: { q, limit, offset },
   });
   print(body);
 }
@@ -351,7 +352,7 @@ export function printHelp(): void {
 Usage: metabot memory <command> [args]
 
 Commands:
-  search <query>              [--limit N]
+  search <query>              [--limit N] [--offset N]
   get <doc_id>
   path </abs/path/to/doc>
   list [folder_id]            [--limit N] [--offset N]

--- a/packages/metamemory/tests/cli.test.ts
+++ b/packages/metamemory/tests/cli.test.ts
@@ -146,6 +146,18 @@ describe('request', () => {
     );
     expect(captured).toBe('http://x/api/memory/search?q=hello&limit=5');
   });
+
+  it('memory search forwards --offset', async () => {
+    let captured = '';
+    const fakeFetch = (async (url: string) => {
+      captured = url;
+      return new Response('{"results":[]}', { status: 200 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fakeFetch);
+    const { cmdSearch } = await import('../src/commands.js');
+    await cmdSearch({ url: 'http://x', token: 't' }, { positional: ['hello'], flags: { limit: '5', offset: '10' } });
+    expect(captured).toBe('http://x/api/memory/search?q=hello&limit=5&offset=10');
+  });
 });
 
 describe('cmdCreate / cmdMkdir — write target', () => {

--- a/packages/server/src/memory/memory-routes.ts
+++ b/packages/server/src/memory/memory-routes.ts
@@ -182,7 +182,8 @@ export function search(store: MemoryStore, query: URLSearchParams, cred: Credent
   const q = query.get('q');
   if (!q || !q.trim()) return err(400, 'q_required');
   const limit = parseInt(query.get('limit') || '20', 10) || 20;
-  const results = store.searchDocuments(q, limit, cred).filter((r) => !isHiddenFromMemoryView(r.path));
+  const offset = Math.max(parseInt(query.get('offset') || '0', 10) || 0, 0);
+  const results = store.searchDocuments(q, limit, cred, offset).filter((r) => !isHiddenFromMemoryView(r.path));
   return { status: 200, body: { results } };
 }
 

--- a/packages/server/src/memory/memory-store.ts
+++ b/packages/server/src/memory/memory-store.ts
@@ -547,8 +547,13 @@ export class MemoryStore {
     return result.changes > 0;
   }
 
-  searchDocuments(query: string, limit: number, cred: Credential): SearchResult[] {
+  /** Search ranked documents, optionally skipping a page of results. */
+  searchDocuments(query: string, limit: number, cred: Credential, offset = 0): SearchResult[] {
     const escaped = escapeFts5Query(query);
+    const pageSize = Math.min(Math.max(limit, 1), 100);
+    const pageOffset = Math.max(Math.floor(offset) || 0, 0);
+    // Fetch the complete requested window before ACL filtering so a private
+    // document does not consume a visible result slot.
     const rows = this.db.prepare(`
       SELECT d.id, d.title, d.path, d.content_type, d.tags, d.shared, d.created_by, d.updated_at,
              snippet(documents_fts, 1, '<mark>', '</mark>', '...', 32) as snippet
@@ -557,10 +562,11 @@ export class MemoryStore {
       WHERE documents_fts MATCH ?
       ORDER BY rank
       LIMIT ?
-    `).all(escaped, Math.min(Math.max(limit, 1), 100)) as RawSearchRow[];
+    `).all(escaped, Math.min(pageOffset + pageSize, 1000)) as RawSearchRow[];
 
     return rows
       .filter((r) => canReadDoc(cred, r.path, r.shared === 1))
+      .slice(pageOffset, pageOffset + pageSize)
       .map((r) => ({
         id: r.id, title: r.title, path: r.path,
         content_type: normalizeStoredContentType(r.content_type),

--- a/packages/server/tests/memory.test.ts
+++ b/packages/server/tests/memory.test.ts
@@ -100,6 +100,19 @@ describe('MemoryStore + ACL', () => {
     expect(bResults[0].path.startsWith('/shared/')).toBe(true);
   });
 
+  it('search supports ranked offset pagination', () => {
+    kit = makeKit('mem-search-offset');
+    const admin = issue(kit, 'admin', 'admin');
+    for (const [title, token] of [['first', 'alpha'], ['second', 'beta'], ['third', 'gamma']]) {
+      kit.memory.createDocument({ title, path: `/shared/${title}`, content: `page-token ${token}` }, admin);
+    }
+    const first = kit.memory.searchDocuments('page-token', 1, admin);
+    const second = kit.memory.searchDocuments('page-token', 1, admin, 1);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(second[0].id).not.toBe(first[0].id);
+  });
+
   it('deleteFolder cascades + enforces ACL', () => {
     kit = makeKit('mem-delete');
     const admin = issue(kit, 'admin', 'admin');

--- a/packages/web-ui/src/lib/api.ts
+++ b/packages/web-ui/src/lib/api.ts
@@ -419,8 +419,10 @@ export const api = {
     request<{ id: string; name: string; path: string; parent_id: string | null }>(
       `/api/memory/folders/${encodeIdOrPath(idOrPath)}`,
     ),
-  searchMemory: (q: string, limit = 20) =>
-    request<{ results: SearchResult[] }>(`/api/memory/search?q=${encodeURIComponent(q)}&limit=${limit}`),
+  searchMemory: (q: string, limit = 20, offset = 0) =>
+    request<{ results: SearchResult[] }>(
+      `/api/memory/search?q=${encodeURIComponent(q)}&limit=${limit}&offset=${offset}`,
+    ),
 
   listSkills: () => request<{ skills: SkillSummary[] }>('/api/skills'),
   getSkill: (name: string) => request<SkillRecord>(`/api/skills/${encodeURIComponent(name)}`),

--- a/packages/web-ui/src/routes/search.tsx
+++ b/packages/web-ui/src/routes/search.tsx
@@ -8,19 +8,27 @@ interface Combined {
   docs: SearchResult[] | null;
   skills: SkillSearchResult[] | null;
   err: string | null;
+  docsHasMore: boolean;
+  docsLoadingMore: boolean;
+  docsLoadError: string | null;
 }
+
+const EMPTY: Combined = {
+  docs: null, skills: null, err: null, docsHasMore: false, docsLoadingMore: false, docsLoadError: null,
+};
+const PAGE_SIZE = 20;
 
 export function Search() {
   const loc = useLocation();
   const q = new URLSearchParams(loc.search).get('q') || '';
 
-  const [state, setState] = useState<Combined>({ docs: null, skills: null, err: null });
+  const [state, setState] = useState<Combined>(EMPTY);
 
   useEffect(() => {
-    if (!q) { setState({ docs: [], skills: [], err: null }); return; }
+    if (!q) { setState({ ...EMPTY, docs: [], skills: [] }); return; }
     let live = true;
-    setState({ docs: null, skills: null, err: null });
-    Promise.allSettled([api.searchMemory(q, 20), api.searchSkills(q)])
+    setState(EMPTY);
+    Promise.allSettled([api.searchMemory(q, PAGE_SIZE), api.searchSkills(q)])
       .then(([m, s]) => {
         if (!live) return;
         const docs = m.status === 'fulfilled' ? m.value.results : [];
@@ -29,10 +37,23 @@ export function Search() {
           m.status === 'rejected' && m.reason instanceof ApiError && m.reason.status !== 401
             ? `memory · ${m.reason.code}`
             : null;
-        setState({ docs, skills, err });
+        setState({ docs, skills, err, docsHasMore: docs.length === PAGE_SIZE, docsLoadingMore: false, docsLoadError: null });
       });
     return () => { live = false; };
   }, [q]);
+
+  async function loadMore() {
+    if (!q || !state.docs || !state.docsHasMore || state.docsLoadingMore) return;
+    const offset = state.docs.length;
+    setState((cur) => ({ ...cur, docsLoadingMore: true, docsLoadError: null }));
+    try {
+      const next = await api.searchMemory(q, PAGE_SIZE, offset);
+      setState((cur) => ({ ...cur, docs: [...(cur.docs || []), ...next.results], docsHasMore: next.results.length === PAGE_SIZE, docsLoadingMore: false }));
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 401) return;
+      setState((cur) => ({ ...cur, docsLoadingMore: false, docsLoadError: e instanceof Error ? e.message : String(e) }));
+    }
+  }
 
   return (
     <div className="main">
@@ -66,7 +87,8 @@ export function Search() {
           ) : state.docs.length === 0 ? (
             <div className="state">no document matches</div>
           ) : (
-            state.docs.map((r) => (
+            <>
+            {state.docs.map((r) => (
               <Link key={r.id} to={`/memory${r.path}`} className="search-row">
                 <div className="head">
                   <span className={r.content_type === 'text/html' ? 'badge html' : 'badge md'}>
@@ -83,7 +105,10 @@ export function Search() {
                   dangerouslySetInnerHTML={{ __html: renderSafeSnippet(r.snippet || '') }}
                 />
               </Link>
-            ))
+            ))}
+            {state.docsLoadError && <div className="state err">{state.docsLoadError} · <button type="button" onClick={loadMore}>retry</button></div>}
+            {state.docsHasMore && !state.docsLoadError && <div className="state"><button type="button" disabled={state.docsLoadingMore} onClick={loadMore}>{state.docsLoadingMore ? 'loading…' : 'load more'}</button></div>}
+            </>
           )}
         </section>
 


### PR DESCRIPTION
Adds offset pagination to MetaMemory search across Core API, CLI, and Console.

- API accepts offset and preserves ranked windows
- `metabot memory search --offset` forwards paging
- Console adds load more/retry for memory results
- Added server and CLI tests plus docs

Validation: npm test -w @xvirobotics/metamemory -- --run; npm test -w @xvirobotics/metabot-core-server -- --run; npm test -w @xvirobotics/metabot-core-web-ui -- --run; npm run build