### PR TITLE
Add GPT-6 Astra models to Codex /model picker

### DIFF
--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -416,6 +416,8 @@ export class CommandHandler {
         { id: 'kimi-code/kimi-for-coding-highspeed', label: 'Kimi for Coding Highspeed', note: 'Low-latency coding model when enabled for your account' },
       ];
       const codexModels = [
+        { id: 'gpt-6-astra', label: 'GPT 6 Astra', note: 'Flagship Codex model · persistent context across windows (Codex ≥0.153)' },
+        { id: 'gpt-6-astra-pro', label: 'GPT 6 Astra Pro', note: 'Higher-capability Astra tier for Pro/Business/Enterprise accounts' },
         { id: 'gpt-5.6', label: 'GPT 5.6', note: 'General GPT-5.6 Codex model' },
         { id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol', note: 'Flagship GPT-5.6 capability model' },
         { id: 'gpt-5.6-terra', label: 'GPT 5.6 Terra', note: 'Stronger speed/cost balance for Codex workers' },
@@ -653,7 +655,7 @@ export class CommandHandler {
       case 'kimi':
         return '`kimi-code/k3`, `kimi-code/kimi-for-coding-highspeed`';
       case 'codex':
-        return '`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`';
+        return '`gpt-6-astra`, `gpt-6-astra-pro`, `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`';
     }
   }
 

--- a/tests/command-handler-model-status.test.ts
+++ b/tests/command-handler-model-status.test.ts
@@ -205,6 +205,7 @@ describe('CommandHandler /model', () => {
   it('lists codex models on /model list when engine is codex', async () => {
     const { handler, notices } = buildHandler({ engine: 'codex' });
     await handler.handle(msg('/model list'));
+    expect(notices[0].content).toContain('gpt-6-astra');
     expect(notices[0].content).toContain('gpt-5.6');
     expect(notices[0].content).toContain('gpt-5.6-terra');
     expect(notices[0].content).toContain('gpt-5.6-luna');


### PR DESCRIPTION
## Summary
- Add `gpt-6-astra` and `gpt-6-astra-pro` to the Codex `/model list` picker and help examples.
- Keeps existing GPT-5.6 / legacy Codex entries unchanged.

## Context
OpenAI Codex CLI 0.153+ adds API support for configuring GPT-6 Astra without changing the default picker. MetaBot already passes arbitrary Codex model IDs through to the CLI, but the bridge `/model` UX did not surface the new flagship models.

## Test plan
- [ ] `npx vitest run tests/command-handler-model-status.test.ts`
- [ ] `/model list` on a Codex session shows `gpt-6-astra` entries
- [ ] `/model gpt-6-astra` switches session model when Codex CLI ≥ 0.153 is installed


Made with [Cursor](https://cursor.com)