### PR TITLE
fix: prefer native claude executables on Windows

### DIFF
--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -11,21 +11,9 @@ import { AsyncQueue } from '../../utils/async-queue.js';
 import { buildMetaBotApiPromptContext } from '../prompt-context.js';
 import type { ApiContext } from '../prompt-context.js';
 import { makeCanUseTool } from './exit-plan-mode.js';
+import { resolveClaudePath } from './resolve-claude.js';
 
 export type { ApiContext } from '../prompt-context.js';
-
-const isWindows = process.platform === 'win32';
-
-/** Resolve the Claude Code binary path at module load time. */
-function resolveClaudePath(): string {
-  if (process.env.CLAUDE_EXECUTABLE_PATH) return process.env.CLAUDE_EXECUTABLE_PATH;
-  try {
-    const cmd = isWindows ? 'where claude' : 'which claude';
-    return execSync(cmd, { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
-  } catch {
-    return isWindows ? 'claude' : '/usr/local/bin/claude';
-  }
-}
 
 const CLAUDE_EXECUTABLE = resolveClaudePath();
 

--- a/src/engines/claude/persistent-executor.ts
+++ b/src/engines/claude/persistent-executor.ts
@@ -25,7 +25,7 @@
  *   - Multi-turn overlap (still one in-flight turn at a time)
  */
 
-import { execSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -39,24 +39,13 @@ import { buildMetaBotApiPromptContext } from '../prompt-context.js';
 import { apply1MContextSettings } from './executor.js';
 import { makeCanUseTool } from './exit-plan-mode.js';
 import { ptyQuery } from './pty/pty-query.js';
+import { resolveClaudePath } from './resolve-claude.js';
 import type {
   PtyQueryOptions,
   PtyPromptSource,
   PtyInteractiveTool,
   PtyInteractiveResponse,
 } from './pty/contract.js';
-
-const isWindows = process.platform === 'win32';
-
-function resolveClaudePath(): string {
-  if (process.env.CLAUDE_EXECUTABLE_PATH) return process.env.CLAUDE_EXECUTABLE_PATH;
-  try {
-    const cmd = isWindows ? 'where claude' : 'which claude';
-    return execSync(cmd, { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
-  } catch {
-    return isWindows ? 'claude' : '/usr/local/bin/claude';
-  }
-}
 
 const CLAUDE_EXECUTABLE = resolveClaudePath();
 

--- a/src/engines/claude/resolve-claude.ts
+++ b/src/engines/claude/resolve-claude.ts
@@ -1,0 +1,41 @@
+import { execSync } from 'node:child_process';
+
+export interface ResolveClaudePathOptions {
+  /** Override for tests; defaults to the current process platform. */
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Resolve the Claude Code executable path.
+ *
+ * On Windows, PATH order may put npm's extensionless POSIX shim before the
+ * real launchers (claude.exe / claude.cmd). node-pty cannot exec the shim
+ * directly (CreateProcess error 193), so prefer native executables by suffix
+ * regardless of PATH order. An explicit CLAUDE_EXECUTABLE_PATH always wins.
+ */
+export function resolveClaudePath(options: ResolveClaudePathOptions = {}): string {
+  if (process.env.CLAUDE_EXECUTABLE_PATH) return process.env.CLAUDE_EXECUTABLE_PATH;
+
+  const isWindows = (options.platform ?? process.platform) === 'win32';
+  const command = isWindows ? 'where claude' : 'which claude';
+  try {
+    const candidates = execSync(command, { encoding: 'utf-8' })
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean);
+
+    if (isWindows) {
+      const nativeExecutable = candidates.find((candidate) => candidate.toLowerCase().endsWith('.exe'))
+        ?? candidates.find((candidate) => /\.(cmd|bat)$/i.test(candidate));
+      if (nativeExecutable) return nativeExecutable;
+    }
+
+    return candidates[0] ?? fallbackExecutable(isWindows);
+  } catch {
+    return fallbackExecutable(isWindows);
+  }
+}
+
+function fallbackExecutable(isWindows: boolean): string {
+  return isWindows ? 'claude' : '/usr/local/bin/claude';
+}

--- a/tests/resolve-claude.test.ts
+++ b/tests/resolve-claude.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { resolveClaudePath } from '../src/engines/claude/resolve-claude.js';
+
+vi.mock('node:child_process', () => ({ execSync: vi.fn() }));
+
+const execSyncMock = vi.mocked(execSync);
+
+describe('resolveClaudePath', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.CLAUDE_EXECUTABLE_PATH;
+    execSyncMock.mockReset();
+  });
+
+  it('returns the explicit CLAUDE_EXECUTABLE_PATH without searching PATH', () => {
+    process.env.CLAUDE_EXECUTABLE_PATH = 'C:/custom/claude.exe';
+    expect(resolveClaudePath({ platform: 'win32' })).toBe('C:/custom/claude.exe');
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('prefers claude.exe over the extensionless npm shim on Windows', () => {
+    execSyncMock.mockReturnValue(
+      'C:/npm/claude\nC:/npm/claude.cmd\nC:/Users/u/.local/bin/claude.exe\n' as never,
+    );
+    expect(resolveClaudePath({ platform: 'win32' })).toBe('C:/Users/u/.local/bin/claude.exe');
+  });
+
+  it('falls back to claude.cmd when no claude.exe exists on Windows', () => {
+    execSyncMock.mockReturnValue('C:/npm/claude\nC:/npm/claude.cmd\n' as never);
+    expect(resolveClaudePath({ platform: 'win32' })).toBe('C:/npm/claude.cmd');
+  });
+
+  it('keeps PATH order as the last resort on Windows', () => {
+    execSyncMock.mockReturnValue('C:/npm/claude\n' as never);
+    expect(resolveClaudePath({ platform: 'win32' })).toBe('C:/npm/claude');
+  });
+
+  it('keeps PATH order on non-Windows platforms', () => {
+    execSyncMock.mockReturnValue('/usr/local/bin/claude\n/opt/homebrew/bin/claude\n' as never);
+    expect(resolveClaudePath({ platform: 'darwin' })).toBe('/usr/local/bin/claude');
+  });
+
+  it('falls back per platform when the lookup fails', () => {
+    execSyncMock.mockImplementation(() => { throw new Error('not found'); });
+    expect(resolveClaudePath({ platform: 'win32' })).toBe('claude');
+    expect(resolveClaudePath({ platform: 'darwin' })).toBe('/usr/local/bin/claude');
+  });
+});


### PR DESCRIPTION
Fixes #390

## Summary
- 抽出共享的 \esolveClaudePath()\，两处 executor 复用同一解析逻辑
- Windows 下按 \claude.exe → claude.cmd/.bat → 无扩展名\ 优先解析，不再被 PATH 中靠前的 npm POSIX shim 触发 error 193
- \CLAUDE_EXECUTABLE_PATH\ 显式覆盖仍保持最高优先级

## Tests
- \itest run tests/resolve-claude.test.ts\（新增 6 例，覆盖解析优先级与回退）
