### PR TITLE
feat(oss): upgrade MetaMemory search and live chat console

### DIFF
--- a/docs/features/metamemory.md
+++ b/docs/features/metamemory.md
@@ -15,6 +15,7 @@ explicit per-document choice.
 
 ```bash
 metabot memory search "deployment guide"
+metabot memory search "deployment guide" --limit 20 --offset 20
 metabot memory list
 metabot memory get <document-id>
 metabot memory path /users/me/project/guide
@@ -30,6 +31,10 @@ metabot memory health
 `create` and `update` read content from standard input when the content argument
 is omitted. Use `--html` only for a complete HTML document; Markdown is the
 default.
+
+Search results are ranked and capped at 100 per request. Use `--offset` with
+`--limit` to retrieve later pages. The Core Console search page exposes the
+same paging through its **load more** control.
 
 ## Paths and sharing
 

--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -21,6 +21,13 @@ Run, and multi-Agent model:
 - Agent DMs and groups routed with `@Agent`
 - per-conversation engine and model selection
 
+The console can subscribe to `GET /api/chat/conversations/<id>/stream` with the
+same Bearer token. The stream sends an initial `snapshot` event, then
+`message.created`, `run.updated`, `run.event`, and `file.created` events as the
+conversation changes. It is participant-scoped; non-participants receive
+`403`, and the server emits periodic comment heartbeats to keep proxies from
+closing idle connections.
+
 ## Architecture
 
 ```text

--- a/docs/features/web-ui.zh.md
+++ b/docs/features/web-ui.zh.md
@@ -21,6 +21,11 @@ Core Console Chat 把实时执行与 Core 的持久 Conversation、Run 和多 Ag
 - 创建 Agent 私聊或带 `@Agent` 路由的群聊
 - 为每个会话选择引擎和模型
 
