### PR TITLE
docs: align root contributing guide with development checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,11 @@ cp .env.example .env
 # 4. Build
 npm run build
 
-# 5. Run in development
+# 5. Run the test suite and lint checks
+npm test
+npm run lint
+
+# 6. Run in development
 npm run dev
 ```
 
@@ -59,7 +63,8 @@ packages/        # Personal Core, Web UI, CLI, and shared packages
 1. Fork the repo and create a branch from `main`
 2. Make your changes with clear commit messages
 3. Ensure `npm run build` passes with no errors
-4. Open a PR with a clear description of what changed and why
+4. Run `npm test` and `npm run lint`
+5. Open a PR with a clear description of what changed and why
 
 ## Code Style
 
@@ -67,6 +72,7 @@ packages/        # Personal Core, Web UI, CLI, and shared packages
 - Use `async/await` over raw promises
 - Keep functions small and focused
 - Add JSDoc comments for public APIs
+- Use ESM imports with `.js` extensions
 
 ## Questions?
 


### PR DESCRIPTION
## What changed

- Add test and lint commands to the root development setup.
- Add `npm test` and `npm run lint` to the pull request checklist.
- Document the repository's ESM `.js` import convention.

## Why

The root contribution guide required only a build, while the development documentation also required tests, linting, and the ESM import convention. Keeping the entry-point guide aligned makes the expected validation steps clear to contributors.

## Verification

- `git diff --check`
- Checked that the modified Markdown file has no missing local links.