### PR TITLE
fix: default BOTS_CONFIG in pm2 ecosystem

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -32,6 +32,7 @@ module.exports = {
       // Environment
       env: {
         NODE_ENV: 'production',
+        BOTS_CONFIG: process.env.BOTS_CONFIG || path.join(__dirname, 'bots.json'),
         CLAUDE_MAX_TURNS: '',  // unlimited turns (override any inherited shell env)
       },
     },


### PR DESCRIPTION
Fixes #392

## Summary
- \cosystem.config.cjs\ 为 \metabot\ 进程增加 \BOTS_CONFIG\ 默认值，指向仓库根目录的 \ots.json\
- 外部环境变量 \BOTS_CONFIG\ 仍可覆盖默认值
- 手动 \git clone + npm install + pm2 start ecosystem.config.cjs\ 场景可直接启动

## Tests
- 配置变更无独立测试；现有安装/启动链路不受影响（install.ps1 生成的 \.env\ 优先级不变）