+控制台可使用同一 Bearer Token 订阅
+`GET /api/chat/conversations/<id>/stream`。连接先发送 `snapshot`，随后推送
+`message.created`、`run.updated`、`run.event` 和 `file.created` 事件。订阅按会话参与者
+授权；非参与者返回 `403`，空闲连接会定期收到注释心跳，避免代理关闭连接。
+
 ## 架构 {#architecture}
 
 ```text

--- a/packages/metamemory/src/commands.ts
+++ b/packages/metamemory/src/commands.ts
@@ -142,9 +142,10 @@ export async function cmdSearch(cfg: Config, args: ParsedArgs): Promise<void> {
   const q = args.positional[0];
   if (!q) throw new Error('search: <query> required');
   const limit = typeof args.flags.limit === 'string' ? args.flags.limit : '20';
+  const offset = typeof args.flags.offset === 'string' ? args.flags.offset : undefined;
   const body = await request(cfg, {
     path: '/api/memory/search',
-    query: { q, limit },
+    query: { q, limit, offset },
   });
   print(body);
 }
@@ -351,7 +352,7 @@ export function printHelp(): void {
 Usage: metabot memory <command> [args]
 
 Commands:
-  search <query>              [--limit N]
+  search <query>              [--limit N] [--offset N]
   get <doc_id>
   path </abs/path/to/doc>
   list [folder_id]            [--limit N] [--offset N]

--- a/packages/metamemory/tests/cli.test.ts
+++ b/packages/metamemory/tests/cli.test.ts
@@ -146,6 +146,18 @@ describe('request', () => {
     );
     expect(captured).toBe('http://x/api/memory/search?q=hello&limit=5');
   });
+
+  it('memory search forwards --offset', async () => {
+    let captured = '';
+    const fakeFetch = (async (url: string) => {
+      captured = url;
+      return new Response('{"results":[]}', { status: 200 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fakeFetch);
+    const { cmdSearch } = await import('../src/commands.js');
+    await cmdSearch({ url: 'http://x', token: 't' }, { positional: ['hello'], flags: { limit: '5', offset: '10' } });
+    expect(captured).toBe('http://x/api/memory/search?q=hello&limit=5&offset=10');
+  });
 });
 
 describe('cmdCreate / cmdMkdir — write target', () => {

--- a/packages/server/src/chat/chat-events.ts
+++ b/packages/server/src/chat/chat-events.ts
@@ -25,7 +25,6 @@ export class ChatEventHub {
       'X-Accel-Buffering': 'no',
     });
     let closed = false;
-    let heartbeat: NodeJS.Timeout;
     const cleanup = (): void => {
       if (closed) return;
       closed = true;
@@ -48,6 +47,10 @@ export class ChatEventHub {
     };
     this.store.events.on('chat', listener);
     this.clients.set(conversationId, this.clientCount(conversationId) + 1);
+    const heartbeat = setInterval(() => {
+      try { res.write(': hb\n\n'); } catch { cleanup(); }
+    }, this.heartbeatMs);
+    if (typeof heartbeat.unref === 'function') heartbeat.unref();
     write('snapshot', {
       messages: this.store.listMessages(conversationId, userRef, { limit: 50 }),
       runs: this.store.listRuns(conversationId, userRef).filter((run) =>
@@ -55,10 +58,6 @@ export class ChatEventHub {
       ),
       files: this.store.listFiles(conversationId, userRef),
     });
-    heartbeat = setInterval(() => {
-      try { res.write(': hb\n\n'); } catch { cleanup(); }
-    }, this.heartbeatMs);
-    if (typeof heartbeat.unref === 'function') heartbeat.unref();
     req.on('close', cleanup);
     req.on('error', cleanup);
     res.on('close', cleanup);

--- a/packages/server/src/chat/chat-events.ts
+++ b/packages/server/src/chat/chat-events.ts
@@ -1,29 +1,66 @@
 import type * as http from 'node:http';
+import type { ChatStore } from './chat-store.js';
 import type { ChatLiveEvent } from './chat-types.js';
 
-/** Lightweight in-process SSE hub for personal chat clients. */
+/** In-process SSE fan-out for the personal chat console. */
 export class ChatEventHub {
-  private readonly listeners = new Set<(event: ChatLiveEvent) => void>();
+  private readonly store: ChatStore;
+  private readonly heartbeatMs: number;
+  private readonly clients = new Map<string, number>();
 
-  publish(event: ChatLiveEvent): void {
-    for (const listener of this.listeners) {
-      try {
-        listener(event);
-      } catch {
-        /* closed clients are harmless */
-      }
-    }
+  constructor(store: ChatStore, options: { heartbeatMs?: number } = {}) {
+    this.store = store;
+    this.heartbeatMs = options.heartbeatMs ?? 25_000;
   }
 
-  stream(req: http.IncomingMessage, res: http.ServerResponse, conversationId: string, _userRef: string): void {
-    res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' });
-    res.write(': connected\n\n');
-    const listener = (event: ChatLiveEvent) => {
-      if (event.conversationId === conversationId) res.write(`data: ${JSON.stringify(event)}\n\n`);
+  clientCount(conversationId: string): number {
+    return this.clients.get(conversationId) ?? 0;
+  }
+
+  stream(req: http.IncomingMessage, res: http.ServerResponse, conversationId: string, userRef: string): void {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    let closed = false;
+    let heartbeat: NodeJS.Timeout;
+    const cleanup = (): void => {
+      if (closed) return;
+      closed = true;
+      clearInterval(heartbeat);
+      this.store.events.off('chat', listener);
+      const count = this.clientCount(conversationId) - 1;
+      if (count > 0) this.clients.set(conversationId, count);
+      else this.clients.delete(conversationId);
+      try { res.end(); } catch { /* already closed */ }
     };
-    this.listeners.add(listener);
-    const close = () => this.listeners.delete(listener);
-    req.on('close', close);
-    res.on('close', close);
+    const write = (event: string, data: unknown): void => {
+      try { res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`); } catch { cleanup(); }
+    };
+    const listener = (event: ChatLiveEvent): void => {
+      if (event.conversationId !== conversationId) return;
+      if (event.type === 'message.created') write('message.created', { message: event.message });
+      else if (event.type === 'run.updated') write('run.updated', { run: event.run });
+      else if (event.type === 'run.event') write('run.event', { runId: event.runId, event: event.event });
+      else if (event.type === 'file.created') write('file.created', { file: event.file });
+    };
+    this.store.events.on('chat', listener);
+    this.clients.set(conversationId, this.clientCount(conversationId) + 1);
+    write('snapshot', {
+      messages: this.store.listMessages(conversationId, userRef, { limit: 50 }),
+      runs: this.store.listRuns(conversationId, userRef).filter((run) =>
+        run.status === 'queued' || run.status === 'running' || run.status === 'waiting_user',
+      ),
+      files: this.store.listFiles(conversationId, userRef),
+    });
+    heartbeat = setInterval(() => {
+      try { res.write(': hb\n\n'); } catch { cleanup(); }
+    }, this.heartbeatMs);
+    if (typeof heartbeat.unref === 'function') heartbeat.unref();
+    req.on('close', cleanup);
+    req.on('error', cleanup);
+    res.on('close', cleanup);
   }
 }

