### PR TITLE
fix: recover undeliverable AskUserQuestion answers

### DIFF
--- a/src/engines/claude/pty/interactive-driver.ts
+++ b/src/engines/claude/pty/interactive-driver.ts
@@ -248,6 +248,7 @@ async function answerQuestions(
     );
     if (!ready) {
       logger.warn({ qIndex: i, header: q.header }, 'pty-driver: AskUserQuestion menu never rendered');
+      await submitAnswersAsPrompt(session, answers, questions, i, logger);
       return;
     }
     await sleep(250);
@@ -290,6 +291,32 @@ async function answerQuestions(
   await sleep(300);
   logger.info('pty-driver: confirming AskUserQuestion (Submit answers)');
   session.sendKeys('\r'); // "Submit answers" is the focused default
+}
+
+/**
+ * Fallback when the AskUserQuestion menu cannot be driven — typically a
+ * resumed session replaying a historical question frame that never becomes
+ * interactive again. Submit the user's answers as a plain follow-up prompt so
+ * the reply still reaches the session instead of wedging the turn.
+ */
+async function submitAnswersAsPrompt(
+  session: PtyClaudeSession,
+  answers: Record<string, string>,
+  questions: PtyParsedQuestion[],
+  fromIndex: number,
+  logger: Logger,
+): Promise<void> {
+  const parts: string[] = [];
+  for (let i = fromIndex; i < questions.length; i++) {
+    const question = questions[i];
+    const answer = (answers[question.header] ?? answers[question.question] ?? '').trim();
+    if (!answer) continue;
+    parts.push(question.header ? `${question.header}: ${answer}` : answer);
+  }
+  const text = parts.join('; ');
+  if (!text) return;
+  logger.info({ text }, 'pty-driver: AskUserQuestion unavailable — submitting answers as prompt');
+  await session.typePrompt(text);
 }
 
 /** Use the "Type something" free-text option: digit → type text → Enter. */

--- a/tests/interactive-driver-ask-fallback.test.ts
+++ b/tests/interactive-driver-ask-fallback.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { driveInteractiveTool } from '../src/engines/claude/pty/interactive-driver.js';
+import type { PtyClaudeSession, PtyParsedQuestion } from '../src/engines/claude/pty/contract.js';
+
+function createSession(snapshot: string) {
+  return {
+    snapshot: () => snapshot,
+    screen: () => snapshot,
+    sendKeys: vi.fn(),
+    typePrompt: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PtyClaudeSession;
+}
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(), child: vi.fn(() => createLogger()) } as any;
+}
+
+const questions: PtyParsedQuestion[] = [
+  { question: 'Deploy now?', header: 'Deploy', options: ['Yes', 'No'], multiSelect: false },
+];
+
+describe('driveInteractiveTool AskUserQuestion fallback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('submits answers as a prompt when the menu never renders', async () => {
+    vi.useFakeTimers();
+    const session = createSession('idle claude screen after resume');
+
+    const promise = driveInteractiveTool({
+      session,
+      tool: { name: 'AskUserQuestion', toolUseId: 'toolu_1', input: { questions: [] } },
+      response: { kind: 'answers', answers: { Deploy: 'Yes' }, questions },
+      logger: createLogger(),
+    });
+    await vi.advanceTimersByTimeAsync(21_000);
+    await promise;
+
+    expect(session.typePrompt).toHaveBeenCalledWith('Deploy: Yes');
+    expect(session.sendKeys).not.toHaveBeenCalled();
+  });
+
+  it('still drives the menu when it renders', async () => {
+    vi.useFakeTimers();
+    const session = createSession('❯ 1. Yes  2. No  Enter to select');
+
+    const promise = driveInteractiveTool({
+      session,
+      tool: { name: 'AskUserQuestion', toolUseId: 'toolu_1', input: { questions: [] } },
+      response: { kind: 'answers', answers: { Deploy: 'Yes' }, questions },
+      logger: createLogger(),
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await promise;
+
+    expect(session.sendKeys).toHaveBeenCalledWith('1');
+    expect(session.typePrompt).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #389

## Summary
- 当 AskUserQuestion 菜单等待超时（典型为 \--resume\ 回放历史提问帧、菜单已不可交互）时，不再静默丢弃用户答案
- 新增降级路径：把已作答问题组装为普通 prompt 提交给会话，回复仍可送达，避免卡死在 Waiting for Input
- 菜单正常渲染时保持原按键注入路径不变

## Tests
- \itest run tests/interactive-driver-ask-fallback.test.ts\（新增 2 例）
- \itest run tests/parse-ask-menu.test.ts tests/between-turn-question.test.ts\
