### PR TITLE
fix: keep doc mappings on cleanup fetch failures

### DIFF
--- a/src/memory/memory-client.ts
+++ b/src/memory/memory-client.ts
@@ -23,6 +23,16 @@ import { proxyFetch } from '../utils/http.js';
 
 const DEFAULT_BASE_URL = 'http://localhost:9200';
 
+export class MemoryClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'MemoryClientError';
+  }
+}
+
 export interface FolderTreeNode {
   id: string;
   name: string;
@@ -130,7 +140,7 @@ export class MemoryClient {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => '');
-      throw new Error(`metabot-core ${res.status}: ${body}`);
+      throw new MemoryClientError(`metabot-core ${res.status}: ${body}`, res.status);
     }
     return res.json() as Promise<T>;
   }
@@ -197,8 +207,11 @@ export class MemoryClient {
         };
       }
       return null;
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof MemoryClientError && error.status === 404) {
+        return null;
+      }
+      throw error;
     }
   }
 

--- a/src/sync/doc-sync.ts
+++ b/src/sync/doc-sync.ts
@@ -525,10 +525,15 @@ export class DocSync {
           // Note: We don't delete the wiki page itself to avoid data loss.
           // The orphaned page can be manually cleaned up.
         }
-      } catch {
-        // If we can't fetch, assume it's deleted
-        this.store.deleteDocMapping(mapping.memoryDocId);
-        if (result) result.deleted++;
+      } catch (error) {
+        // Fetch failures (network/auth/5xx) are not deletions; keep the
+        // mapping so a later sync can reconcile once the service recovers.
+        const message = error instanceof Error ? error.message : String(error);
+        if (result) result.errors.push(`Cleanup "${mapping.memoryPath}": ${message}`);
+        this.logger.warn(
+          { doc: mapping.memoryPath, err: message },
+          'Document verification failed during cleanup; keeping mapping',
+        );
       }
     }
   }

--- a/tests/doc-sync.test.ts
+++ b/tests/doc-sync.test.ts
@@ -212,6 +212,22 @@ describe('DocSync', () => {
     expect(result.deleted).toBe(1);
   });
 
+  it('keeps mappings when document verification fails during cleanup', async () => {
+    const doc = makeSampleDoc();
+    setup([doc]);
+
+    await docSync.syncAll();
+
+    (docSync as any).fetchDocument = vi.fn().mockRejectedValue(new Error('metabot-core 503: unavailable'));
+    mockMemory.listDocuments.mockResolvedValue([]);
+
+    const result = await docSync.syncAll();
+    expect(result.deleted).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('503');
+    expect((docSync as any).store.getAllDocMappings()).toHaveLength(1);
+  });
+
   it('finds existing wiki space by name', async () => {
     setup();
     const spaceId = await (docSync as any).ensureWikiSpace();


### PR DESCRIPTION
Fixes #393

## Summary
- \MemoryClient\ 新增 \MemoryClientError\ 并在 HTTP 非 2xx 时携带状态码；\getDocument()\ 仅将 404 视为文档不存在，网络/401/5xx 正常抛错
- \DocSync.cleanupDeleted()\ 不再把任何 fetch 异常当作已删除：失败时保留 mapping、计入 \rrors[]\ 并记录 warn 日志，服务恢复后下次同步可继续对账
- 仅 fetch 返回 null（明确 404）时才清理 mapping

## Tests
- \itest run tests/doc-sync.test.ts\（14/14，新增「验证失败保留 mapping」1 例）
