### PR TITLE
fix: make memory writes atomic and centralize view policy

### DIFF
--- a/packages/server/src/memory/memory-routes.ts
+++ b/packages/server/src/memory/memory-routes.ts
@@ -1,7 +1,7 @@
 import type { MemoryStore } from './memory-store.js';
 import type { AgentStore } from '../agents/agent-store.js';
 import type { Credential } from '../auth/credentials.js';
-import { isHiddenFromMemoryView } from './hidden-paths.js';
+import { canReadFolder, isHiddenFromMemoryView, isHiddenIdOrPath, pruneHiddenSubtrees } from './view-policy.js';
 
 export interface RouteResult {
   status: number;
@@ -15,23 +15,6 @@ function err(status: number, error: string): RouteResult {
 function statusFromException(e: unknown): number {
   const s = (e as { statusCode?: number }).statusCode;
   return typeof s === 'number' ? s : 400;
-}
-
-function isHiddenIdOrPath(store: MemoryStore, idOrPath: string, kind: 'folder' | 'document'): boolean {
-  if (idOrPath.startsWith('/')) return isHiddenFromMemoryView(idOrPath);
-  const path = kind === 'folder'
-    ? store.findFolderById(idOrPath)?.path ?? null
-    : store.findDocumentPathById(idOrPath);
-  return path !== null && isHiddenFromMemoryView(path);
-}
-
-function pruneHiddenSubtrees<T extends { path: string; children: T[] }>(node: T): T {
-  return {
-    ...node,
-    children: node.children
-      .filter((c) => !isHiddenFromMemoryView(c.path))
-      .map(pruneHiddenSubtrees),
-  };
 }
 
 // ---- Folder handlers ----
@@ -185,11 +168,4 @@ export function search(store: MemoryStore, query: URLSearchParams, cred: Credent
   const offset = Math.max(parseInt(query.get('offset') || '0', 10) || 0, 0);
   const results = store.searchDocuments(q, limit, cred, offset).filter((r) => !isHiddenFromMemoryView(r.path));
   return { status: 200, body: { results } };
-}
-
-function canReadFolder(store: MemoryStore, folder: { path: string }, cred: Credential): boolean {
-  return store.accessibleRoots(cred).some((root) => {
-    if (root === '/') return true;
-    return folder.path === root || folder.path.startsWith(root + '/');
-  }) || folder.path.startsWith('/shared');
 }

--- a/packages/server/src/memory/memory-store.ts
+++ b/packages/server/src/memory/memory-store.ts
@@ -358,6 +358,13 @@ export class MemoryStore {
   }
 
   deleteFolder(folderIdOrPath: string, cred: Credential): void {
+    const deleteRecursively = this.db.transaction(
+      (idOrPath: string) => this.deleteFolderRecursively(idOrPath, cred),
+    );
+    deleteRecursively(folderIdOrPath);
+  }
+
+  private deleteFolderRecursively(folderIdOrPath: string, cred: Credential): void {
     const folder = this.resolveFolder(folderIdOrPath);
     if (!folder) throw Object.assign(new Error('not_found'), { statusCode: 404 });
     if (folder.id === 'root') throw Object.assign(new Error('cannot_delete_root'), { statusCode: 400 });
@@ -366,7 +373,7 @@ export class MemoryStore {
     // recurse
     this.db.prepare('DELETE FROM documents WHERE folder_id = ?').run(folder.id);
     const children = this.db.prepare('SELECT id FROM folders WHERE parent_id = ?').all(folder.id) as { id: string }[];
-    for (const child of children) this.deleteFolder(child.id, cred);
+    for (const child of children) this.deleteFolderRecursively(child.id, cred);
     this.db.prepare('DELETE FROM folders WHERE id = ?').run(folder.id);
   }
 
@@ -378,6 +385,13 @@ export class MemoryStore {
   // ---- Document operations ----
 
   createDocument(data: DocumentCreateInput, cred: Credential): Document {
+    const insertDocument = this.db.transaction(
+      (input: DocumentCreateInput) => this.insertDocument(input, cred),
+    );
+    return insertDocument(data);
+  }
+
+  private insertDocument(data: DocumentCreateInput, cred: Credential): Document {
     let folderId: string;
     let docPath: string;
     let title = data.title;

--- a/packages/server/src/memory/view-policy.ts
+++ b/packages/server/src/memory/view-policy.ts
@@ -1,0 +1,37 @@
+/**
+ * Memory view policy — the single source of truth for which memory paths are
+ * visible to API callers. Routes translate these decisions into HTTP semantics
+ * (403 on create, 404 on read/delete, empty lists) and never re-implement the
+ * path-hiding rules themselves.
+ */
+import type { MemoryStore } from './memory-store.js';
+import type { Credential } from '../auth/credentials.js';
+import { isHiddenFromMemoryView } from './hidden-paths.js';
+
+export { isHiddenFromMemoryView };
+
+export type MemoryNodeKind = 'folder' | 'document';
+
+export function isHiddenIdOrPath(store: MemoryStore, idOrPath: string, kind: MemoryNodeKind): boolean {
+  if (idOrPath.startsWith('/')) return isHiddenFromMemoryView(idOrPath);
+  const path = kind === 'folder'
+    ? store.findFolderById(idOrPath)?.path ?? null
+    : store.findDocumentPathById(idOrPath);
+  return path !== null && isHiddenFromMemoryView(path);
+}
+
+export function pruneHiddenSubtrees<T extends { path: string; children: T[] }>(node: T): T {
+  return {
+    ...node,
+    children: node.children
+      .filter((child) => !isHiddenFromMemoryView(child.path))
+      .map(pruneHiddenSubtrees),
+  };
+}
+
+export function canReadFolder(store: MemoryStore, folder: { path: string }, cred: Credential): boolean {
+  return store.accessibleRoots(cred).some((root) => {
+    if (root === '/') return true;
+    return folder.path === root || folder.path.startsWith(root + '/');
+  }) || folder.path.startsWith('/shared');
+}

--- a/packages/server/tests/memory.test.ts
+++ b/packages/server/tests/memory.test.ts
@@ -152,3 +152,58 @@ describe('MemoryStore + ACL', () => {
     expect(list.some((f) => f.path === '/shared/teamx')).toBe(false);
   });
 });
+
+describe('MemoryStore transactional writes', () => {
+  it('rolls back auto-created folders when the document insert fails', () => {
+    kit = makeKit('mem-tx-create');
+    const admin = issue(kit, 'admin', 'admin');
+    const db = kit.db as any;
+    const originalPrepare = db.prepare.bind(db);
+    db.prepare = (sql: string) => {
+      if (sql.startsWith('INSERT INTO documents')) {
+        return { run: () => { throw new Error('insert failed'); } };
+      }
+      return originalPrepare(sql);
+    };
+
+    expect(() => kit.memory.createDocument({
+      title: 'tx doc',
+      path: '/tx-rollback/nested/doc',
+      content: 'x',
+    }, admin)).toThrow('insert failed');
+    db.prepare = originalPrepare;
+
+    expect(kit.memory.findFolderByPath('/tx-rollback')).toBeNull();
+    expect(kit.memory.findFolderByPath('/tx-rollback/nested')).toBeNull();
+  });
+
+  it('rolls back recursive folder deletion when a child delete fails', () => {
+    kit = makeKit('mem-tx-delete');
+    const admin = issue(kit, 'admin', 'admin');
+    const parent = kit.memory.createFolder({ path: '/tx-parent' }, admin);
+    kit.memory.createFolder({ path: '/tx-parent/child-a' }, admin);
+    kit.memory.createFolder({ path: '/tx-parent/child-b' }, admin);
+    kit.memory.createDocument({ title: 'a', path: '/tx-parent/child-a/a', content: 'x' }, admin);
+
+    const db = kit.db as any;
+    const originalPrepare = db.prepare.bind(db);
+    let folderDeletes = 0;
+    db.prepare = (sql: string) => {
+      const statement = originalPrepare(sql);
+      if (sql.startsWith('DELETE FROM folders')) {
+        folderDeletes++;
+        if (folderDeletes === 2) {
+          return { run: () => { throw new Error('delete failed'); } };
+        }
+      }
+      return statement;
+    };
+
+    expect(() => kit.memory.deleteFolder(parent.id, admin)).toThrow('delete failed');
+    db.prepare = originalPrepare;
+
+    expect(kit.memory.findFolderByPath('/tx-parent')).toBeTruthy();
+    expect(kit.memory.findFolderByPath('/tx-parent/child-a')).toBeTruthy();
+    expect(kit.memory.getDocument('/tx-parent/child-a/a', admin)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #395

## Summary
- \createDocument\ 的目录链创建与文档 INSERT、\deleteFolder\ 的递归删除均包裹在单个 SQLite 事务中，中途失败整体回滚
- 隐藏路径判定收敛到新的 \iew-policy.ts\：\isHiddenIdOrPath\、\pruneHiddenSubtrees\、\canReadFolder\ 单点维护，路由层只调用不解释，HTTP 语义（403/404/空列表）保持不变

## Tests
- \
pm test -w @xvirobotics/metabot-core-server -- tests/memory.test.ts tests/memory-routes-hidden-paths.test.ts tests/memory-share-flag.test.ts\（41/41，新增 2 例回滚测试）
