### PR TITLE
fix(oss): avoid Windows Codex spawn EINVAL

### DIFF
--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -23,10 +23,6 @@ const FALLBACK_CODEX_CONTEXT_WINDOW = 272000;
 const CODEX_AUTH_ENV_VARS = ['OPENAI_API_KEY', 'CODEX_API_KEY', 'CODEX_ACCESS_TOKEN'];
 const CODEX_EXIT_GRACE_MS = 1000;
 
-export function resolveCodexPath(explicitPath?: string): string {
-  const override = explicitPath || process.env.CODEX_EXECUTABLE_PATH;
-  if (override && existsSync(override)) return override;
-
 function findWindowsCodexBinary(npmPrefix: string | undefined): string | undefined {
   if (!npmPrefix) return undefined;
 
@@ -76,6 +72,10 @@ export function buildCodexSpawnCommand(
   }
   return { command: executable, args };
 }
+
+export function resolveCodexPath(explicitPath?: string): string {
+  const override = explicitPath || process.env.CODEX_EXECUTABLE_PATH;
+  if (override && existsSync(override)) return override;
 
   try {
     if (isWindows) {

--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -27,8 +27,63 @@ export function resolveCodexPath(explicitPath?: string): string {
   const override = explicitPath || process.env.CODEX_EXECUTABLE_PATH;
   if (override && existsSync(override)) return override;
 
+function findWindowsCodexBinary(npmPrefix: string | undefined): string | undefined {
+  if (!npmPrefix) return undefined;
+
+  const target = process.arch === 'arm64'
+    ? { packageName: 'codex-win32-arm64', triple: 'aarch64-pc-windows-msvc' }
+    : { packageName: 'codex-win32-x64', triple: 'x86_64-pc-windows-msvc' };
+  const candidate = path.join(
+    npmPrefix,
+    'node_modules',
+    '@openai',
+    'codex',
+    'node_modules',
+    '@openai',
+    target.packageName,
+    'vendor',
+    target.triple,
+    'bin',
+    'codex.exe',
+  );
+  return existsSync(candidate) ? candidate : undefined;
+}
+
+export function buildCodexSpawnCommand(
+  executable: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
+  if (platform !== 'win32') return { command: executable, args };
+
+  if (path.basename(executable).toLowerCase() === 'codex.cmd') {
+    const codexScript = path.join(
+      path.dirname(executable),
+      'node_modules',
+      '@openai',
+      'codex',
+      'bin',
+      'codex.js',
+    );
+    if (existsSync(codexScript)) {
+      return { command: process.execPath, args: [codexScript, ...args] };
+    }
+    throw new Error(`Unable to resolve Codex npm entrypoint for ${executable}`);
+  }
+
+  if (/\.(?:cmd|bat)$/i.test(executable)) {
+    throw new Error(`Codex executable must be a native executable on Windows: ${executable}`);
+  }
+  return { command: executable, args };
+}
+
   try {
-    const cmd = isWindows ? 'where codex' : 'which codex';
+    if (isWindows) {
+      const npmPrefix = process.env.APPDATA ? path.join(process.env.APPDATA, 'npm') : undefined;
+      const nativeBinary = findWindowsCodexBinary(npmPrefix);
+      if (nativeBinary) return nativeBinary;
+    }
+    const cmd = isWindows ? 'where codex.cmd' : 'which codex';
     return execSync(cmd, { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
   } catch {
     if (!isWindows) {
@@ -392,10 +447,12 @@ export class CodexExecutor {
     };
 
     try {
-      child = spawn(executable, args, {
+      const spawnCommand = buildCodexSpawnCommand(executable, args);
+      child = spawn(spawnCommand.command, spawnCommand.args, {
         cwd,
         env: buildCodexEnv(codexConfig),
         stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
       });
     } catch (err: any) {
       finishWithError(err?.message || String(err));

--- a/tests/codex-build-args.test.ts
+++ b/tests/codex-build-args.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { buildCodexArgs, buildCodexEnv, resolveCodexModelMetadata, resolveCodexPath } from '../src/engines/codex/executor.js';
+import {
+  buildCodexArgs,
+  buildCodexSpawnCommand,
+  buildCodexEnv,
+  resolveCodexModelMetadata,
+  resolveCodexPath,
+} from '../src/engines/codex/executor.js';
 import { type CodexBotConfig, normalizeCodexReasoningEffort } from '../src/config.js';
 
 describe('buildCodexArgs', () => {
@@ -185,5 +191,53 @@ describe('buildCodexEnv', () => {
     );
     expect(env.OPENAI_API_KEY).toBe('sk-bot-env');
     expect(env.PATH).toBe('/bin');
+  });
+});
+
+describe('buildCodexSpawnCommand', () => {
+  const args = ['exec', '--json', 'prompt with spaces & "quotes"'];
+
+  it('runs the npm Codex wrapper through Node when codex.js exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'metabot-codex-wrapper-'));
+    try {
+      const codexScript = join(dir, 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+      mkdirSync(join(dir, 'node_modules', '@openai', 'codex', 'bin'), { recursive: true });
+      writeFileSync(codexScript, '');
+
+      expect(buildCodexSpawnCommand(join(dir, 'codex.cmd'), args, 'win32')).toEqual({
+        command: process.execPath,
+        args: [codexScript, ...args],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects other Windows command wrappers', () => {
+    expect(() => buildCodexSpawnCommand(
+      'C:\\tools\\custom-codex.cmd',
+      args,
+      'win32',
+    )).toThrow('Codex executable must be a native executable on Windows');
+  });
+
+  it('runs Windows native executables directly', () => {
+    expect(buildCodexSpawnCommand('C:\\tools\\codex.exe', args, 'win32')).toEqual({
+      command: 'C:\\tools\\codex.exe',
+      args,
+    });
+  });
+
+  it('leaves non-Windows commands unchanged', () => {
+    expect(buildCodexSpawnCommand('/usr/local/bin/codex', args, 'linux')).toEqual({
+      command: '/usr/local/bin/codex',
+      args,
+    });
+  });
+
+  it('rejects a Codex wrapper when its npm entrypoint is missing', () => {
+    expect(() => buildCodexSpawnCommand('codex.cmd', args, 'win32')).toThrow(
+      'Unable to resolve Codex npm entrypoint',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- resolve the native Windows Codex binary from the npm installation before falling back to `codex.cmd`
- execute the npm wrapper through Node instead of spawning `.cmd` directly
- reject unsupported Windows command wrappers with a diagnostic error
- preserve current Codex path/auth behavior and add regression coverage

This is a rebased successor to #371 against current `main`.

## Verification
- `npx vitest run tests/codex-build-args.test.ts` (22 passed)
- `npx tsc --noEmit`
- full CI/package/build required
