### PR TITLE
fix: fall back to metabot-core bootstrap token

### DIFF
--- a/packages/cli-core/src/config.ts
+++ b/packages/cli-core/src/config.ts
@@ -25,11 +25,16 @@ export function tokenFilePath(): string {
   return path.join(os.homedir(), '.metabot-core', 'token');
 }
 
+export function adminBootstrapTokenFilePath(): string {
+  return path.join(os.homedir(), '.metabot-core', 'data', 'admin-bootstrap-token.txt');
+}
+
 /**
  * Resolve URL + token.
  *
  * URL precedence:   METABOT_CORE_URL → DEFAULT_URL.
- * Token precedence: METABOT_CORE_TOKEN → ~/.metabot-core/token (first line).
+ * Token precedence: METABOT_CORE_TOKEN → ~/.metabot-core/token (first line)
+ *                  → metabot-core bootstrap token (first line).
  *
  * Throws when no token is configured.
  */
@@ -41,8 +46,12 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     if (fromFile) token = fromFile;
   }
   if (!token) {
+    const fromBootstrapFile = readFirstLine(adminBootstrapTokenFilePath());
+    if (fromBootstrapFile) token = fromBootstrapFile;
+  }
+  if (!token) {
     throw new Error(
-      `no token configured — set METABOT_CORE_TOKEN env var, or write the token to ${tokenFilePath()}`,
+      `no token configured — set METABOT_CORE_TOKEN env var, write the token to ${tokenFilePath()}, or start metabot-core once to generate ${adminBootstrapTokenFilePath()}`,
     );
   }
   return { url, token };

--- a/packages/metamemory/tests/cli.test.ts
+++ b/packages/metamemory/tests/cli.test.ts
@@ -26,14 +26,19 @@ describe('parseArgs', () => {
 describe('loadConfig', () => {
   let tmpHome: string;
   let origHome: string | undefined;
+  let origUserProfile: string | undefined;
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mm-cfg-'));
     origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
     process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
   });
   afterEach(() => {
     if (origHome !== undefined) process.env.HOME = origHome;
     else delete process.env.HOME;
+    if (origUserProfile !== undefined) process.env.USERPROFILE = origUserProfile;
+    else delete process.env.USERPROFILE;
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
@@ -48,6 +53,21 @@ describe('loadConfig', () => {
     fs.writeFileSync(path.join(tmpHome, '.metabot-core', 'token'), 'file-tok\n');
     const cfg = loadConfig({});
     expect(cfg.url).toBe(DEFAULT_URL);
+    expect(cfg.token).toBe('file-tok');
+  });
+
+  it('falls back to the metabot-core bootstrap token', () => {
+    fs.mkdirSync(path.join(tmpHome, '.metabot-core', 'data'), { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, '.metabot-core', 'data', 'admin-bootstrap-token.txt'), 'bootstrap-tok\n');
+    const cfg = loadConfig({});
+    expect(cfg.token).toBe('bootstrap-tok');
+  });
+
+  it('prefers ~/.metabot-core/token over the bootstrap token', () => {
+    fs.mkdirSync(path.join(tmpHome, '.metabot-core', 'data'), { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, '.metabot-core', 'data', 'admin-bootstrap-token.txt'), 'bootstrap-tok\n');
+    fs.writeFileSync(path.join(tmpHome, '.metabot-core', 'token'), 'file-tok\n');
+    const cfg = loadConfig({});
     expect(cfg.token).toBe('file-tok');
   });
 


### PR DESCRIPTION
Fixes #391

## Summary
- \loadConfig()\ 在 \~/.metabot-core/token\ 之后增加 \~/.metabot-core/data/admin-bootstrap-token.txt\ 读取回退，与服务端 bootstrap 写入路径对齐
- 无 token 时的报错信息列出两个可用路径
- 全新安装启动 core 后，无需手工复制 token 即可使用 \metabot memory ...\

## Tests
- \
pm test -w @xvirobotics/metamemory -- tests/cli.test.ts\（45/45，新增 bootstrap 回退与优先级 2 例）
