### PR TITLE
test: redirect USERPROFILE alongside HOME for Windows

### DIFF
--- a/packages/metamemory/tests/cli.test.ts
+++ b/packages/metamemory/tests/cli.test.ts
@@ -26,14 +26,19 @@ describe('parseArgs', () => {
 describe('loadConfig', () => {
   let tmpHome: string;
   let origHome: string | undefined;
+  let origUserProfile: string | undefined;
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mm-cfg-'));
     origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
     process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
   });
   afterEach(() => {
     if (origHome !== undefined) process.env.HOME = origHome;
     else delete process.env.HOME;
+    if (origUserProfile !== undefined) process.env.USERPROFILE = origUserProfile;
+    else delete process.env.USERPROFILE;
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
Fixes #394

## Summary
- metamemory CLI 测试在模拟用户目录时同时设置 \HOME\ 与 \USERPROFILE\，Windows 下 \os.homedir()\ 与真实环境解耦
- 测试后按原值恢复两个环境变量

## Tests
- \
pm test -w @xvirobotics/metamemory -- tests/cli.test.ts\（43/43）