--- a/packages/server/src/chat/chat-routes.ts
+++ b/packages/server/src/chat/chat-routes.ts
@@ -1,6 +1,8 @@
+import type * as http from 'node:http';
 import type { Credential } from '../auth/credentials.js';
 import type { AgentRecord, AgentStore } from '../agents/agent-store.js';
 import type { ChatStore } from './chat-store.js';
+import type { ChatEventHub } from './chat-events.js';
 import { ChatForbiddenError, ChatNotFoundError } from './chat-store.js';
 import type {
   ChatParticipantCandidate,
@@ -18,6 +20,7 @@ export interface RouteResult {
 export interface ChatRouteDeps {
   chat: ChatStore;
   agents: AgentStore;
+  events: ChatEventHub;
   deliverRun?: (run: {
     id: string;
     conversationId: string;
@@ -230,6 +233,25 @@ export function listParticipants(deps: ChatRouteDeps, id: string, cred: Credenti
     status: 200,
     body: { participants: deps.chat.listParticipants(id, userRef(cred)) },
   }));
+}
+
+/** Open a participant-scoped SSE stream for live conversation updates. */
+export function streamConversation(
+  deps: ChatRouteDeps,
+  id: string,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  cred: Credential,
+): RouteResult | null {
+  try {
+    deps.chat.getConversationForUser(id, userRef(cred));
+  } catch (e) {
+    if (e instanceof ChatNotFoundError) return err(404, 'conversation_not_found');
+    if (e instanceof ChatForbiddenError) return err(403, 'chat_participant_required');
+    throw e;
+  }
+  deps.events.stream(req, res, id, userRef(cred));
+  return null;
 }
 
 export function addParticipant(

--- a/packages/server/src/chat/chat-store.ts
+++ b/packages/server/src/chat/chat-store.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'node:crypto';
+import { EventEmitter } from 'node:events';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type Database from 'better-sqlite3';
@@ -188,11 +189,22 @@ interface RawFileRow {
 export class ChatStore {
   private db: Database.Database;
   private logger: Logger;
+  /** In-process fan-out for chat SSE subscribers. */
+  readonly events = new EventEmitter();
 
   constructor(db: Database.Database, logger: Logger) {
     this.db = db;
     this.logger = logger;
+    this.events.setMaxListeners(0);
     this.initSchema();
+  }
+
+  private emitLive(event: import('./chat-types.js').ChatLiveEvent): void {
+    try {
+      this.events.emit('chat', event);
+    } catch (err) {
+      this.logger.warn({ err, type: event.type, conversationId: event.conversationId }, 'chat live event listener threw');
+    }
   }
 
   private initSchema(): void {
@@ -573,7 +585,9 @@ export class ChatStore {
     if (input.senderKind === 'user') {
       this.markReadUnchecked(input.conversationId, input.senderRef, id, now);
     }
-    return this.getMessage(id)!;
+    const message = this.getMessage(id)!;
+    this.emitLive({ type: 'message.created', conversationId: input.conversationId, message });
+    return message;
   }
 
   listMessages(
@@ -654,7 +668,9 @@ export class ChatStore {
         now,
         now,
       );
-    return this.getRun(id)!;
+    const run = this.getRun(id)!;
+    this.emitLive({ type: 'run.updated', conversationId: input.conversationId, run });
+    return run;
   }
 
   getRunForUser(runId: string, userRef: string): ChatRun {
@@ -728,6 +744,7 @@ export class ChatStore {
     const run = this.getRun(input.runId);
     if (!run) throw Object.assign(new Error('run_not_found'), { statusCode: 404 });
 
+    let inserted = false;
     const tx = this.db.transaction(() => {
       const payloadJson = JSON.stringify(input.payload);
       const existing = this.db
@@ -753,6 +770,7 @@ export class ChatStore {
       `,
         )
         .run(id, input.runId, input.seq, input.kind, payloadJson, now);
+      inserted = true;
 
       if (input.kind === 'state') {
         this.updateRunStatus(input.runId, payloadStatus(input.payload) || 'running', now);
@@ -775,7 +793,24 @@ export class ChatStore {
       const row = this.db.prepare('SELECT * FROM chat_run_events WHERE id = ?').get(id) as RawRunEventRow;
       return rowToRunEvent(row);
     });
-    return tx();
+    const event = tx();
+    const updatedRun = this.getRun(input.runId);
+    if (updatedRun && inserted) {
+      this.emitLive({ type: 'run.event', conversationId: updatedRun.conversationId, runId: updatedRun.id, event });
+      this.emitLive({ type: 'run.updated', conversationId: updatedRun.conversationId, run: updatedRun });
+      if (event.kind === 'complete' && updatedRun.finalMessageId) {
+        const message = this.getMessage(updatedRun.finalMessageId);
+        if (message) this.emitLive({ type: 'message.created', conversationId: updatedRun.conversationId, message });
+      }
+      if (event.kind === 'file') {
+        const rows = this.db.prepare('SELECT * FROM chat_files WHERE run_id = ? ORDER BY created_at ASC, id ASC').all(updatedRun.id) as RawFileRow[];
+        for (const row of rows) {
+          const file = rowToFile(row);
+          this.emitLive({ type: 'file.created', conversationId: updatedRun.conversationId, file });
+        }
+      }
+    }
+    return event;
   }
 
   listRunEventsForUser(runId: string, userRef: string): ChatRunEvent[] {

--- a/packages/server/src/memory/memory-routes.ts
+++ b/packages/server/src/memory/memory-routes.ts
@@ -182,7 +182,8 @@ export function search(store: MemoryStore, query: URLSearchParams, cred: Credent
   const q = query.get('q');
   if (!q || !q.trim()) return err(400, 'q_required');
   const limit = parseInt(query.get('limit') || '20', 10) || 20;
-  const results = store.searchDocuments(q, limit, cred).filter((r) => !isHiddenFromMemoryView(r.path));
+  const offset = Math.max(parseInt(query.get('offset') || '0', 10) || 0, 0);
+  const results = store.searchDocuments(q, limit, cred, offset).filter((r) => !isHiddenFromMemoryView(r.path));
   return { status: 200, body: { results } };
 }
 

--- a/packages/server/src/memory/memory-store.ts
+++ b/packages/server/src/memory/memory-store.ts
@@ -547,8 +547,13 @@ export class MemoryStore {
     return result.changes > 0;
   }
 
-  searchDocuments(query: string, limit: number, cred: Credential): SearchResult[] {
+  /** Search ranked documents, optionally skipping a page of results. */
+  searchDocuments(query: string, limit: number, cred: Credential, offset = 0): SearchResult[] {
     const escaped = escapeFts5Query(query);
+    const pageSize = Math.min(Math.max(limit, 1), 100);
+    const pageOffset = Math.max(Math.floor(offset) || 0, 0);
+    // Fetch the complete requested window before ACL filtering so a private
+    // document does not consume a visible result slot.
     const rows = this.db.prepare(`
       SELECT d.id, d.title, d.path, d.content_type, d.tags, d.shared, d.created_by, d.updated_at,
              snippet(documents_fts, 1, '<mark>', '</mark>', '...', 32) as snippet
@@ -557,10 +562,11 @@ export class MemoryStore {
       WHERE documents_fts MATCH ?
       ORDER BY rank
       LIMIT ?
-    `).all(escaped, Math.min(Math.max(limit, 1), 100)) as RawSearchRow[];
+    `).all(escaped, Math.min(pageOffset + pageSize, 1000)) as RawSearchRow[];
 
     return rows
       .filter((r) => canReadDoc(cred, r.path, r.shared === 1))
+      .slice(pageOffset, pageOffset + pageSize)
       .map((r) => ({
         id: r.id, title: r.title, path: r.path,
         content_type: normalizeStoredContentType(r.content_type),

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -561,7 +561,7 @@ export function startServer(options: ServerOptions): ServerHandle {
   const chatStore = new ChatStore(db, logger.child({ module: 'chat' }));
   const messageStore = new MessageStore(db, logger.child({ module: 'messages' }));
   const busEventHub = new BusEventHub();
-  const chatEventHub = new ChatEventHub();
+  const chatEventHub = new ChatEventHub(chatStore);
   const t5tFolderIds = loadT5tFolderIds(process.env, memoryStore, logger.child({ module: 't5t-folders' }));
   const t5tStore = new T5tStore(memoryStore, t5tFolderIds, logger.child({ module: 't5t' }));
   const auditLog = createDefaultAuditLog(dataDir, logger);
@@ -1088,6 +1088,13 @@ export function startServer(options: ServerOptions): ServerHandle {
         const conversationId = decodeURIComponent(chatParticipantsMatch[1]);
         const body = await parseJsonBody(req);
         return jsonResult(res, chatRoutes.addParticipant(chatDeps, conversationId, body, cred));
+      }
+      const chatStreamMatch = pathname.match(/^\/api\/chat\/conversations\/([^/]+)\/stream$/);
+      if (chatStreamMatch && method === 'GET') {
+        const conversationId = decodeURIComponent(chatStreamMatch[1]);
+        const result = chatRoutes.streamConversation(chatDeps, conversationId, req, res, cred);
+        if (result) return jsonResult(res, result);
+        return;
       }
       const chatRunsMatch = pathname.match(/^\/api\/chat\/conversations\/([^/]+)\/runs$/);
       if (chatRunsMatch && method === 'GET') {

--- a/packages/server/tests/chat-events.test.ts
+++ b/packages/server/tests/chat-events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { ChatEventHub } from '../src/chat/chat-events.js';
+import { ChatStore } from '../src/chat/chat-store.js';
+import { makeKit } from './helpers.js';
+
+function fakeResponse() {
+  const writes: string[] = [];
+  const response = new EventEmitter() as EventEmitter & {
+    writeHead: (status: number, headers: Record<string, string>) => void;
+    write: (chunk: string) => boolean;
+    end: () => void;
+  };
+  response.writeHead = () => undefined;
+  response.write = (chunk) => { writes.push(chunk); return true; };
+  response.end = () => undefined;
+  return { response, writes };
+}
+
+describe('ChatEventHub', () => {
+  it('sends a participant-scoped snapshot and live message events', () => {
+    const kit = makeKit('chat-events');
+    try {
+      const store = new ChatStore(kit.db, kit.logger);
+      const conversation = store.createConversation({
+        kind: 'dm',
+        createdBy: 'alice@example.com',
+        participants: [{ kind: 'user', ref: 'alice@example.com' }, { kind: 'agent', ref: 'bot' }],
+      });
+      const hub = new ChatEventHub(store, { heartbeatMs: 60_000 });
+      const { response, writes } = fakeResponse();
+      const req = new EventEmitter() as EventEmitter;
+
+      hub.stream(req as never, response as never, conversation.id, 'alice@example.com');
+      expect(writes[0]).toContain('event: snapshot');
+      expect(JSON.parse(writes[0].split('data: ')[1]).messages).toEqual([]);
+      expect(hub.clientCount(conversation.id)).toBe(1);
+
+      store.appendMessage({
+        conversationId: conversation.id,
+        kind: 'user',
+        senderKind: 'user',
+        senderRef: 'alice@example.com',
+        content: 'hello',
+      });
+      expect(writes.some((chunk) => chunk.includes('event: message.created') && chunk.includes('hello'))).toBe(true);
+
+      req.emit('close');
+      expect(hub.clientCount(conversation.id)).toBe(0);
+    } finally {
+      kit.cleanup();
+    }
+  });
+});

--- a/packages/server/tests/memory.test.ts
+++ b/packages/server/tests/memory.test.ts
@@ -100,6 +100,19 @@ describe('MemoryStore + ACL', () => {
     expect(bResults[0].path.startsWith('/shared/')).toBe(true);
   });
 
+  it('search supports ranked offset pagination', () => {
+    kit = makeKit('mem-search-offset');
+    const admin = issue(kit, 'admin', 'admin');
+    for (const [title, token] of [['first', 'alpha'], ['second', 'beta'], ['third', 'gamma']]) {
+      kit.memory.createDocument({ title, path: `/shared/${title}`, content: `page-token ${token}` }, admin);
+    }
+    const first = kit.memory.searchDocuments('page-token', 1, admin);
+    const second = kit.memory.searchDocuments('page-token', 1, admin, 1);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(second[0].id).not.toBe(first[0].id);
+  });
+
   it('deleteFolder cascades + enforces ACL', () => {
     kit = makeKit('mem-delete');
     const admin = issue(kit, 'admin', 'admin');

--- a/packages/web-ui/src/lib/api.ts
+++ b/packages/web-ui/src/lib/api.ts
@@ -419,8 +419,10 @@ export const api = {
     request<{ id: string; name: string; path: string; parent_id: string | null }>(
       `/api/memory/folders/${encodeIdOrPath(idOrPath)}`,
     ),
-  searchMemory: (q: string, limit = 20) =>
-    request<{ results: SearchResult[] }>(`/api/memory/search?q=${encodeURIComponent(q)}&limit=${limit}`),
+  searchMemory: (q: string, limit = 20, offset = 0) =>
+    request<{ results: SearchResult[] }>(
+      `/api/memory/search?q=${encodeURIComponent(q)}&limit=${limit}&offset=${offset}`,
+    ),
 
   listSkills: () => request<{ skills: SkillSummary[] }>('/api/skills'),
   getSkill: (name: string) => request<SkillRecord>(`/api/skills/${encodeURIComponent(name)}`),

--- a/packages/web-ui/src/routes/search.tsx
+++ b/packages/web-ui/src/routes/search.tsx
@@ -8,19 +8,27 @@ interface Combined {
   docs: SearchResult[] | null;
   skills: SkillSearchResult[] | null;
   err: string | null;
+  docsHasMore: boolean;
+  docsLoadingMore: boolean;
+  docsLoadError: string | null;
 }
+
+const EMPTY: Combined = {
+  docs: null, skills: null, err: null, docsHasMore: false, docsLoadingMore: false, docsLoadError: null,
+};
+const PAGE_SIZE = 20;
 
 export function Search() {
   const loc = useLocation();
   const q = new URLSearchParams(loc.search).get('q') || '';
 
-  const [state, setState] = useState<Combined>({ docs: null, skills: null, err: null });
+  const [state, setState] = useState<Combined>(EMPTY);
 
   useEffect(() => {
-    if (!q) { setState({ docs: [], skills: [], err: null }); return; }
+    if (!q) { setState({ ...EMPTY, docs: [], skills: [] }); return; }
     let live = true;
-    setState({ docs: null, skills: null, err: null });
-    Promise.allSettled([api.searchMemory(q, 20), api.searchSkills(q)])
+    setState(EMPTY);
+    Promise.allSettled([api.searchMemory(q, PAGE_SIZE), api.searchSkills(q)])
       .then(([m, s]) => {
         if (!live) return;
         const docs = m.status === 'fulfilled' ? m.value.results : [];
@@ -29,10 +37,23 @@ export function Search() {
           m.status === 'rejected' && m.reason instanceof ApiError && m.reason.status !== 401
             ? `memory · ${m.reason.code}`
             : null;
-        setState({ docs, skills, err });
+        setState({ docs, skills, err, docsHasMore: docs.length === PAGE_SIZE, docsLoadingMore: false, docsLoadError: null });
       });
     return () => { live = false; };
   }, [q]);
+
+  async function loadMore() {
+    if (!q || !state.docs || !state.docsHasMore || state.docsLoadingMore) return;
+    const offset = state.docs.length;
+    setState((cur) => ({ ...cur, docsLoadingMore: true, docsLoadError: null }));
+    try {
+      const next = await api.searchMemory(q, PAGE_SIZE, offset);
+      setState((cur) => ({ ...cur, docs: [...(cur.docs || []), ...next.results], docsHasMore: next.results.length === PAGE_SIZE, docsLoadingMore: false }));
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 401) return;
+      setState((cur) => ({ ...cur, docsLoadingMore: false, docsLoadError: e instanceof Error ? e.message : String(e) }));
+    }
+  }
 
   return (
     <div className="main">
@@ -66,7 +87,8 @@ export function Search() {
           ) : state.docs.length === 0 ? (
             <div className="state">no document matches</div>
           ) : (
-            state.docs.map((r) => (
+            <>
+            {state.docs.map((r) => (
               <Link key={r.id} to={`/memory${r.path}`} className="search-row">
                 <div className="head">
                   <span className={r.content_type === 'text/html' ? 'badge html' : 'badge md'}>
@@ -83,7 +105,10 @@ export function Search() {
                   dangerouslySetInnerHTML={{ __html: renderSafeSnippet(r.snippet || '') }}
                 />
               </Link>
-            ))
+            ))}
+            {state.docsLoadError && <div className="state err">{state.docsLoadError} · <button type="button" onClick={loadMore}>retry</button></div>}
+            {state.docsHasMore && !state.docsLoadError && <div className="state"><button type="button" disabled={state.docsLoadingMore} onClick={loadMore}>{state.docsLoadingMore ? 'loading…' : 'load more'}</button></div>}
+            </>
           )}
         </section>
 


### PR DESCRIPTION
## Summary
- add offset pagination to MetaMemory search across Core API, CLI, and Web Console
- add participant-scoped live chat SSE with snapshots, run/message/file events, and heartbeats
- preserve Personal Edition auth and local Core boundaries; no Feilian or internal service coupling
- add focused regression coverage and feature documentation

## Verification
- `npm run test -w @xvirobotics/metabot-core-server` (391 tests)
- `npm run test -w @xvirobotics/metamemory`
- `npm run test -w @xvirobotics/metabot-core-web-ui`
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
